### PR TITLE
modem: cellular: vendor specific configuration pointer

### DIFF
--- a/doc/services/connectivity/modem/index.rst
+++ b/doc/services/connectivity/modem/index.rst
@@ -299,11 +299,9 @@ binding, then write a driver source file using the macros from
    #include <zephyr/drivers/modem/modem_cellular.h>
    #include <zephyr/device.h>
 
-   MODEM_CHAT_MATCH_DEFINE(ok_match, "OK", "", NULL);
-   MODEM_CHAT_MATCH_DEFINE(connect_match, "CONNECT", "", NULL);
-   MODEM_CHAT_MATCHES_DEFINE(abort_matches,
-       MODEM_CHAT_MATCH("ERROR", "", NULL),
-       MODEM_CHAT_MATCH("NO CARRIER", "", NULL));
+   MODEM_CELLULAR_COMMON_CHAT_MATCHES();
+   MODEM_CHAT_MATCHES_DEFINE(my_modem_unsol,
+       MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
 
    /* Init script — configure the modem, enable unsolicited LTE
     * registration notifications, then switch to CMUX.
@@ -322,7 +320,24 @@ binding, then write a driver source file using the macros from
        MODEM_CHAT_SCRIPT_CMD_RESP("ATD*99#",   connect_match));
 
    MODEM_CHAT_SCRIPT_DEFINE(dial_chat_script, dial_chat_script_cmds,
-       abort_matches, modem_cellular_chat_callback_handler, 60);
+       dial_abort_matches, modem_cellular_chat_callback_handler, 60);
+
+   static const struct modem_cellular_vendor_config my_modem_vendor = {
+       .scripts = {
+           .init = &init_chat_script,
+           .dial = &dial_chat_script,
+       },
+       .unsol_matches = {
+           .matches = my_modem_unsol,
+           .size = ARRAY_SIZE(my_modem_unsol),
+       },
+       .chat_delimiter = "\r",
+       .chat_filter = "\n",
+       .power_pulse_duration_ms = 1000,
+       .reset_pulse_duration_ms = 100,
+       .startup_time_ms = 5000,
+       .shutdown_time_ms = 5000,
+   };
 
    /* Macro for defining a DT instance */
    #define MY_MODEM_DEVICE(inst)                                                   \
@@ -330,18 +345,12 @@ binding, then write a driver source file using the macros from
            MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);                   \
                                                                                    \
        static struct modem_cellular_data                                           \
-           MODEM_CELLULAR_INST_NAME(data, inst) = {                                \
-           .chat_delimiter = "\r",                                                 \
-           .chat_filter = "\n",                                                    \
-           .ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                            \
-       };                                                                          \
+           MODEM_CELLULAR_INST_NAME(data, inst);                                   \
                                                                                    \
        MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst,                             \
            (user_pipe_0, 3), (user_pipe_1, 4))                                     \
                                                                                    \
-       MODEM_CELLULAR_DEFINE_INSTANCE(inst,                                        \
-           1000, 100, 5000, 5000, false, NULL,                                     \
-           &init_chat_script, &dial_chat_script, NULL, NULL)
+       MODEM_CELLULAR_DEFINE_INSTANCE(inst, &my_modem_vendor, NULL)
 
    #define DT_DRV_COMPAT my_modem
    DT_INST_FOREACH_STATUS_OKAY(MY_MODEM_DEVICE)

--- a/drivers/modem/vendor_modem_cellular/cellular_fibocom_le250.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_fibocom_le250.c
@@ -97,6 +97,6 @@ static const struct modem_cellular_vendor_config fibocom_le250_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &fibocom_le250_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &fibocom_le250_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_FIBOCOM_LE250)

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -84,6 +84,6 @@ static const struct modem_cellular_vendor_config nrf91_slm_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3))                            \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_slm_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_slm_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM)

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_sm_v2.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_sm_v2.c
@@ -83,6 +83,6 @@ static const struct modem_cellular_vendor_config nrf91_sm_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_sm_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf91_sm_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SM_V2)

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -10,13 +10,18 @@
 
 #define DT_DRV_COMPAT nordic_nrf93m1
 
+struct nrf93m1_modem_cellular_config {
+	/** UART bus is configured with RTS/CTS hardware flow control */
+	bool bus_has_hwfc;
+};
+
 struct nrf93m1_modem_cellular_data {
 	/** Common modem data */
 	struct modem_cellular_data data;
 	/** Vendor specific data */
 
-	/** IFC already correctly configured */
-	bool ifc_configured;
+	/** HWFC already enabled */
+	bool hwfc_enabled;
 };
 BUILD_ASSERT(offsetof(struct nrf93m1_modem_cellular_data, data) == 0,
 	     "Common data must be at start of struct");
@@ -137,7 +142,7 @@ static void nrf93m1_on_ifc(struct modem_chat *chat, char **argv, uint16_t argc, 
 	 * If the configuration is already correct, we can skip the delay that needs to be
 	 * respected while the interface is reconfigured.
 	 */
-	vendor_data->ifc_configured =
+	vendor_data->hwfc_enabled =
 		(argc == 3) && (strtol(argv[1], NULL, 10) == 2) && (strtol(argv[2], NULL, 10) == 2);
 }
 
@@ -146,8 +151,13 @@ static bool nrf93m1_ifc_required(void *user_data)
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
 	struct nrf93m1_modem_cellular_data *vendor_data =
 		CONTAINER_OF(data, struct nrf93m1_modem_cellular_data, data);
+	const struct modem_cellular_config *config = data->dev->config;
+	const struct nrf93m1_modem_cellular_config *vendor_config = config->vendor_specific;
 
-	return !vendor_data->ifc_configured;
+	/* IFC configuration should only be sent if the bus supports HWFC and it is not already
+	 * enabled.
+	 */
+	return vendor_config->bus_has_hwfc && !vendor_data->hwfc_enabled;
 }
 
 static const struct modem_cellular_vendor_config nrf93m1_vendor = {
@@ -177,10 +187,14 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
+	static const struct nrf93m1_modem_cellular_config nrf93m1_vendor_cfg##inst = {             \
+		.bus_has_hwfc = DT_PROP(DT_INST_BUS(inst), hw_flow_control),                       \
+	};                                                                                         \
+                                                                                                   \
 	static struct nrf93m1_modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);            \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf93m1_vendor, NULL)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf93m1_vendor, &nrf93m1_vendor_cfg##inst)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1)

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -181,6 +181,6 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf93m1_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &nrf93m1_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg770.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg770.c
@@ -121,6 +121,6 @@ static const struct modem_cellular_vendor_config quectel_bg770_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_bg770_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_bg770_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG770)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -85,7 +85,7 @@ static const struct modem_cellular_vendor_config quectel_bg9x_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_bg9x_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_bg9x_vendor, NULL)
 
 #define DT_DRV_COMPAT quectel_bg95
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_BG9X)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
@@ -187,7 +187,7 @@ static const struct modem_cellular_vendor_config quectel_eg2x_g_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg2x_g_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg2x_g_vendor, NULL)
 
 #define DT_DRV_COMPAT quectel_eg21_g
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_EG2X_G)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -77,4 +77,4 @@ static const struct modem_cellular_vendor_config quectel_eg800q_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg800q_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg800q_vendor, NULL)

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
@@ -77,6 +77,6 @@ static const struct modem_cellular_vendor_config quectel_eg915u_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg915u_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &quectel_eg915u_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_QUECTEL_EG915U)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -86,6 +86,6 @@ static const struct modem_cellular_vendor_config simcom_a76xx_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_a76xx_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_a76xx_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_A76XX)

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -75,6 +75,6 @@ static const struct modem_cellular_vendor_config simcom_sim7080_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_sim7080_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &simcom_sim7080_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080)

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -69,6 +69,6 @@ static const struct modem_cellular_vendor_config sqn_gm02s_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &sqn_gm02s_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &sqn_gm02s_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SQN_GM02S)

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -83,6 +83,6 @@ static const struct modem_cellular_vendor_config hl7800_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &hl7800_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &hl7800_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_SWIR_HL7800)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -81,6 +81,6 @@ static const struct modem_cellular_vendor_config telit_le910c1tx_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_le910c1tx_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_le910c1tx_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
@@ -87,6 +87,6 @@ static const struct modem_cellular_vendor_config telit_lex10q1_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_lex10q1_vendor);
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_lex10q1_vendor, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LEX10Q1)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -87,7 +87,7 @@ __maybe_unused static const struct modem_cellular_vendor_config telit_me910g1_ve
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me910g1_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me910g1_vendor, NULL)
 
 #if DT_HAS_COMPAT_STATUS_OKAY(telit_me310g1)
 static const struct modem_cellular_vendor_config telit_me310g1_vendor = {
@@ -121,7 +121,7 @@ static const struct modem_cellular_vendor_config telit_me310g1_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me310g1_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_me310g1_vendor, NULL)
 
 #define DT_DRV_COMPAT telit_me910g1
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_ME910G1)

--- a/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
@@ -91,6 +91,6 @@ static const struct modem_cellular_vendor_config trasna_lexi_r10_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &trasna_lexi_r10_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &trasna_lexi_r10_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -110,6 +110,6 @@ static const struct modem_cellular_vendor_config u_blox_lara_r6_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_lara_r6_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_lara_r6_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -75,6 +75,6 @@ static const struct modem_cellular_vendor_config u_blox_sara_r4_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r4_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r4_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4)

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -80,6 +80,6 @@ static const struct modem_cellular_vendor_config u_blox_sara_r5_vendor = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 4), (user_pipe_0, 3))          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r5_vendor)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &u_blox_sara_r5_vendor, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5)

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -310,6 +310,7 @@ struct modem_cellular_vendor_config {
 struct modem_cellular_config {
 	const struct device *uart;
 	const struct modem_cellular_vendor_config *vendor;
+	const void *vendor_specific;
 	struct modem_ppp *ppp;
 	struct gpio_dt_spec power_gpio;
 	struct gpio_dt_spec reset_gpio;
@@ -553,12 +554,15 @@ void modem_cellular_chat_callback_handler(struct modem_chat *chat,
  * @param inst Devicetree instance number.
  * @param vendor_config Pointer to a constant @ref modem_cellular_vendor_config object. Must not be
  *        NULL and must remain valid for the lifetime of the device.
+ * @param _vendor_specific Pointer to an arbitrary vendor-specific configuration structure. Can be
+ *        NULL.
  */
-#define MODEM_CELLULAR_DEFINE_INSTANCE(inst, vendor_config)                                        \
+#define MODEM_CELLULAR_DEFINE_INSTANCE(inst, vendor_config, _vendor_specific)                      \
 	BUILD_ASSERT(vendor_config != NULL, "vendor_config must be non-NULL");                     \
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
 		.vendor = vendor_config,                                                           \
+		.vendor_specific = _vendor_specific,                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \


### PR DESCRIPTION
Add the option for modems to register an arbitrary configuration structure as part of the core config. This provides a location to store per-instance, vendor-specific information.

Only send the `AT+IFC` command to the nRF93M1 modem if the bus actually supports hardware flow control.