### PR TITLE
dts: nxp: mcxw: remove tstmr0 from MCXW72

### DIFF
--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.dts
@@ -171,10 +171,6 @@
 	status = "okay";
 };
 
-&tstmr0 {
-	status = "okay";
-};
-
 &ieee802154 {
 	counter = <&lptmr1>;
 };

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.dts
@@ -159,10 +159,6 @@
 	status = "okay";
 };
 
-&tstmr0 {
-	status = "okay";
-};
-
 &ieee802154 {
 	counter = <&lptmr1>;
 };

--- a/dts/arm/nxp/mcx/mcxw/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/mcx/mcxw/nxp_mcxw72.dtsi
@@ -6,6 +6,9 @@
 
 #include "nxp_mcxw7x_common.dtsi"
 
+/* TSTMR is removed from MCXW72 due to SIRC clock source instability. */
+/delete-node/ &tstmr0;
+
 &fast_peripheral1 {
 	smu2: smu2@1c0000 {
 		ranges = <0x0 0x1c0000 DT_SIZE_K(80)>;


### PR DESCRIPTION
The TSTMR peripheral on MCXW72 is clocked by the SIRC oscillator, which is not stable enough to guarantee reliable timestamp counter operation. Keeping the node enabled leads to inaccurate timing on MCXW72 parts.

The tstmr0 node is defined in the shared nxp_mcxw7x_common.dtsi that is used by both MCXW71 and MCXW72. To disable it for MCXW72 only, without affecting MCXW71, delete the node in nxp_mcxw72.dtsi via /delete-node/ and drop the now-dangling &tstmr0 board overrides from the frdm_mcxw72 and mcxw72_evk board DTS files.

Verified that devicetree preprocessing of the frdm_mcxw72 board parses cleanly with the node removed, that no &tstmr0 reference remains in the MCXW72 board/SoC DTS, and that nxp_mcxw7x_common.dtsi still defines tstmr0 so MCXW71 is unaffected.