### PR TITLE
arch: xtensa: add missing extern "C" guards to interrupt_controller and xtensa headers

### DIFF
--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -13,6 +13,10 @@
 
 #define CONFIG_GEN_IRQ_START_VECTOR 0
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @cond INTERNAL_HIDDEN
  */
@@ -294,6 +298,10 @@ static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
  * @return True if interrupt is enabled, false otherwise.
  */
 int xtensa_irq_is_enabled(unsigned int irq);
+
+#ifdef __cplusplus
+}
+#endif
 
 #include <zephyr/irq.h>
 

--- a/include/zephyr/drivers/interrupt_controller/intc_esp32.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_esp32.h
@@ -10,6 +10,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Interrupt allocation flags - These flags can be used to specify
  * which interrupt qualities the code calling esp_intr_alloc* needs.
@@ -308,5 +312,9 @@ void esp_intr_noniram_disable(void);
  * @brief Re-enable interrupts disabled by esp_intr_noniram_disable
  */
 void esp_intr_noniram_enable(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_INTERRUPT_CONTROLLER_INTC_ESP32_H_ */


### PR DESCRIPTION
## Description

Two public headers were missing the `extern "C" { ... }` block guarded
by `__cplusplus`:

- `include/zephyr/drivers/interrupt_controller/intc_esp32.h`
- `include/zephyr/arch/xtensa/arch.h`

Including either of these headers directly from a C++ translation unit
would result in name-mangled symbols and link failures against the
C-compiled sources.

This PR adds the missing guards for consistency with other public
headers in the tree.

## Testing

- Verified both headers now correctly wrap declarations in `extern "C"`
  when built by a C++ compiler.
- No functional/behavioral change for existing C consumers.