### PR TITLE
drivers: ethernet: dwc_mac: stm32: reset the MAC during bus init

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -79,6 +79,7 @@ config ETH_STM32_DWC_ETHER_QOS
 	select ETH_DWC_ETHER_QOS_CORE
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select PINCTRL
+	select RESET
 	select HWINFO
 	select CRC
 	default y
@@ -98,6 +99,7 @@ config ETH_STM32_DWC_ETHER_1000
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT \
 				 && !$(dt_chosen_enabled,$(DT_CHOSEN_Z_DTCM))
 	select PINCTRL
+	select RESET
 	select HWINFO
 	select CRC
 	default y

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 
@@ -57,10 +58,31 @@ static const struct pinctrl_dev_config *eth0_pcfg = PINCTRL_DT_INST_DEV_CONFIG_G
 
 static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
 
+static const struct reset_dt_spec eth_reset = RESET_DT_SPEC_INST_GET(0);
+
 int dwmac_bus_init(const struct device *dev)
 {
 	const struct dwmac_config *cfg = dev->config;
 	int ret;
+
+	/*
+	 * Hold the MAC in reset while the pins, the PHY interface mode and the
+	 * clocks are configured. The PHY interface mode must be selected while
+	 * the MAC is under reset.
+	 */
+	ret = reset_line_assert_dt(&eth_reset);
+	if (ret != 0) {
+		LOG_ERR("Could not assert ethernet reset");
+		return ret;
+	}
+
+	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure ethernet pins");
+		return ret;
+	}
+
+	STM32_CONFIGURE_ETH_PHY_MODE();
 
 	for (size_t n = 0; n < ARRAY_SIZE(pclken); n++) {
 		if (IN_RANGE(pclken[n].bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX)) {
@@ -76,13 +98,11 @@ int dwmac_bus_init(const struct device *dev)
 		}
 	}
 
-	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret < 0) {
-		LOG_ERR("Could not configure ethernet pins");
+	ret = reset_line_deassert_dt(&eth_reset);
+	if (ret != 0) {
+		LOG_ERR("Could not deassert ethernet reset");
 		return ret;
 	}
-
-	STM32_CONFIGURE_ETH_PHY_MODE();
 
 	return 0;
 }

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 
@@ -85,10 +86,31 @@ static const struct pinctrl_dev_config *eth0_pcfg =
 
 static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
 
+static const struct reset_dt_spec eth_reset = RESET_DT_SPEC_INST_GET(0);
+
 int dwmac_bus_init(const struct device *dev)
 {
 	const struct dwmac_config *cfg = dev->config;
 	int ret;
+
+	/*
+	 * Hold the MAC in reset while the pins, the PHY interface mode and the
+	 * clocks are configured. The PHY interface mode must be selected while
+	 * the MAC is under reset.
+	 */
+	ret = reset_line_assert_dt(&eth_reset);
+	if (ret != 0) {
+		LOG_ERR("Could not assert ethernet reset");
+		return ret;
+	}
+
+	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure ethernet pins");
+		return ret;
+	}
+
+	STM32_CONFIGURE_ETH_PHY_MODE();
 
 	for (size_t n = 0; n < ARRAY_SIZE(pclken); n++) {
 		if (IN_RANGE(pclken[n].bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX)) {
@@ -105,13 +127,11 @@ int dwmac_bus_init(const struct device *dev)
 		}
 	}
 
-	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret < 0) {
-		LOG_ERR("Could not configure ethernet pins");
+	ret = reset_line_deassert_dt(&eth_reset);
+	if (ret != 0) {
+		LOG_ERR("Could not deassert ethernet reset");
 		return ret;
 	}
-
-	STM32_CONFIGURE_ETH_PHY_MODE();
 
 	return 0;
 }

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -193,6 +193,7 @@
 				 <&rcc STM32_SRC_HSE ETH1CLK_SEL(3)>,
 				 <&rcc STM32_SRC_HSE ETH1CLKDIV_SEL(0)>,
 				 <&rcc STM32_SRC_HSE ETH1REFCLK_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB1, 19)>;
 			interrupts = <94 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -26,6 +26,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 14)>,
 				 <&rcc STM32_CLOCK(AHB1, 15)>,
 				 <&rcc STM32_CLOCK(AHB1, 16)>;
+			resets = <&rctl STM32_RESET(AHB1, 14)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -18,6 +18,7 @@
 				 <&rcc STM32_CLOCK(AHB1, 26)>,
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
+			resets = <&rctl STM32_RESET(AHB1, 25)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -18,6 +18,7 @@
 				 <&rcc STM32_CLOCK(AHB1, 26)>,
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
+			resets = <&rctl STM32_RESET(AHB1, 25)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -84,6 +84,7 @@
 				 <&rcc STM32_CLOCK(AHB1, 26)>,
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
+			resets = <&rctl STM32_RESET(AHB1, 25)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -129,6 +129,7 @@
 				 <&rcc STM32_CLOCK(AHB1, 26)>,
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
+			resets = <&rctl STM32_RESET(AHB1, 25)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -29,6 +29,7 @@
 				 <&rcc STM32_CLOCK(AHB1, 20)>,
 				 <&rcc STM32_CLOCK(AHB1, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q NO_SEL>;
+			resets = <&rctl STM32_RESET(AHB1, 19)>;
 			interrupts = <106 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1235,6 +1235,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
 				 <&rcc STM32_CLOCK(AHB1, 16)>,
 				 <&rcc STM32_CLOCK(AHB1, 17)>;
+			resets = <&rctl STM32_RESET(AHB1, 15)>;
 			interrupts = <61 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1007,6 +1007,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
 				 <&rcc STM32_CLOCK(AHB1, 16)>,
 				 <&rcc STM32_CLOCK(AHB1, 17)>;
+			resets = <&rctl STM32_RESET(AHB1, 15)>;
 			interrupts = <92 0>;
 			snps,multicast-filter-bins = <64>;
 			snps,perfect-filter-entries = <4>;

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -737,6 +737,7 @@
 				 <&rcc STM32_CLOCK(AHB6, 9)>,
 				 <&rcc STM32_CLOCK(AHB6, 10)>,
 				 <&rcc STM32_SRC_PLL4_Q ETH1_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB6, 10)>;
 			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			snps,multicast-filter-bins = <64>;

--- a/dts/arm/st/mp13/stm32mp133.dtsi
+++ b/dts/arm/st/mp13/stm32mp133.dtsi
@@ -20,6 +20,7 @@
 				 <&rcc STM32_CLOCK(AHB6, 29)>,
 				 <&rcc STM32_CLOCK(AHB6, 30)>,
 				 <&rcc STM32_SRC_PLL4_P ETH2_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB6, 30)>;
 			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 98 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			snps,multicast-filter-bins = <64>;

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -975,6 +975,7 @@
 				clocks = <&rcc STM32_CLOCK(AHB5, 22)>,
 					 <&rcc STM32_CLOCK(AHB5, 23)>,
 					 <&rcc STM32_CLOCK(AHB5, 24)>;
+				resets = <&rctl STM32_RESET(AHB5, 25)>;
 				interrupts = <179 0>;
 				snps,multicast-filter-bins = <64>;
 				snps,perfect-filter-entries = <4>;

--- a/dts/bindings/ethernet/st,stm32-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet.yaml
@@ -9,6 +9,7 @@ compatible: "st,stm32-ethernet"
 include:
   - name: snps,dwmac.yaml
   - name: pinctrl-device.yaml
+  - name: reset-device.yaml
 
 properties:
   reg:
@@ -16,6 +17,8 @@ properties:
   clocks:
     required: true
   clock-names:
+    required: true
+  resets:
     required: true
   interrupts:
     required: true


### PR DESCRIPTION
The PHY interface mode must be selected while the MAC is under reset and before its clocks are enabled. The STM32N6 reference manual, for example, states:
> Apply this configuration while the ETH1 is under reset, before enabling the ETH1 clocks.

This constraint is not STM32 specific, it comes from the Synopsys DesignWare Ethernet IP core. Other glue drivers, such as the one for the Infineon XMC4xxx, already perform the sequence in this order.

Until now the STM32 glue drivers enabled the clocks first and selected the PHY interface mode last, without ever asserting the reset line.