### PR TITLE
Bluetooth: hci_stm32wba: Cleanups in the vendor command paths

### DIFF
--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -47,11 +47,6 @@ static bt_addr_t bd_addr_dflt = {{0x65, 0x43, 0x21, 0x1E, 0x08, 0x00}};
 #define ACI_HAL_WRITE_CONFIG_DATA	   BT_OP(BT_OGF_VS, 0xFC0C)
 #define HCI_CONFIG_DATA_PUBADDR_OFFSET	   0
 static bt_addr_t bd_addr_udn;
-struct aci_set_ble_addr {
-	uint8_t config_offset;
-	uint8_t length;
-	uint8_t value[6];
-} __packed;
 #endif /* CONFIG_BT_HCI_SETUP */
 
 /* ACI Reset command */

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -453,8 +453,8 @@ static int bt_hci_stm32wba_open(const struct device *dev)
 
 static int bt_hci_stm32wba_close(const struct device *dev)
 {
-	int err = 0;
 	uint8_t aci_reset_cmd[9];
+	int err;
 
 	ARG_UNUSED(dev);
 
@@ -468,7 +468,16 @@ static int bt_hci_stm32wba_close(const struct device *dev)
 	aci_reset_cmd[7] = (uint8_t)(CFG_BLE_OPTIONS >> 16);
 	aci_reset_cmd[8] = (uint8_t)(CFG_BLE_OPTIONS >> 24);
 
+	err = k_mutex_lock(&hci_lock, K_FOREVER);
+	if (err != 0) {
+		LOG_ERR("Failed to lock the controller (%d)", err);
+		return err;
+	}
+
 	BleStack_Request(aci_reset_cmd);
+
+	err = k_mutex_unlock(&hci_lock);
+	__ASSERT_NO_MSG(err == 0);
 
 	bt_hci_state = BT_HCI_STATE_CLOSED;
 
@@ -487,7 +496,7 @@ static int bt_hci_stm32wba_close(const struct device *dev)
 	__HAL_RCC_RADIO_CLK_SLEEP_DISABLE();
 #endif
 
-	return err;
+	return 0;
 }
 
 #if defined(CONFIG_BT_HCI_SETUP)
@@ -539,6 +548,7 @@ static int bt_hci_stm32wba_setup(const struct device *dev,
 	bt_addr_t *uid_addr;
 	uint8_t aci_set_ble_addr_cmd[12];
 	uint16_t event_length;
+	int err;
 
 	ARG_UNUSED(dev);
 
@@ -560,7 +570,17 @@ static int bt_hci_stm32wba_setup(const struct device *dev,
 		memcpy(&aci_set_ble_addr_cmd[6], &(params->public_addr), 6);
 	}
 
+	err = k_mutex_lock(&hci_lock, K_FOREVER);
+	if (err != 0) {
+		LOG_ERR("Failed to lock the controller (%d)", err);
+		return err;
+	}
+
 	event_length = BleStack_Request(aci_set_ble_addr_cmd);
+
+	err = k_mutex_unlock(&hci_lock);
+	__ASSERT_NO_MSG(err == 0);
+
 	if (event_length) {
 		/* Get the return status from the event */
 		uint8_t evt_status;


### PR DESCRIPTION
Two small items found while inventorying the HCI driver `setup()` implementations: `struct aci_set_ble_addr` is unused, since `setup()` builds the `ACI_HAL_WRITE_CONFIG_DATA` command in a byte array; and the `BleStack_Request()` calls in `setup()` and `close()` bypass `hci_lock`, which exists to serialize accesses to the controller. Nothing else calls into the controller at those points of the current call sequence, so the second is invariant hygiene rather than an observed race.

Build-tested on nucleo_wba55cg with peripheral_hr and `CONFIG_BUILD_ONLY_NO_BLOBS`; no STM32WBA hardware was available to run it.