### PR TITLE
Bluetooth: hci_spi_st: Check the result of the LL-only configuration

### DIFF
--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -693,10 +693,16 @@ static int bt_spi_open(const struct device *dev)
 	}
 
 #if defined(CONFIG_BT_HCI_RAW) && defined(CONFIG_BT_BLUENRG_ACI)
-	/* force BlueNRG to be on controller mode */
-	uint8_t data = 1;
+	if (DT_INST_PROP_OR(0, req_ll_only, false)) {
+		/* force BlueNRG to be on controller mode */
+		uint8_t data = 1;
 
-	bt_spi_send_aci_config(BLUENRG_CONFIG_LL_ONLY_OFFSET, &data, 1);
+		err = bt_spi_send_aci_config(BLUENRG_CONFIG_LL_ONLY_OFFSET, &data, 1);
+		if (err != 0) {
+			LOG_ERR("Failed to set BlueNRG LL-only mode (%d)", err);
+			return err;
+		}
+	}
 #endif /* CONFIG_BT_HCI_RAW && CONFIG_BT_BLUENRG_ACI */
 	return 0;
 }

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -373,7 +373,11 @@ static int bt_spi_bluenrg_setup(const struct device *dev,
 		/* force BlueNRG to be on controller mode */
 		uint8_t data = 1;
 
-		bt_spi_send_aci_config(BLUENRG_CONFIG_LL_ONLY_OFFSET, &data, 1);
+		ret = bt_spi_send_aci_config(BLUENRG_CONFIG_LL_ONLY_OFFSET, &data, 1);
+		if (ret != 0) {
+			LOG_ERR("Failed to set BlueNRG LL-only mode (%d)", ret);
+			return ret;
+		}
 	}
 
 	if (!bt_addr_eq(addr, BT_ADDR_NONE) && !bt_addr_eq(addr, BT_ADDR_ANY)) {


### PR DESCRIPTION
Two fixes around the `ACI_HAL_WRITE_CONFIG_DATA` write that puts a BlueNRG into link layer only mode. In the Host build, `setup()` ignores the command's result while checking the public address write a few lines further down; the unchecked form dates from when the command was sent from the RX thread's vendor event handler and survived the move into `setup()`. Since LL-only mode is a precondition for the Zephyr Host and the controller accepts the write only as its first command after reset, a failure now fails `bt_enable()` instead of the stack coming up on a controller whose embedded host is still active. In the controller-only build, `open()` sends the same write for every BlueNRG ACI controller, unchecked, while the Host build sends it only when the device tree sets `req-ll-only` (a8c09c2e34d6); the second commit applies the same condition and checks that the command was sent.

Build-tested on disco_l475_iot1 with peripheral_hr and hci_usb. Found while inventorying the HCI driver `setup()` implementations; no BlueNRG hardware was available to run it.
