### PR TITLE
Bluetooth: hci_nxp_setup: Fix link failure in controller-only builds

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1740,7 +1740,12 @@ int bt_h4_vnd_setup(const struct device *dev, const struct bt_hci_setup_params *
 	operation_speed = DT_PROP_OR(DT_DRV_INST(0), hci_operation_speed, default_speed);
 	flowcontrol_of_hci = (bool)DT_PROP_OR(DT_DRV_INST(0), hw_flow_control, false);
 
-	if (operation_speed == default_speed) {
+	/* Raising the link to the operation speed needs the Host command APIs to
+	 * tell the controller about the new rate, so a raw (controller-only)
+	 * build has to leave both the controller and the local UART at the
+	 * device tree current-speed.
+	 */
+	if (!IS_ENABLED(CONFIG_BT_HCI_HOST) || operation_speed == default_speed) {
 		fw_upload.is_setup_done = true;
 		return 0;
 	}


### PR DESCRIPTION
`bt_hci_baudrate_update()` uses `bt_hci_cmd_alloc()` and `bt_hci_cmd_send_sync()`, which do not exist in a `CONFIG_BT_HCI_RAW` build, so `samples/bluetooth/hci_uart` fails to link on frdm_mcxn947 with the nxp_m2_2el_wifi_bt shield (given an overlay for the `zephyr,bt-c2h-uart` chosen node the sample needs there) and on mimxrt1170_evk revision B. No in-tree CI configuration builds this backend in controller-only mode, which is why it went unnoticed. The function is only reachable from the `setup()` op, which raw builds never call, so it is guarded with `CONFIG_BT_HCI_HOST` like the calibration functions in the same file already are, and controller-only builds keep both sides of the link at the device tree `current-speed`, as the firmware download path already does.

Build-tested on frdm_mcxn947 with the shield and `CONFIG_BUILD_ONLY_NO_BLOBS`: hci_uart, which fails to link on main, and peripheral_hr. Found while inventorying the HCI driver `setup()` implementations; no NXP hardware was available to run it.