### PR TITLE
kconfig: Error out on deprecated usage when requested

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -547,7 +547,10 @@ config LTO_SINGLE_THREADED
 config COMPILER_WARNINGS_AS_ERRORS
 	bool "Treat warnings as errors"
 	help
-	  Turn on "warning as error" toolchain flags
+	  Turn on "warning as error" toolchain flags, will also cause build system to throw
+	  failures depending upon other configuration options e.g. with this and
+	  ``CONFIG_WARN_DEPRECATED`` enabled, Kconfig will throw an error if a deprecated Kconfig
+	  is selected.
 
 config DEPRECATION_TEST
 	bool "Indicate test for deprecated feature"

--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -268,6 +268,9 @@ def check_deprecated(kconf):
             selector_name = split_expr(selector, AND)[0].name
             warn(f'Deprecated symbol {selector_name} is enabled.')
 
+        if kconf.syms.get('COMPILER_WARNINGS_AS_ERRORS', kconf.y).tri_value == 2 and \
+            len(selectors) > 0:
+            err("Aborting due to Kconfig deprecation warnings")
 
 def check_experimental(kconf):
     experimental = kconf.syms.get('EXPERIMENTAL')


### PR DESCRIPTION
    When both ``CONFIG_COMPILER_WARNINGS_AS_ERRORS`` and
    ``CONFIG_WARN_DEPRECATED`` are enabled, Kconfig will now throw an
    error if a deprecated Kconfig is enabled in a build, this ensures
    API lifecycle compliance in CI.
