### PR TITLE
bluetooth: classic: rfcomm: remove `K_FOREVER` from buffer allocation

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -155,6 +155,9 @@ struct bt_rfcomm_dlc {
 	 */
 	struct k_work_delayable rtx_work;
 
+	/** Work for retransmission. */
+	struct k_work_delayable retry_work;
+
 	/** Queue for outgoing data.
 	 *
 	 *  Holds net_buf fragments waiting to be transmitted over this DLC.

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -155,9 +155,6 @@ struct bt_rfcomm_dlc {
 	 */
 	struct k_work_delayable rtx_work;
 
-	/** Work for retransmission. */
-	struct k_work_delayable retry_work;
-
 	/** Queue for outgoing data.
 	 *
 	 *  Holds net_buf fragments waiting to be transmitted over this DLC.
@@ -180,7 +177,7 @@ struct bt_rfcomm_dlc {
 	 *  @p tx_queue and credits are available, to drain the queue and push
 	 *  data to L2CAP.
 	 */
-	struct k_work tx_work;
+	struct k_work_delayable tx_work;
 
 	/** Pointer to the RFCOMM session this DLC belongs to. */
 	struct bt_rfcomm_session *session;

--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -179,6 +179,9 @@ struct bt_rfcomm_dlc {
 	 */
 	struct k_work_delayable tx_work;
 
+	/* Retry timeout expired timer */
+	struct k_work_delayable retry_timeout_work;
+
 	/** Pointer to the RFCOMM session this DLC belongs to. */
 	struct bt_rfcomm_session *session;
 

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -337,13 +337,35 @@ static int rfcomm_send(struct bt_rfcomm_session *session, struct net_buf *buf)
 	return rfcomm_send_cb(session, buf, NULL, NULL);
 }
 
+static struct net_buf *rfcomm_create_pdu(uint16_t len)
+{
+	struct net_buf *buf;
+
+	buf = bt_l2cap_create_pdu_timeout(NULL, 0, K_NO_WAIT);
+	if (buf == NULL) {
+		LOG_WRN("net buffer allocation failure");
+		return NULL;
+	}
+
+	if (net_buf_tailroom(buf) < len) {
+		LOG_WRN("Tail room too small (%zu < %u)", net_buf_tailroom(buf), len);
+		net_buf_unref(buf);
+		return NULL;
+	}
+
+	return buf;
+}
+
 static int rfcomm_send_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	struct bt_rfcomm_hdr *hdr;
 	struct net_buf *buf;
 	uint8_t cr, fcs;
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	buf = rfcomm_create_pdu(sizeof(*hdr) + sizeof(fcs));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	cr = BT_RFCOMM_CMD_CR(session->role);
@@ -365,7 +387,10 @@ static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 
 	LOG_DBG("dlci %d", dlci);
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	buf = rfcomm_create_pdu(sizeof(*hdr) + sizeof(fcs));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	cr = BT_RFCOMM_CMD_CR(session->role);
@@ -380,25 +405,37 @@ static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 
 static void rfcomm_session_disconnect(struct bt_rfcomm_session *session)
 {
+	int err;
+
 	if (!sys_slist_is_empty(&session->dlcs)) {
 		return;
 	}
 
 	session->state = BT_RFCOMM_STATE_DISCONNECTING;
-	rfcomm_send_disc(session, 0);
-	bt_work_reschedule(&session->rtx_work, RFCOMM_DISC_TIMEOUT);
+	err = rfcomm_send_disc(session, 0);
+	if (err == 0) {
+		bt_work_reschedule(&session->rtx_work, RFCOMM_DISC_TIMEOUT);
+	} else {
+		LOG_ERR("Failed to send disc on session %p (%d)", session, err);
+		bt_work_reschedule(&session->rtx_work, K_NO_WAIT);
+	}
 }
 
-static struct net_buf *rfcomm_make_uih_msg(struct bt_rfcomm_session *session,
-					   uint8_t cr, uint8_t type,
-					   uint8_t len)
+static struct net_buf *rfcomm_make_uih_msg(struct bt_rfcomm_session *session, uint8_t cr,
+					   uint8_t type, uint8_t len)
 {
 	struct bt_rfcomm_hdr *hdr;
 	struct bt_rfcomm_msg_hdr *msg_hdr;
 	struct net_buf *buf;
+	uint16_t total_len;
 	uint8_t hdr_cr;
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	total_len = len + sizeof(*hdr) + sizeof(*msg_hdr) + sizeof(uint8_t);
+
+	buf = rfcomm_create_pdu(total_len);
+	if (buf == NULL) {
+		return NULL;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr_cr = BT_RFCOMM_UIH_CR(session->role);
@@ -416,6 +453,7 @@ static struct net_buf *rfcomm_make_uih_msg(struct bt_rfcomm_session *session,
 static void rfcomm_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
+	int err;
 
 	LOG_DBG("Session %p", session);
 
@@ -423,17 +461,10 @@ static void rfcomm_connected(struct bt_l2cap_chan *chan)
 	session->mtu = MIN(session->br_chan.rx.mtu, session->br_chan.tx.mtu);
 
 	if (session->mtu < (BT_RFCOMM_OVERHEAD_SIZE + RFCOMM_MIN_MTU)) {
-		int err;
-
 		LOG_ERR("Invalid RFCOMM session MTU %u < %u", session->mtu,
 			BT_RFCOMM_OVERHEAD_SIZE + RFCOMM_MIN_MTU);
 
-		err = bt_l2cap_chan_disconnect(chan);
-		if (err < 0) {
-			LOG_ERR("Failed to disconnect RFCOMM session (err %d)", err);
-		}
-
-		return;
+		goto disconnect;
 	}
 
 	/* Discount the overhead size from the L2CAP MTU.
@@ -447,7 +478,18 @@ static void rfcomm_connected(struct bt_l2cap_chan *chan)
 	session->mtu -= BT_RFCOMM_OVERHEAD_SIZE;
 
 	if (session->state == BT_RFCOMM_STATE_CONNECTING) {
-		rfcomm_send_sabm(session, 0);
+		err = rfcomm_send_sabm(session, 0);
+		if (err != 0) {
+			LOG_ERR("Failed to send sabm on session %p (%d)", session, err);
+			goto disconnect;
+		}
+	}
+	return;
+
+disconnect:
+	err = bt_l2cap_chan_disconnect(chan);
+	if (err < 0) {
+		LOG_ERR("Failed to disconnect RFCOMM session (err %d)", err);
 	}
 }
 
@@ -548,7 +590,10 @@ static int rfcomm_send_dm(struct bt_rfcomm_session *session, uint8_t dlci)
 
 	LOG_DBG("dlci %d", dlci);
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	buf = rfcomm_create_pdu(sizeof(*hdr) + sizeof(fcs));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	cr = BT_RFCOMM_RESP_CR(session->role);
@@ -637,7 +682,10 @@ static int rfcomm_send_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 	struct net_buf *buf;
 	uint8_t cr, fcs;
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	buf = rfcomm_create_pdu(sizeof(*hdr) + sizeof(fcs));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	cr = BT_RFCOMM_RESP_CR(session->role);
@@ -658,8 +706,10 @@ static int rfcomm_send_msc(struct bt_rfcomm_dlc *dlc, uint8_t cr,
 	struct net_buf *buf;
 	uint8_t fcs;
 
-	buf = rfcomm_make_uih_msg(dlc->session, cr, BT_RFCOMM_MSC,
-				  sizeof(*msc));
+	buf = rfcomm_make_uih_msg(dlc->session, cr, BT_RFCOMM_MSC, sizeof(*msc));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	msc = net_buf_add(buf, sizeof(*msc));
 	/* cr bit should be always 1 in MSC */
@@ -679,8 +729,10 @@ static int rfcomm_send_rls(struct bt_rfcomm_dlc *dlc, uint8_t cr,
 	struct net_buf *buf;
 	uint8_t fcs;
 
-	buf = rfcomm_make_uih_msg(dlc->session, cr, BT_RFCOMM_RLS,
-				  sizeof(*rls));
+	buf = rfcomm_make_uih_msg(dlc->session, cr, BT_RFCOMM_RLS, sizeof(*rls));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	rls = net_buf_add(buf, sizeof(*rls));
 	/* cr bit should be always 1 in RLS */
@@ -731,6 +783,9 @@ static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
 	uint8_t fcs;
 
 	buf = rfcomm_make_uih_msg(session, cr, BT_RFCOMM_RPN, sizeof(*rpn));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	net_buf_add_mem(buf, rpn, sizeof(*rpn));
 
@@ -779,6 +834,9 @@ static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr, uint8
 	uint8_t fcs;
 
 	buf = rfcomm_make_uih_msg(session, cr, BT_RFCOMM_TEST, len);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	net_buf_add_mem(buf, pattern, len);
 
@@ -793,8 +851,10 @@ static int rfcomm_send_nsc(struct bt_rfcomm_session *session, uint8_t cmd_type)
 	struct net_buf *buf;
 	uint8_t fcs;
 
-	buf = rfcomm_make_uih_msg(session, BT_RFCOMM_MSG_RESP_CR,
-				  BT_RFCOMM_NSC, sizeof(cmd_type));
+	buf = rfcomm_make_uih_msg(session, BT_RFCOMM_MSG_RESP_CR, BT_RFCOMM_NSC, sizeof(cmd_type));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	net_buf_add_u8(buf, cmd_type);
 
@@ -810,6 +870,9 @@ static int rfcomm_send_fcon(struct bt_rfcomm_session *session, uint8_t cr)
 	uint8_t fcs;
 
 	buf = rfcomm_make_uih_msg(session, cr, BT_RFCOMM_FCON, 0);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
@@ -823,6 +886,9 @@ static int rfcomm_send_fcoff(struct bt_rfcomm_session *session, uint8_t cr)
 	uint8_t fcs;
 
 	buf = rfcomm_make_uih_msg(session, cr, BT_RFCOMM_FCOFF, 0);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	fcs = rfcomm_calc_fcs(BT_RFCOMM_FCS_LEN_UIH, buf->data);
 	net_buf_add_u8(buf, fcs);
@@ -875,14 +941,33 @@ static void rfcomm_dlc_drop(struct bt_rfcomm_dlc *dlc)
 	rfcomm_dlc_destroy(dlc);
 }
 
+static void rfcomm_dlc_disconn(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
+	err = rfcomm_send_disc(dlc->session, dlc->dlci);
+	if (err == 0) {
+		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
+	} else {
+		LOG_ERR("Failed to send disc on DLC %p (%d)", dlc, err);
+		bt_work_reschedule(&dlc->rtx_work, K_NO_WAIT);
+	}
+}
+
 static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
 {
+	int err;
+
 	LOG_DBG("dlc %p", dlc);
 
 	switch (dlc->state) {
 	case BT_RFCOMM_STATE_SECURITY_PENDING:
 		if (dlc->role == BT_RFCOMM_ROLE_ACCEPTOR) {
-			rfcomm_send_dm(dlc->session, dlc->dlci);
+			err = rfcomm_send_dm(dlc->session, dlc->dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
+			}
 		}
 		__fallthrough;
 	case BT_RFCOMM_STATE_INIT:
@@ -891,8 +976,7 @@ static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
 	case BT_RFCOMM_STATE_CONNECTING:
 	case BT_RFCOMM_STATE_CONFIG:
 		dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
-		rfcomm_send_disc(dlc->session, dlc->dlci);
-		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
+		rfcomm_dlc_disconn(dlc);
 		break;
 	case BT_RFCOMM_STATE_CONNECTED:
 		dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
@@ -918,6 +1002,9 @@ static int rfcomm_send_pn(struct bt_rfcomm_dlc *dlc, uint8_t cr)
 	uint8_t fcs;
 
 	buf = rfcomm_make_uih_msg(dlc->session, cr, BT_RFCOMM_PN, sizeof(*pn));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	LOG_DBG("mtu %x", dlc->mtu);
 
@@ -958,7 +1045,10 @@ static int rfcomm_send_credit(struct bt_rfcomm_dlc *dlc, uint8_t credits)
 
 	LOG_DBG("Dlc %p credits %d", dlc, credits);
 
-	buf = bt_l2cap_create_pdu(NULL, 0);
+	buf = rfcomm_create_pdu(sizeof(*hdr) + sizeof(credits) + sizeof(fcs));
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	cr = BT_RFCOMM_UIH_CR(dlc->session->role);
@@ -975,6 +1065,7 @@ static int rfcomm_send_credit(struct bt_rfcomm_dlc *dlc, uint8_t credits)
 
 static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
 {
+	int err;
 	enum security_result result;
 
 	LOG_DBG("dlc %p", dlc);
@@ -984,8 +1075,11 @@ static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
 	case RFCOMM_SECURITY_PASSED:
 		dlc->mtu = MIN(dlc->mtu, dlc->session->mtu);
 		dlc->state = BT_RFCOMM_STATE_CONFIG;
-		rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
-		break;
+		err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
+		if (err != 0) {
+			LOG_ERR("Failed to send pn on DLC %p (%d)", dlc, err);
+		}
+		return err;
 	case RFCOMM_SECURITY_PENDING:
 		dlc->state = BT_RFCOMM_STATE_SECURITY_PENDING;
 		break;
@@ -1132,8 +1226,7 @@ disconnect:
 	}
 
 	if (dlc->state == BT_RFCOMM_STATE_DISCONNECTING) {
-		rfcomm_send_disc(dlc->session, dlc->dlci);
-		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
+		rfcomm_dlc_disconn(dlc);
 	} else {
 		rfcomm_dlc_destroy(dlc);
 	}
@@ -1161,7 +1254,10 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
 		LOG_DBG("CFC not supported %p", dlc);
-		rfcomm_send_fcon(dlc->session, BT_RFCOMM_MSG_CMD_CR);
+		err = rfcomm_send_fcon(dlc->session, BT_RFCOMM_MSG_CMD_CR);
+		if (err != 0) {
+			LOG_ERR("Failed to send fcon command on dlc %p (%d)", dlc, err);
+		}
 		/* Use tx_credits as binary sem for MSC FC */
 		k_sem_init(&dlc->tx_credits, 0, 1);
 	}
@@ -1179,6 +1275,8 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 
 static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 {
+	int err;
+
 	if (!dlci) {
 		if (rfcomm_send_ua(session, dlci) < 0) {
 			return;
@@ -1192,10 +1290,14 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 		dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
 		if (dlc == NULL) {
 			dlc = rfcomm_dlc_accept(session, dlci);
-			if (dlc == NULL) {
-				rfcomm_send_dm(session, dlci);
-				return;
+		}
+
+		if (dlc == NULL) {
+			err = rfcomm_send_dm(session, dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm to %u (%d)", dlci, err);
 			}
+			return;
 		}
 
 		result = rfcomm_dlc_security(dlc);
@@ -1207,7 +1309,10 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 			break;
 		case RFCOMM_SECURITY_REJECT:
 		default:
-			rfcomm_send_dm(session, dlci);
+			err = rfcomm_send_dm(session, dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
+			}
 			rfcomm_dlc_drop(dlc);
 			return;
 		}
@@ -1296,6 +1401,7 @@ static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 	struct bt_rfcomm_msc *msc;
 	struct bt_rfcomm_dlc *dlc;
 	uint8_t dlci;
+	int err;
 
 	if (buf->len < sizeof(*msc)) {
 		LOG_WRN("Malformed MSC command %u < %zu", buf->len, sizeof(*msc));
@@ -1336,7 +1442,10 @@ static void rfcomm_handle_msc(struct bt_rfcomm_session *session,
 		}
 	}
 
-	rfcomm_send_msc(dlc, BT_RFCOMM_MSG_RESP_CR, msc->v24_signal);
+	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_RESP_CR, msc->v24_signal);
+	if (err != 0) {
+		LOG_ERR("Failed to send msc on DLC %p (%d)", dlc, err);
+	}
 }
 
 static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
@@ -1345,6 +1454,7 @@ static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 	struct bt_rfcomm_rls *rls;
 	uint8_t dlci;
 	struct bt_rfcomm_dlc *dlc;
+	int err;
 
 	if (buf->len < sizeof(*rls)) {
 		LOG_WRN("Malformed RLS command %u < %zu", buf->len, sizeof(*rls));
@@ -1367,7 +1477,10 @@ static void rfcomm_handle_rls(struct bt_rfcomm_session *session,
 	}
 
 	/* As per the ETSI same line status has to returned in the response */
-	rfcomm_send_rls(dlc, BT_RFCOMM_MSG_RESP_CR, rls->line_status);
+	err = rfcomm_send_rls(dlc, BT_RFCOMM_MSG_RESP_CR, rls->line_status);
+	if (err != 0) {
+		LOG_ERR("Failed to send rls on DLC %p (%d)", dlc, err);
+	}
 }
 
 static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
@@ -1376,6 +1489,7 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 	struct bt_rfcomm_rpn rsp;
 	uint8_t dlci;
 	uint8_t data_bits, stop_bits, parity_bits;
+	int err;
 
 	if (!cr) {
 		/* Ignore if its a response */
@@ -1393,7 +1507,10 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 		rsp = *rpn;
 		/* Accept all the values proposed by the sender */
 		rsp.param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
-		rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
+		err = rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
+		if (err != 0) {
+			LOG_ERR("Failed to send rpn setting rsp (%d)", err);
+		}
 		return;
 	}
 
@@ -1420,7 +1537,50 @@ static void rfcomm_handle_rpn(struct bt_rfcomm_session *session,
 	rsp.line_settings = BT_RFCOMM_SET_LINE_SETTINGS(data_bits, stop_bits, parity_bits);
 	rsp.param_mask = sys_cpu_to_le16(BT_RFCOMM_RPN_PARAM_MASK_ALL);
 
-	rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
+	err = rfcomm_send_rpn(session, BT_RFCOMM_MSG_RESP_CR, &rsp);
+	if (err != 0) {
+		LOG_ERR("Failed to send rpn getting rsp (%d)", err);
+	}
+}
+
+static void rfcomm_handle_test(struct bt_rfcomm_session *session, struct net_buf *buf, uint8_t cr)
+{
+	int err;
+
+	if (!cr) {
+		return;
+	}
+
+	if (buf->len > UINT8_MAX) {
+		LOG_WRN("TEST command too long %u > %u", buf->len, UINT8_MAX);
+		return;
+	}
+
+	err = rfcomm_send_test(session, BT_RFCOMM_MSG_RESP_CR, buf->data, buf->len);
+	if (err != 0) {
+		LOG_ERR("Failed to send test rsp on session %p (%d)", session, err);
+	}
+}
+
+static void rfcomm_dlc_connect(struct bt_rfcomm_session *session, struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+	uint8_t state;
+
+	state = dlc->state;
+	dlc->state = BT_RFCOMM_STATE_CONNECTING;
+	err = rfcomm_send_sabm(session, dlc->dlci);
+	if (err == 0) {
+		return;
+	}
+
+	LOG_ERR("Failed to send sabm on DLC %p (%d)", dlc, err);
+
+	dlc->state = state;
+	err = rfcomm_dlc_close(dlc);
+	if (err != 0) {
+		LOG_ERR("Failed to close DLC %p state %u (%d)", dlc, state, err);
+	}
 }
 
 static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
@@ -1428,6 +1588,7 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 {
 	struct bt_rfcomm_pn *pn;
 	struct bt_rfcomm_dlc *dlc;
+	int err;
 
 	if (buf->len < sizeof(*pn)) {
 		LOG_WRN("Malformed PN command %u < %zu", buf->len, sizeof(*pn));
@@ -1444,13 +1605,19 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 
 		if (!BT_RFCOMM_CHECK_MTU(pn->mtu)) {
 			LOG_ERR("Invalid mtu %d", pn->mtu);
-			rfcomm_send_dm(session, pn->dlci);
+			err = rfcomm_send_dm(session, pn->dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm to %u (%d)", pn->dlci, err);
+			}
 			return;
 		}
 
 		dlc = rfcomm_dlc_accept(session, pn->dlci);
-		if (!dlc) {
-			rfcomm_send_dm(session, pn->dlci);
+		if (dlc == NULL) {
+			err = rfcomm_send_dm(session, pn->dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm to %u (%d)", pn->dlci, err);
+			}
 			return;
 		}
 
@@ -1469,7 +1636,10 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 		}
 
 		dlc->state = BT_RFCOMM_STATE_CONFIG;
-		rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+		err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+		if (err != 0) {
+			LOG_ERR("Failed to send pn rsp on DLC %p (%d)", dlc, err);
+		}
 		/* Cancel idle timer if any */
 		k_work_cancel_delayable(&session->rtx_work);
 	} else {
@@ -1481,7 +1651,10 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 				return;
 			}
 			dlc->mtu = MIN(dlc->mtu, sys_le16_to_cpu(pn->mtu));
-			rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+			err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+			if (err != 0) {
+				LOG_ERR("Failed to send pn rsp on DLC %p (%d)", dlc, err);
+			}
 		} else {
 			if (dlc->state != BT_RFCOMM_STATE_CONFIG) {
 				return;
@@ -1498,8 +1671,7 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 				session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
 			}
 
-			dlc->state = BT_RFCOMM_STATE_CONNECTING;
-			rfcomm_send_sabm(session, dlc->dlci);
+			rfcomm_dlc_connect(session, dlc);
 		}
 	}
 }
@@ -1507,17 +1679,24 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	struct bt_rfcomm_dlc *dlc;
+	int err;
 
 	LOG_DBG("Dlci %d", dlci);
 
 	if (dlci) {
 		dlc = rfcomm_dlcs_remove_dlci(session, dlci);
 		if (dlc == NULL) {
-			rfcomm_send_dm(session, dlci);
+			err = rfcomm_send_dm(session, dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send dm to %u (%d)", dlci, err);
+			}
 			return;
 		}
 
-		rfcomm_send_ua(session, dlci);
+		err = rfcomm_send_ua(session, dlci);
+		if (err != 0) {
+			LOG_ERR("Failed to send ua on DLC %p (%d)", dlc, err);
+		}
 		rfcomm_dlc_disconnect(dlc);
 
 		if (sys_slist_is_empty(&session->dlcs)) {
@@ -1527,7 +1706,10 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 	} else {
 		/* Cancel idle timer */
 		k_work_cancel_delayable(&session->rtx_work);
-		rfcomm_send_ua(session, 0);
+		err = rfcomm_send_ua(session, 0);
+		if (err != 0) {
+			LOG_ERR("Failed to send ua to DLCI0 (%d)", err);
+		}
 		rfcomm_session_disconnected(session);
 	}
 }
@@ -1536,6 +1718,7 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 {
 	struct bt_rfcomm_msg_hdr *hdr;
 	uint8_t msg_type, len, cr;
+	int err;
 
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Too small RFCOMM message");
@@ -1568,16 +1751,7 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 		rfcomm_handle_rpn(session, buf, cr);
 		break;
 	case BT_RFCOMM_TEST:
-		if (!cr) {
-			break;
-		}
-
-		if (buf->len > UINT8_MAX) {
-			LOG_WRN("TEST command too long %u > %u", buf->len, UINT8_MAX);
-			return;
-		}
-
-		rfcomm_send_test(session, BT_RFCOMM_MSG_RESP_CR, buf->data, buf->len);
+		rfcomm_handle_test(session, buf, cr);
 		break;
 	case BT_RFCOMM_FCON:
 		if (session->cfc == BT_RFCOMM_CFC_SUPPORTED) {
@@ -1593,7 +1767,10 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 		 * of this session in sem_take().
 		 */
 		k_sem_give(&session->fc);
-		rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
+		err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
+		if (err != 0) {
+			LOG_ERR("Failed to send fcon rsp on session %p (%d)", session, err);
+		}
 		rfcomm_dlcs_tx_trigger(session);
 		break;
 	case BT_RFCOMM_FCOFF:
@@ -1613,11 +1790,17 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 		 * the semaphore.
 		 */
 		k_sem_take(&session->fc, K_NO_WAIT);
-		rfcomm_send_fcoff(session, BT_RFCOMM_MSG_RESP_CR);
+		err = rfcomm_send_fcoff(session, BT_RFCOMM_MSG_RESP_CR);
+		if (err != 0) {
+			LOG_ERR("Failed to send fcoff rsp on session %p (%d)", session, err);
+		}
 		break;
 	default:
 		LOG_WRN("Unknown/Unsupported RFCOMM Msg type 0x%02x", msg_type);
-		rfcomm_send_nsc(session, hdr->type);
+		err = rfcomm_send_nsc(session, hdr->type);
+		if (err != 0) {
+			LOG_ERR("Failed to send nsc rsp on session %p (%d)", session, err);
+		}
 		break;
 	}
 }
@@ -1659,9 +1842,12 @@ static void rfcomm_handle_data(struct bt_rfcomm_session *session, struct net_buf
 	LOG_DBG("dlci %d, pf %d", dlci, pf);
 
 	dlc = rfcomm_dlcs_lookup_dlci(session, dlci);
-	if (!dlc) {
+	if (dlc == NULL) {
 		LOG_ERR("Data recvd in non existing DLC");
-		rfcomm_send_dm(session, dlci);
+		err = rfcomm_send_dm(session, dlci);
+		if (err != 0) {
+			LOG_ERR("Failed to send dm to %u (%d)", dlci, err);
+		}
 		return;
 	}
 
@@ -1840,6 +2026,7 @@ static void rfcomm_encrypt_change(struct bt_l2cap_chan *chan,
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
 	struct bt_conn *conn = chan->conn;
 	struct bt_rfcomm_dlc *dlc, *tmp;
+	int err;
 
 	LOG_DBG("session %p status 0x%02x encr 0x%02x", session, hci_status, conn->encrypt);
 
@@ -1855,12 +2042,18 @@ static void rfcomm_encrypt_change(struct bt_l2cap_chan *chan,
 		}
 
 		if (dlc->role == BT_RFCOMM_ROLE_ACCEPTOR) {
-			rfcomm_send_ua(session, dlc->dlci);
+			err = rfcomm_send_ua(session, dlc->dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send ua on DLC %p (%d)", dlc, err);
+			}
 			rfcomm_dlc_connected(dlc);
 		} else {
 			dlc->mtu = MIN(dlc->mtu, session->mtu);
 			dlc->state = BT_RFCOMM_STATE_CONFIG;
-			rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
+			err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
+			if (err != 0) {
+				LOG_ERR("Failed to send pn on DLC %p (%d)", dlc, err);
+			}
 		}
 	}
 }
@@ -1885,6 +2078,7 @@ static void rfcomm_session_rtx_timeout(struct k_work *work)
 	case BT_RFCOMM_STATE_DISCONNECTING:
 		session->state = BT_RFCOMM_STATE_DISCONNECTED;
 		if (bt_l2cap_chan_disconnect(&session->br_chan.chan) < 0) {
+			LOG_ERR("Failed to disconnect RFCOMM session %p", session);
 			session->state = BT_RFCOMM_STATE_IDLE;
 		}
 		break;

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -51,8 +51,8 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 #define RFCOMM_DISC_TIMEOUT     K_SECONDS(20)
 #define RFCOMM_IDLE_TIMEOUT     K_SECONDS(2)
 
-#define DLC_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
-				 struct bt_rfcomm_dlc, rtx_work)
+#define DLC_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, rtx_work)
+#define DLC_RETRY(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, retry_work)
 #define SESSION_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				     struct bt_rfcomm_session, rtx_work)
 
@@ -243,6 +243,7 @@ static void rfcomm_dlc_destroy(struct bt_rfcomm_dlc *dlc)
 	LOG_DBG("dlc %p", dlc);
 
 	k_work_cancel_delayable(&dlc->rtx_work);
+	k_work_cancel_delayable(&dlc->retry_work);
 	k_work_cancel(&dlc->tx_work);
 
 	dlc->state = BT_RFCOMM_STATE_IDLE;
@@ -516,6 +517,15 @@ static void rfcomm_dlc_rtx_timeout(struct k_work *work)
 	rfcomm_session_disconnect(session);
 }
 
+static void rfcomm_dlc_retry_handler(struct k_work *work)
+{
+	struct bt_rfcomm_dlc *dlc = DLC_RETRY(work);
+
+	LOG_DBG("dlc %p retry", dlc);
+
+	rfcomm_dlc_tx_trigger(dlc);
+}
+
 static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 			    struct bt_rfcomm_session *session,
 			    uint8_t dlci,
@@ -545,6 +555,7 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 	dlc->state = BT_RFCOMM_STATE_INIT;
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
+	k_work_init_delayable(&dlc->retry_work, rfcomm_dlc_retry_handler);
 
 	/* Start a conn timer which includes auth as well */
 	bt_work_schedule(&dlc->rtx_work, RFCOMM_CONN_TIMEOUT);
@@ -1111,9 +1122,48 @@ static inline uint8_t rfcomm_dlc_get_available_credits(struct bt_rfcomm_dlc *dlc
 	return max_credits - inprogress_credits;
 }
 
+#define RFCOMM_RETRY_TIMEOUT 1
+
+static void rfcomm_dlc_update_fc_on(struct bt_rfcomm_dlc *dlc, bool retry)
+{
+	struct bt_rfcomm_session *session;
+	int err;
+
+	session = dlc->session;
+	if (session == NULL) {
+		return;
+	}
+
+	if (session->cfc != BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		return;
+	}
+
+	if (!atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ)) {
+		return;
+	}
+
+	if (atomic_test_and_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON)) {
+		return;
+	}
+
+	err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_CMD_CR);
+	if (err != 0) {
+		atomic_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON);
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ);
+		LOG_ERR("Failed to send fcon command on session %p (%d)", session, err);
+	}
+
+	/* Retry. */
+	if (err == -ENOBUFS && retry) {
+		bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+	}
+}
+
 static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
 {
 	int err;
+
+	rfcomm_dlc_update_fc_on(dlc, true);
 
 	if (!atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ)) {
 		return;
@@ -1128,6 +1178,11 @@ static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
 		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
 		LOG_ERR("Failed to send MSC with FC cleared (%d)", err);
+	}
+
+	/* Retry. */
+	if (err == -ENOBUFS) {
+		bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 	}
 }
 
@@ -1159,6 +1214,11 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 		if (err != 0) {
 			LOG_ERR("Failed to send credit (%d)", err);
 			dlc->rx_credit -= credits;
+		}
+
+		/* Retry. */
+		if (err == -ENOBUFS) {
+			bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 		}
 	}
 }
@@ -1257,10 +1317,8 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
 		LOG_DBG("CFC not supported %p", dlc);
-		err = rfcomm_send_fcon(dlc->session, BT_RFCOMM_MSG_CMD_CR);
-		if (err != 0) {
-			LOG_ERR("Failed to send fcon command on dlc %p (%d)", dlc, err);
-		}
+		atomic_set_bit(&dlc->session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ);
+		rfcomm_dlc_update_fc_on(dlc, false);
 		/* Use tx_credits as binary sem for MSC FC */
 		k_sem_init(&dlc->tx_credits, 0, 1);
 	}
@@ -1273,6 +1331,10 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 
 	if (dlc->ops && dlc->ops->connected) {
 		dlc->ops->connected(dlc);
+	}
+
+	if (atomic_test_bit(&dlc->session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ)) {
+		rfcomm_dlc_tx_trigger(dlc);
 	}
 }
 
@@ -2115,7 +2177,7 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		k_work_init_delayable(&session->rtx_work,
 				      rfcomm_session_rtx_timeout);
 		k_sem_init(&session->fc, 0, 1);
-
+		atomic_clear(&session->flags);
 		return session;
 	}
 

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -1243,6 +1243,9 @@ static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
 	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
 	if (err == 0) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+	} else {
+		LOG_ERR("Failed to send msc on dlc %p (%d)", dlc, err);
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
 	}
 
 	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -54,10 +54,15 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 
 #define DLC_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, rtx_work)
 #define DLC_TX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, tx_work)
+#define DLC_RETRY_TIMEOUT(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
+					   struct bt_rfcomm_dlc, retry_timeout_work)
+
 #define SESSION_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				     struct bt_rfcomm_session, rtx_work)
 #define SESSION_RETRY(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				       struct bt_rfcomm_session, retry_work)
+#define SESSION_RETRY_TIMEOUT(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
+					       struct bt_rfcomm_session, retry_timeout_work)
 
 static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 
@@ -66,8 +71,10 @@ static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 
 static struct bt_rfcomm_session bt_rfcomm_pool[CONFIG_BT_MAX_CONN];
 
-#define RFCOMM_RETRY_TIMEOUT_MAX 100
-#define RFCOMM_RETRY_TIMEOUT (sys_rand32_get() % RFCOMM_RETRY_TIMEOUT_MAX)
+#define RFCOMM_RETRY_INTERVAL_MAX 100
+#define RFCOMM_RETRY_INTERVAL (K_MSEC((sys_rand32_get() % RFCOMM_RETRY_INTERVAL_MAX)))
+
+#define RFCOMM_RETRY_TIMEOUT (K_SECONDS(5))
 
 #define RFCOMM_CRC_POLY CRC8_REFLECT_POLY
 #define RFCOMM_CRC_INIT 0xff
@@ -250,6 +257,7 @@ static void rfcomm_dlc_destroy(struct bt_rfcomm_dlc *dlc)
 
 	k_work_cancel_delayable(&dlc->rtx_work);
 	k_work_cancel_delayable(&dlc->tx_work);
+	k_work_cancel_delayable(&dlc->retry_timeout_work);
 
 	dlc->state = BT_RFCOMM_STATE_IDLE;
 	dlc->session = NULL;
@@ -469,6 +477,7 @@ static void rfcomm_session_disconn_req(struct bt_rfcomm_session *session)
 
 	err = bt_l2cap_chan_disconnect(&session->br_chan.chan);
 	if (err == 0) {
+		k_work_cancel_delayable(&session->retry_timeout_work);
 		return;
 	}
 
@@ -476,7 +485,8 @@ static void rfcomm_session_disconn_req(struct bt_rfcomm_session *session)
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_DISCONN_REQ);
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
 		return;
 	}
 
@@ -531,6 +541,7 @@ static void rfcomm_disconnected(struct bt_l2cap_chan *chan)
 
 	k_work_cancel_delayable(&session->rtx_work);
 	k_work_cancel_delayable(&session->retry_work);
+	k_work_cancel_delayable(&session->retry_timeout_work);
 	rfcomm_session_disconnected(session);
 	session->state = BT_RFCOMM_STATE_IDLE;
 }
@@ -545,6 +556,15 @@ static void rfcomm_dlc_rtx_timeout(struct k_work *work)
 	rfcomm_dlcs_remove_dlci(session, dlc->dlci);
 	rfcomm_dlc_disconnect(dlc);
 	rfcomm_session_disconnect(session);
+}
+
+static void rfcomm_dlc_retry_timeout(struct k_work *work)
+{
+	struct bt_rfcomm_dlc *dlc = DLC_RETRY_TIMEOUT(work);
+
+	LOG_WRN("dlc %p state %d retry timeout", dlc, dlc->state);
+
+	bt_work_reschedule(&dlc->rtx_work, K_NO_WAIT);
 }
 
 static void rfcomm_dlc_tx_worker(struct k_work *work);
@@ -579,6 +599,7 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
 	k_work_init_delayable(&dlc->tx_work, rfcomm_dlc_tx_worker);
+	k_work_init_delayable(&dlc->retry_timeout_work, rfcomm_dlc_retry_timeout);
 
 	/* Start a conn timer which includes auth as well */
 	bt_work_schedule(&dlc->rtx_work, RFCOMM_CONN_TIMEOUT);
@@ -982,9 +1003,11 @@ static void rfcomm_dlc_disconn(struct bt_rfcomm_dlc *dlc)
 	dlc->state = BT_RFCOMM_STATE_DISCONNECTING;
 	err = rfcomm_send_disc(dlc->session, dlc->dlci);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
 	} else if (err == -ENOBUFS) {
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 	} else {
 		LOG_ERR("Failed to send disc on DLC %p (%d)", dlc, err);
 		bt_work_reschedule(&dlc->rtx_work, K_NO_WAIT);
@@ -1010,13 +1033,15 @@ static int rfcomm_dlc_send_dm(struct bt_rfcomm_dlc *dlc)
 
 	err = rfcomm_send_dm(dlc->session, dlc->dlci);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		rfcomm_dlc_drop(dlc);
 		return 0;
 	}
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_DM);
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 		return 0;
 	}
 
@@ -1157,6 +1182,7 @@ static int rfcomm_dlc_send_pn_req(struct bt_rfcomm_dlc *dlc)
 	dlc->state = BT_RFCOMM_STATE_CONFIG;
 	err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		return 0;
 	}
 
@@ -1164,7 +1190,8 @@ static int rfcomm_dlc_send_pn_req(struct bt_rfcomm_dlc *dlc)
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_PN_REQ);
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 		return 0;
 	}
 
@@ -1190,12 +1217,14 @@ static int rfcomm_dlc_send_pn_rsp(struct bt_rfcomm_dlc *dlc)
 
 	err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		return 0;
 	}
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_PN_RSP);
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 		return 0;
 	}
 
@@ -1257,16 +1286,23 @@ static void rfcomm_session_send_fc_on_req(struct bt_rfcomm_session *session)
 	}
 
 	err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_CMD_CR);
-	if (err != 0) {
-		atomic_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON);
-		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ);
-		LOG_ERR("Failed to send fcon command on session %p (%d)", session, err);
+	if (err == 0) {
+		k_work_cancel_delayable(&session->retry_timeout_work);
+		return;
 	}
 
-	/* Retry. */
+	atomic_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON);
+	atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ);
+	LOG_ERR("Failed to send fcon command on session %p (%d)", session, err);
+
 	if (err == -ENOBUFS) {
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		/* Retry. */
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
+		return;
 	}
+
+	rfcomm_session_disconn_req(session);
 }
 
 static void rfcomm_session_send_fc_on_rsp(struct bt_rfcomm_session *session)
@@ -1278,20 +1314,26 @@ static void rfcomm_session_send_fc_on_rsp(struct bt_rfcomm_session *session)
 	}
 
 	err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
-	if (err != 0) {
-		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_RSP);
-		LOG_ERR("Failed to send fcon rsp on session %p (%d)", session, err);
-	} else {
+	if (err == 0) {
 		/* Give the sem so that it will unblock the waiting dlc threads
 		 * of this session in sem_take().
 		 */
 		k_sem_give(&session->fc);
+		k_work_cancel_delayable(&session->retry_timeout_work);
+		return;
 	}
 
-	/* Retry. */
+	atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_RSP);
+	LOG_ERR("Failed to send fcon rsp on session %p (%d)", session, err);
+
 	if (err == -ENOBUFS) {
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		/* Retry. */
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
+		return;
 	}
+
+	rfcomm_session_disconn_req(session);
 }
 
 static void rfcomm_session_send_fc_off_rsp(struct bt_rfcomm_session *session)
@@ -1303,15 +1345,22 @@ static void rfcomm_session_send_fc_off_rsp(struct bt_rfcomm_session *session)
 	}
 
 	err = rfcomm_send_fcoff(session, BT_RFCOMM_MSG_RESP_CR);
-	if (err != 0) {
-		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_OFF_RSP);
-		LOG_ERR("Failed to send fcoff rsp on session %p (%d)", session, err);
+	if (err == 0) {
+		k_work_cancel_delayable(&session->retry_timeout_work);
+		return;
 	}
 
-	/* Retry. */
+	atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_OFF_RSP);
+	LOG_ERR("Failed to send fcoff rsp on session %p (%d)", session, err);
+
 	if (err == -ENOBUFS) {
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		/* Retry. */
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
+		return;
 	}
+
+	rfcomm_session_disconn_req(session);
 }
 
 static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
@@ -1327,15 +1376,19 @@ static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
 	}
 
 	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
-	if (err != 0) {
-		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
-		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
-		LOG_ERR("Failed to send MSC with FC cleared (%d)", err);
+	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
+		return;
 	}
 
-	/* Retry. */
 	if (err == -ENOBUFS) {
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+		atomic_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
+	} else {
+		LOG_ERR("Failed to send MSC with FC cleared on DLC %p (%d)", dlc, err);
+		rfcomm_dlc_close(dlc);
 	}
 }
 
@@ -1364,14 +1417,21 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 		credits = credit_available - dlc->rx_credit;
 		dlc->rx_credit += credits;
 		err = rfcomm_send_credit(dlc, credits);
-		if (err != 0) {
-			LOG_ERR("Failed to send credit (%d)", err);
-			dlc->rx_credit -= credits;
+		if (err == 0) {
+			k_work_cancel_delayable(&dlc->retry_timeout_work);
+			return;
 		}
+
+		LOG_ERR("Failed to send credit (%d)", err);
+		dlc->rx_credit -= credits;
 
 		/* Retry. */
 		if (err == -ENOBUFS) {
-			bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+			bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+			bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
+		} else {
+			/* Disconnected*/
+			rfcomm_dlc_close(dlc);
 		}
 	}
 }
@@ -1426,6 +1486,7 @@ static int rfcomm_dlc_send_ua_for_sabm(struct bt_rfcomm_dlc *dlc)
 
 	err = rfcomm_send_ua(dlc->session, dlc->dlci);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		/* Cancel idle timer if any */
 		k_work_cancel_delayable(&dlc->session->rtx_work);
 		rfcomm_dlc_connected(dlc);
@@ -1434,7 +1495,8 @@ static int rfcomm_dlc_send_ua_for_sabm(struct bt_rfcomm_dlc *dlc)
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_SABM);
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 		return 0;
 	}
 
@@ -1455,12 +1517,14 @@ static void rfcomm_dlc_process_disc(struct bt_rfcomm_dlc *dlc)
 
 	err = rfcomm_send_ua(session, dlc->dlci);
 	if (err == 0) {
+		k_work_cancel_delayable(&dlc->retry_timeout_work);
 		goto done;
 	}
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_DISC);
-		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&dlc->tx_work, RFCOMM_RETRY_INTERVAL);
 		return;
 	}
 
@@ -1600,6 +1664,7 @@ static void rfcomm_session_send_ua_for_sabm(struct bt_rfcomm_session *session)
 	err = rfcomm_send_ua(session, 0);
 	if (err == 0) {
 		session->state = BT_RFCOMM_STATE_CONNECTED;
+		k_work_cancel_delayable(&session->retry_timeout_work);
 		return;
 	}
 
@@ -1607,7 +1672,8 @@ static void rfcomm_session_send_ua_for_sabm(struct bt_rfcomm_session *session)
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_SABM);
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
 		return;
 	}
 
@@ -2037,11 +2103,13 @@ static void rfcomm_session_send_ua_for_disc(struct bt_rfcomm_session *session)
 
 	if (err == -ENOBUFS) {
 		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_DISC);
-		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&session->retry_timeout_work, RFCOMM_RETRY_TIMEOUT);
+		bt_work_schedule(&session->retry_work, RFCOMM_RETRY_INTERVAL);
 		return;
 	}
 
 disconnected:
+	k_work_cancel_delayable(&session->retry_timeout_work);
 	rfcomm_session_disconnected(session);
 }
 
@@ -2463,6 +2531,20 @@ static void rfcomm_session_retry_handler(struct k_work *work)
 	}
 }
 
+static void rfcomm_session_retry_timeout(struct k_work *work)
+{
+	struct bt_rfcomm_session *session = SESSION_RETRY_TIMEOUT(work);
+
+	if (session->br_chan.chan.conn == NULL) {
+		/* The underlying connection is already gone; there is nothing
+		 * left for the timeout to act on.
+		 */
+		return;
+	}
+
+	bt_work_reschedule(&session->rtx_work, K_NO_WAIT);
+}
+
 static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 {
 	static const struct bt_l2cap_chan_ops ops = {
@@ -2489,6 +2571,7 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		sys_slist_init(&session->dlcs);
 		k_work_init_delayable(&session->rtx_work, rfcomm_session_rtx_timeout);
 		k_work_init_delayable(&session->retry_work, rfcomm_session_retry_handler);
+		k_work_init_delayable(&session->retry_timeout_work, rfcomm_session_retry_timeout);
 		k_sem_init(&session->fc, 0, 1);
 		atomic_clear(&session->flags);
 		return session;

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -15,6 +15,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/debug/stack.h>
+#include <zephyr/random/random.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -52,9 +53,11 @@ LOG_MODULE_REGISTER(bt_rfcomm);
 #define RFCOMM_IDLE_TIMEOUT     K_SECONDS(2)
 
 #define DLC_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, rtx_work)
-#define DLC_RETRY(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, retry_work)
+#define DLC_TX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), struct bt_rfcomm_dlc, tx_work)
 #define SESSION_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
 				     struct bt_rfcomm_session, rtx_work)
+#define SESSION_RETRY(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \
+				       struct bt_rfcomm_session, retry_work)
 
 static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 
@@ -62,6 +65,9 @@ static sys_slist_t servers = SYS_SLIST_STATIC_INIT(&servers);
 					 struct bt_rfcomm_session, br_chan.chan)
 
 static struct bt_rfcomm_session bt_rfcomm_pool[CONFIG_BT_MAX_CONN];
+
+#define RFCOMM_RETRY_TIMEOUT_MAX 100
+#define RFCOMM_RETRY_TIMEOUT (sys_rand32_get() % RFCOMM_RETRY_TIMEOUT_MAX)
 
 #define RFCOMM_CRC_POLY CRC8_REFLECT_POLY
 #define RFCOMM_CRC_INIT 0xff
@@ -204,15 +210,15 @@ static void rfcomm_dlc_tx_trigger(struct bt_rfcomm_dlc *dlc)
 {
 	int err;
 
-	if ((dlc == NULL) || (dlc->tx_work.handler == NULL)) {
+	if ((dlc == NULL) || (dlc->tx_work.work.handler == NULL)) {
 		return;
 	}
 
 	LOG_DBG("DLC %p TX trigger", dlc);
 
-	err = bt_work_submit(&dlc->tx_work);
+	err = bt_work_reschedule(&dlc->tx_work, K_NO_WAIT);
 	if (err < 0) {
-		LOG_ERR("Failed to submit tx work: %d", err);
+		LOG_ERR("Failed to reschedule tx work: %d", err);
 	}
 }
 
@@ -243,8 +249,7 @@ static void rfcomm_dlc_destroy(struct bt_rfcomm_dlc *dlc)
 	LOG_DBG("dlc %p", dlc);
 
 	k_work_cancel_delayable(&dlc->rtx_work);
-	k_work_cancel_delayable(&dlc->retry_work);
-	k_work_cancel(&dlc->tx_work);
+	k_work_cancel_delayable(&dlc->tx_work);
 
 	dlc->state = BT_RFCOMM_STATE_IDLE;
 	dlc->session = NULL;
@@ -451,6 +456,33 @@ static struct net_buf *rfcomm_make_uih_msg(struct bt_rfcomm_session *session, ui
 	return buf;
 }
 
+static void rfcomm_session_disconn_req(struct bt_rfcomm_session *session)
+{
+	int err;
+
+	if (session->br_chan.chan.conn == NULL) {
+		/* The underlying connection is already gone; there is nothing
+		 * left for the timeout to act on.
+		 */
+		return;
+	}
+
+	err = bt_l2cap_chan_disconnect(&session->br_chan.chan);
+	if (err == 0) {
+		return;
+	}
+
+	LOG_ERR("Failed to disconnect RFCOMM session %p (%d)", session, err);
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_DISCONN_REQ);
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return;
+	}
+
+	bt_work_reschedule(&session->rtx_work, K_NO_WAIT);
+}
+
 static void rfcomm_connected(struct bt_l2cap_chan *chan)
 {
 	struct bt_rfcomm_session *session = RFCOMM_SESSION(chan);
@@ -488,10 +520,7 @@ static void rfcomm_connected(struct bt_l2cap_chan *chan)
 	return;
 
 disconnect:
-	err = bt_l2cap_chan_disconnect(chan);
-	if (err < 0) {
-		LOG_ERR("Failed to disconnect RFCOMM session (err %d)", err);
-	}
+	rfcomm_session_disconn_req(session);
 }
 
 static void rfcomm_disconnected(struct bt_l2cap_chan *chan)
@@ -501,6 +530,7 @@ static void rfcomm_disconnected(struct bt_l2cap_chan *chan)
 	LOG_DBG("Session %p", session);
 
 	k_work_cancel_delayable(&session->rtx_work);
+	k_work_cancel_delayable(&session->retry_work);
 	rfcomm_session_disconnected(session);
 	session->state = BT_RFCOMM_STATE_IDLE;
 }
@@ -517,14 +547,7 @@ static void rfcomm_dlc_rtx_timeout(struct k_work *work)
 	rfcomm_session_disconnect(session);
 }
 
-static void rfcomm_dlc_retry_handler(struct k_work *work)
-{
-	struct bt_rfcomm_dlc *dlc = DLC_RETRY(work);
-
-	LOG_DBG("dlc %p retry", dlc);
-
-	rfcomm_dlc_tx_trigger(dlc);
-}
+static void rfcomm_dlc_tx_worker(struct k_work *work);
 
 static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 			    struct bt_rfcomm_session *session,
@@ -535,11 +558,11 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 
 	LOG_DBG("dlc %p", dlc);
 
-	if (dlc->tx_work.handler != NULL) {
+	if (dlc->tx_work.work.handler != NULL) {
 		/* Make sure the tx_work is cancelled before reinitializing */
-		k_work_cancel_sync(&dlc->tx_work, &sync);
+		k_work_cancel_delayable_sync(&dlc->tx_work, &sync);
 		/* Reset the work handler to NULL before the DLC connected */
-		dlc->tx_work.handler = NULL;
+		dlc->tx_work.work.handler = NULL;
 	}
 
 	dlc->dlci = dlci;
@@ -555,7 +578,7 @@ static void rfcomm_dlc_init(struct bt_rfcomm_dlc *dlc,
 	dlc->state = BT_RFCOMM_STATE_INIT;
 	dlc->role = role;
 	k_work_init_delayable(&dlc->rtx_work, rfcomm_dlc_rtx_timeout);
-	k_work_init_delayable(&dlc->retry_work, rfcomm_dlc_retry_handler);
+	k_work_init_delayable(&dlc->tx_work, rfcomm_dlc_tx_worker);
 
 	/* Start a conn timer which includes auth as well */
 	bt_work_schedule(&dlc->rtx_work, RFCOMM_CONN_TIMEOUT);
@@ -960,10 +983,46 @@ static void rfcomm_dlc_disconn(struct bt_rfcomm_dlc *dlc)
 	err = rfcomm_send_disc(dlc->session, dlc->dlci);
 	if (err == 0) {
 		bt_work_reschedule(&dlc->rtx_work, RFCOMM_DISC_TIMEOUT);
+	} else if (err == -ENOBUFS) {
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 	} else {
 		LOG_ERR("Failed to send disc on DLC %p (%d)", dlc, err);
 		bt_work_reschedule(&dlc->rtx_work, K_NO_WAIT);
 	}
+}
+
+static int rfcomm_dlc_send_dm(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	if (dlc->session == NULL) {
+		return -ENOTCONN;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_SECURITY_PENDING &&
+	    dlc->state != BT_RFCOMM_STATE_SECURITY_FAILED) {
+		return -EINVAL;
+	}
+
+	if (dlc->role != BT_RFCOMM_ROLE_ACCEPTOR) {
+		return -EINVAL;
+	}
+
+	err = rfcomm_send_dm(dlc->session, dlc->dlci);
+	if (err == 0) {
+		rfcomm_dlc_drop(dlc);
+		return 0;
+	}
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_DM);
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return 0;
+	}
+
+	LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
+	return err;
+
 }
 
 static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
@@ -975,12 +1034,14 @@ static int rfcomm_dlc_close(struct bt_rfcomm_dlc *dlc)
 	switch (dlc->state) {
 	case BT_RFCOMM_STATE_SECURITY_PENDING:
 		if (dlc->role == BT_RFCOMM_ROLE_ACCEPTOR) {
-			err = rfcomm_send_dm(dlc->session, dlc->dlci);
-			if (err != 0) {
-				LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
+			err = rfcomm_dlc_send_dm(dlc);
+			if (err == 0) {
+				return 0;
 			}
+			LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
 		}
 		__fallthrough;
+	case BT_RFCOMM_STATE_SECURITY_FAILED:
 	case BT_RFCOMM_STATE_INIT:
 		rfcomm_dlc_drop(dlc);
 		break;
@@ -1074,9 +1135,76 @@ static int rfcomm_send_credit(struct bt_rfcomm_dlc *dlc, uint8_t credits)
 	return rfcomm_send(dlc->session, buf);
 }
 
-static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
+static int rfcomm_dlc_send_pn_req(struct bt_rfcomm_dlc *dlc)
 {
 	int err;
+	uint8_t state;
+
+	if (dlc->session == NULL) {
+		return -EINVAL;
+	}
+
+	if (dlc->role != BT_RFCOMM_ROLE_INITIATOR) {
+		return -EINVAL;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_INIT && dlc->state != BT_RFCOMM_STATE_SECURITY_PENDING) {
+		return -EINVAL;
+	}
+
+	dlc->mtu = MIN(dlc->mtu, dlc->session->mtu);
+	state = dlc->state;
+	dlc->state = BT_RFCOMM_STATE_CONFIG;
+	err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
+	if (err == 0) {
+		return 0;
+	}
+
+	dlc->state = state;
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_PN_REQ);
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return 0;
+	}
+
+	LOG_ERR("Failed to send pn on DLC %p (%d)", dlc, err);
+	return err;
+}
+
+static int rfcomm_dlc_send_pn_rsp(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	if (dlc->session == NULL) {
+		return -EINVAL;
+	}
+
+	if (dlc->role != BT_RFCOMM_ROLE_ACCEPTOR) {
+		return -EINVAL;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_CONFIG) {
+		return -EINVAL;
+	}
+
+	err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+	if (err == 0) {
+		return 0;
+	}
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_PN_RSP);
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return 0;
+	}
+
+	LOG_ERR("Failed to send pn rsp on DLC %p (%d)", dlc, err);
+	return err;
+}
+
+static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
+{
 	enum security_result result;
 
 	LOG_DBG("dlc %p", dlc);
@@ -1084,13 +1212,7 @@ static int rfcomm_dlc_start(struct bt_rfcomm_dlc *dlc)
 	result = rfcomm_dlc_security(dlc);
 	switch (result) {
 	case RFCOMM_SECURITY_PASSED:
-		dlc->mtu = MIN(dlc->mtu, dlc->session->mtu);
-		dlc->state = BT_RFCOMM_STATE_CONFIG;
-		err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
-		if (err != 0) {
-			LOG_ERR("Failed to send pn on DLC %p (%d)", dlc, err);
-		}
-		return err;
+		return rfcomm_dlc_send_pn_req(dlc);
 	case RFCOMM_SECURITY_PENDING:
 		dlc->state = BT_RFCOMM_STATE_SECURITY_PENDING;
 		break;
@@ -1122,23 +1244,11 @@ static inline uint8_t rfcomm_dlc_get_available_credits(struct bt_rfcomm_dlc *dlc
 	return max_credits - inprogress_credits;
 }
 
-#define RFCOMM_RETRY_TIMEOUT 1
-
-static void rfcomm_dlc_update_fc_on(struct bt_rfcomm_dlc *dlc, bool retry)
+static void rfcomm_session_send_fc_on_req(struct bt_rfcomm_session *session)
 {
-	struct bt_rfcomm_session *session;
 	int err;
 
-	session = dlc->session;
-	if (session == NULL) {
-		return;
-	}
-
 	if (session->cfc != BT_RFCOMM_CFC_NOT_SUPPORTED) {
-		return;
-	}
-
-	if (!atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ)) {
 		return;
 	}
 
@@ -1154,16 +1264,59 @@ static void rfcomm_dlc_update_fc_on(struct bt_rfcomm_dlc *dlc, bool retry)
 	}
 
 	/* Retry. */
-	if (err == -ENOBUFS && retry) {
-		bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+	if (err == -ENOBUFS) {
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+	}
+}
+
+static void rfcomm_session_send_fc_on_rsp(struct bt_rfcomm_session *session)
+{
+	int err;
+
+	if (session->cfc != BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		return;
+	}
+
+	err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
+	if (err != 0) {
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_RSP);
+		LOG_ERR("Failed to send fcon rsp on session %p (%d)", session, err);
+	} else {
+		/* Give the sem so that it will unblock the waiting dlc threads
+		 * of this session in sem_take().
+		 */
+		k_sem_give(&session->fc);
+	}
+
+	/* Retry. */
+	if (err == -ENOBUFS) {
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+	}
+}
+
+static void rfcomm_session_send_fc_off_rsp(struct bt_rfcomm_session *session)
+{
+	int err;
+
+	if (session->cfc != BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		return;
+	}
+
+	err = rfcomm_send_fcoff(session, BT_RFCOMM_MSG_RESP_CR);
+	if (err != 0) {
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_OFF_RSP);
+		LOG_ERR("Failed to send fcoff rsp on session %p (%d)", session, err);
+	}
+
+	/* Retry. */
+	if (err == -ENOBUFS) {
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 	}
 }
 
 static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
 {
 	int err;
-
-	rfcomm_dlc_update_fc_on(dlc, true);
 
 	if (!atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ)) {
 		return;
@@ -1182,7 +1335,7 @@ static void rfcomm_dlc_fc_check_and_on(struct bt_rfcomm_dlc *dlc)
 
 	/* Retry. */
 	if (err == -ENOBUFS) {
-		bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 	}
 }
 
@@ -1218,19 +1371,165 @@ static void rfcomm_dlc_update_credits(struct bt_rfcomm_dlc *dlc)
 
 		/* Retry. */
 		if (err == -ENOBUFS) {
-			bt_work_reschedule(&dlc->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+			bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
 		}
+	}
+}
+
+static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
+{
+	dlc->state = BT_RFCOMM_STATE_CONNECTED;
+
+	atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+	rfcomm_dlc_fc_check_and_on(dlc);
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
+		/* This means PN negotiation is not done for this session and
+		 * can happen only for 1.0b device.
+		 */
+		dlc->session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
+	}
+
+	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
+		LOG_DBG("CFC not supported %p", dlc);
+		rfcomm_session_send_fc_on_req(dlc->session);
+		/* Use tx_credits as binary sem for MSC FC */
+		k_sem_init(&dlc->tx_credits, 0, 1);
+	}
+
+	/* Cancel conn timer */
+	k_work_cancel_delayable(&dlc->rtx_work);
+
+	k_fifo_init(&dlc->tx_queue);
+
+	if (dlc->ops != NULL && dlc->ops->connected != NULL) {
+		dlc->ops->connected(dlc);
+	}
+}
+
+static int rfcomm_dlc_send_ua_for_sabm(struct bt_rfcomm_dlc *dlc)
+{
+	int err;
+
+	if (dlc->session == NULL) {
+		return -EINVAL;
+	}
+
+	if (dlc->role != BT_RFCOMM_ROLE_ACCEPTOR) {
+		return -EINVAL;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_INIT && dlc->state != BT_RFCOMM_STATE_SECURITY_PENDING &&
+	    dlc->state != BT_RFCOMM_STATE_CONFIG) {
+		return -EINVAL;
+	}
+
+	err = rfcomm_send_ua(dlc->session, dlc->dlci);
+	if (err == 0) {
+		/* Cancel idle timer if any */
+		k_work_cancel_delayable(&dlc->session->rtx_work);
+		rfcomm_dlc_connected(dlc);
+		return 0;
+	}
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_SABM);
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return 0;
+	}
+
+	LOG_ERR("Failed to send UA for SABM on DLC %p (%d)", dlc, err);
+	return err;
+}
+
+static void rfcomm_dlc_process_disc(struct bt_rfcomm_dlc *dlc)
+{
+	struct bt_rfcomm_session *session;
+	int err;
+
+	if (dlc->session == NULL) {
+		return;
+	}
+
+	session = dlc->session;
+
+	err = rfcomm_send_ua(session, dlc->dlci);
+	if (err == 0) {
+		goto done;
+	}
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_DISC);
+		bt_work_schedule(&dlc->tx_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return;
+	}
+
+	LOG_ERR("Failed to send UA for DISC on DLC %p (%d)", dlc, err);
+done:
+	rfcomm_dlc_disconnect(dlc);
+
+	if (sys_slist_is_empty(&session->dlcs)) {
+		/* Start a session idle timer */
+		bt_work_reschedule(&session->rtx_work, RFCOMM_IDLE_TIMEOUT);
+	}
+}
+
+static void rfcomm_dlc_reprocess_disc(struct bt_rfcomm_dlc *dlc)
+{
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_DISC)) {
+		rfcomm_dlc_process_disc(dlc);
+	}
+}
+
+static void rfcomm_dlc_retry(struct bt_rfcomm_dlc *dlc)
+{
+	int err = 0;
+
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_PN_RSP)) {
+		err = rfcomm_dlc_send_pn_rsp(dlc);
+		if (err != 0) {
+			goto failed;
+		}
+	}
+
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_PN_REQ)) {
+		err = rfcomm_dlc_send_pn_req(dlc);
+		if (err != 0) {
+			goto failed;
+		}
+	}
+
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_UA_FOR_SABM)) {
+		err = rfcomm_dlc_send_ua_for_sabm(dlc);
+		if (err != 0) {
+			goto failed;
+		}
+	}
+
+	if (atomic_test_and_clear_bit(&dlc->flags, RFCOMM_FLAG_DM)) {
+		err = rfcomm_dlc_send_dm(dlc);
+		if (err != 0) {
+			goto failed;
+		}
+	}
+
+failed:
+	if (err != 0) {
+		rfcomm_dlc_drop(dlc);
 	}
 }
 
 static void rfcomm_dlc_tx_worker(struct k_work *work)
 {
-	struct bt_rfcomm_dlc *dlc = CONTAINER_OF(work, struct bt_rfcomm_dlc, tx_work);
+	struct bt_rfcomm_dlc *dlc = DLC_TX(work);
 	struct net_buf *buf;
 
 	LOG_DBG("Work for dlc %p state %u", dlc, dlc->state);
 
+	rfcomm_dlc_reprocess_disc(dlc);
+
 	if (dlc->state < BT_RFCOMM_STATE_CONNECTED) {
+		rfcomm_dlc_retry(dlc);
 		return;
 	}
 
@@ -1294,60 +1593,33 @@ disconnect:
 	LOG_DBG("dlc %p exiting", dlc);
 }
 
-static void rfcomm_dlc_connected(struct bt_rfcomm_dlc *dlc)
+static void rfcomm_session_send_ua_for_sabm(struct bt_rfcomm_session *session)
 {
 	int err;
 
-	dlc->state = BT_RFCOMM_STATE_CONNECTED;
-
-	err = rfcomm_send_msc(dlc, BT_RFCOMM_MSG_CMD_CR, BT_RFCOMM_DEFAULT_V24_SIG);
+	err = rfcomm_send_ua(session, 0);
 	if (err == 0) {
-		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEARED);
-	} else {
-		LOG_ERR("Failed to send msc on dlc %p (%d)", dlc, err);
-		atomic_set_bit(&dlc->flags, RFCOMM_FLAG_MSC_FC_CLEAR_REQ);
+		session->state = BT_RFCOMM_STATE_CONNECTED;
+		return;
 	}
 
-	if (dlc->session->cfc == BT_RFCOMM_CFC_UNKNOWN) {
-		/* This means PN negotiation is not done for this session and
-		 * can happen only for 1.0b device.
-		 */
-		dlc->session->cfc = BT_RFCOMM_CFC_NOT_SUPPORTED;
+	LOG_ERR("Failed to send UA for SABM to DLCI0 (%d)", err);
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_SABM);
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return;
 	}
 
-	if (dlc->session->cfc == BT_RFCOMM_CFC_NOT_SUPPORTED) {
-		LOG_DBG("CFC not supported %p", dlc);
-		atomic_set_bit(&dlc->session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ);
-		rfcomm_dlc_update_fc_on(dlc, false);
-		/* Use tx_credits as binary sem for MSC FC */
-		k_sem_init(&dlc->tx_credits, 0, 1);
-	}
-
-	/* Cancel conn timer */
-	k_work_cancel_delayable(&dlc->rtx_work);
-
-	k_fifo_init(&dlc->tx_queue);
-	k_work_init(&dlc->tx_work, rfcomm_dlc_tx_worker);
-
-	if (dlc->ops && dlc->ops->connected) {
-		dlc->ops->connected(dlc);
-	}
-
-	if (atomic_test_bit(&dlc->session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ)) {
-		rfcomm_dlc_tx_trigger(dlc);
-	}
+	rfcomm_session_disconn_req(session);
 }
 
 static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	int err;
 
-	if (!dlci) {
-		if (rfcomm_send_ua(session, dlci) < 0) {
-			return;
-		}
-
-		session->state = BT_RFCOMM_STATE_CONNECTED;
+	if (dlci == 0) {
+		rfcomm_session_send_ua_for_sabm(session);
 	} else {
 		struct bt_rfcomm_dlc *dlc;
 		enum security_result result;
@@ -1365,6 +1637,15 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 			return;
 		}
 
+		if (dlc->state == BT_RFCOMM_STATE_CONNECTED) {
+			err = rfcomm_send_ua(dlc->session, dlc->dlci);
+			if (err != 0) {
+				LOG_ERR("Failed to send UA for SABM on DLC %p (%d)", dlc, err);
+			}
+			/* Just ignore the error if the DLC has been established. */
+			return;
+		}
+
 		result = rfcomm_dlc_security(dlc);
 		switch (result) {
 		case RFCOMM_SECURITY_PENDING:
@@ -1374,53 +1655,54 @@ static void rfcomm_handle_sabm(struct bt_rfcomm_session *session, uint8_t dlci)
 			break;
 		case RFCOMM_SECURITY_REJECT:
 		default:
-			err = rfcomm_send_dm(session, dlci);
+			dlc->state = BT_RFCOMM_STATE_SECURITY_FAILED;
+			err = rfcomm_dlc_send_dm(dlc);
 			if (err != 0) {
+				rfcomm_dlc_drop(dlc);
 				LOG_ERR("Failed to send dm on DLC %p (%d)", dlc, err);
 			}
-			rfcomm_dlc_drop(dlc);
 			return;
 		}
 
-		if (rfcomm_send_ua(session, dlci) < 0) {
-			return;
+		err = rfcomm_dlc_send_ua_for_sabm(dlc);
+		if (err != 0) {
+			rfcomm_dlc_close(dlc);
 		}
+	}
+}
 
-		/* Cancel idle timer if any */
-		k_work_cancel_delayable(&session->rtx_work);
+static void rfcomm_session_control_channel_connected(struct bt_rfcomm_session *session)
+{
+	struct bt_rfcomm_dlc *dlc;
+	int err;
 
-		rfcomm_dlc_connected(dlc);
+	SYS_SLIST_FOR_EACH_CONTAINER(&session->dlcs, dlc, _node) {
+		if (dlc->role == BT_RFCOMM_ROLE_INITIATOR && dlc->state == BT_RFCOMM_STATE_INIT) {
+			err = rfcomm_dlc_start(dlc);
+			if (err != 0) {
+				LOG_ERR("Failed to start DLC %p (%d)", dlc, err);
+				rfcomm_dlc_drop(dlc);
+			}
+		}
 	}
 }
 
 static void rfcomm_handle_ua(struct bt_rfcomm_session *session, uint8_t dlci)
 {
-	struct bt_rfcomm_dlc *dlc, *tmp;
-	int err;
+	struct bt_rfcomm_dlc *dlc;
 
 	if (!dlci) {
 		switch (session->state) {
 		case BT_RFCOMM_STATE_CONNECTING:
 			session->state = BT_RFCOMM_STATE_CONNECTED;
-			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->dlcs, dlc, tmp, _node) {
-				if (dlc->role == BT_RFCOMM_ROLE_INITIATOR &&
-				    dlc->state == BT_RFCOMM_STATE_INIT) {
-					if (rfcomm_dlc_start(dlc) < 0) {
-						rfcomm_dlc_drop(dlc);
-					}
-				}
-			}
+			rfcomm_session_control_channel_connected(session);
 			/* Disconnect session if there is no dlcs left */
 			rfcomm_session_disconnect(session);
 			break;
 		case BT_RFCOMM_STATE_DISCONNECTING:
-			session->state = BT_RFCOMM_STATE_DISCONNECTED;
 			/* Cancel disc timer */
 			k_work_cancel_delayable(&session->rtx_work);
-			err = bt_l2cap_chan_disconnect(&session->br_chan.chan);
-			if (err < 0) {
-				session->state = BT_RFCOMM_STATE_IDLE;
-			}
+			rfcomm_session_disconn_req(session);
 			break;
 		default:
 			break;
@@ -1701,9 +1983,10 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 		}
 
 		dlc->state = BT_RFCOMM_STATE_CONFIG;
-		err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_RESP_CR);
+		err = rfcomm_dlc_send_pn_rsp(dlc);
 		if (err != 0) {
 			LOG_ERR("Failed to send pn rsp on DLC %p (%d)", dlc, err);
+			rfcomm_dlc_drop(dlc);
 		}
 		/* Cancel idle timer if any */
 		k_work_cancel_delayable(&session->rtx_work);
@@ -1741,6 +2024,27 @@ static void rfcomm_handle_pn(struct bt_rfcomm_session *session,
 	}
 }
 
+static void rfcomm_session_send_ua_for_disc(struct bt_rfcomm_session *session)
+{
+	int err;
+
+	err = rfcomm_send_ua(session, 0);
+	if (err == 0) {
+		goto disconnected;
+	}
+
+	LOG_ERR("Failed to send ua to DLCI0 (%d)", err);
+
+	if (err == -ENOBUFS) {
+		atomic_set_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_DISC);
+		bt_work_schedule(&session->retry_work, K_MSEC(RFCOMM_RETRY_TIMEOUT));
+		return;
+	}
+
+disconnected:
+	rfcomm_session_disconnected(session);
+}
+
 static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 {
 	struct bt_rfcomm_dlc *dlc;
@@ -1758,24 +2062,11 @@ static void rfcomm_handle_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 			return;
 		}
 
-		err = rfcomm_send_ua(session, dlci);
-		if (err != 0) {
-			LOG_ERR("Failed to send ua on DLC %p (%d)", dlc, err);
-		}
-		rfcomm_dlc_disconnect(dlc);
-
-		if (sys_slist_is_empty(&session->dlcs)) {
-			/* Start a session idle timer */
-			bt_work_reschedule(&session->rtx_work, RFCOMM_IDLE_TIMEOUT);
-		}
+		rfcomm_dlc_process_disc(dlc);
 	} else {
 		/* Cancel idle timer */
 		k_work_cancel_delayable(&session->rtx_work);
-		err = rfcomm_send_ua(session, 0);
-		if (err != 0) {
-			LOG_ERR("Failed to send ua to DLCI0 (%d)", err);
-		}
-		rfcomm_session_disconnected(session);
+		rfcomm_session_send_ua_for_disc(session);
 	}
 }
 
@@ -1828,14 +2119,8 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 			break;
 		}
 
-		/* Give the sem so that it will unblock the waiting dlc threads
-		 * of this session in sem_take().
-		 */
-		k_sem_give(&session->fc);
-		err = rfcomm_send_fcon(session, BT_RFCOMM_MSG_RESP_CR);
-		if (err != 0) {
-			LOG_ERR("Failed to send fcon rsp on session %p (%d)", session, err);
-		}
+		atomic_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_OFF_RSP);
+		rfcomm_session_send_fc_on_rsp(session);
 		rfcomm_dlcs_tx_trigger(session);
 		break;
 	case BT_RFCOMM_FCOFF:
@@ -1848,6 +2133,7 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 			break;
 		}
 
+		atomic_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_RSP);
 		/* Take the semaphore with timeout K_NO_WAIT so that all the
 		 * dlc threads in this session will be blocked when it tries
 		 * sem_take before sending the data. K_NO_WAIT timeout will
@@ -1855,10 +2141,7 @@ static void rfcomm_handle_msg(struct bt_rfcomm_session *session, struct net_buf 
 		 * the semaphore.
 		 */
 		k_sem_take(&session->fc, K_NO_WAIT);
-		err = rfcomm_send_fcoff(session, BT_RFCOMM_MSG_RESP_CR);
-		if (err != 0) {
-			LOG_ERR("Failed to send fcoff rsp on session %p (%d)", session, err);
-		}
+		rfcomm_session_send_fc_off_rsp(session);
 		break;
 	default:
 		LOG_WRN("Unknown/Unsupported RFCOMM Msg type 0x%02x", msg_type);
@@ -2100,25 +2383,19 @@ static void rfcomm_encrypt_change(struct bt_l2cap_chan *chan,
 			continue;
 		}
 
-		if (hci_status || !conn->encrypt ||
-		    conn->sec_level < dlc->required_sec_level) {
+		if (hci_status || !conn->encrypt || conn->sec_level < dlc->required_sec_level) {
 			rfcomm_dlc_close(dlc);
 			continue;
 		}
 
 		if (dlc->role == BT_RFCOMM_ROLE_ACCEPTOR) {
-			err = rfcomm_send_ua(session, dlc->dlci);
-			if (err != 0) {
-				LOG_ERR("Failed to send ua on DLC %p (%d)", dlc, err);
-			}
-			rfcomm_dlc_connected(dlc);
+			err = rfcomm_dlc_send_ua_for_sabm(dlc);
 		} else {
-			dlc->mtu = MIN(dlc->mtu, session->mtu);
-			dlc->state = BT_RFCOMM_STATE_CONFIG;
-			err = rfcomm_send_pn(dlc, BT_RFCOMM_MSG_CMD_CR);
-			if (err != 0) {
-				LOG_ERR("Failed to send pn on DLC %p (%d)", dlc, err);
-			}
+			err = rfcomm_dlc_send_pn_req(dlc);
+		}
+
+		if (err != 0) {
+			rfcomm_dlc_close(dlc);
 		}
 	}
 }
@@ -2150,6 +2427,42 @@ static void rfcomm_session_rtx_timeout(struct k_work *work)
 	}
 }
 
+static void rfcomm_session_retry_handler(struct k_work *work)
+{
+	struct bt_rfcomm_session *session = SESSION_RETRY(work);
+
+	if (session->br_chan.chan.conn == NULL) {
+		/* The underlying connection is already gone; there is nothing
+		 * left for the timeout to act on.
+		 */
+		return;
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_REQ)) {
+		rfcomm_session_send_fc_on_req(session);
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_ON_RSP)) {
+		rfcomm_session_send_fc_on_rsp(session);
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_FC_OFF_RSP)) {
+		rfcomm_session_send_fc_off_rsp(session);
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_SABM)) {
+		rfcomm_session_send_ua_for_sabm(session);
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_UA_FOR_DISC)) {
+		rfcomm_session_send_ua_for_disc(session);
+	}
+
+	if (atomic_test_and_clear_bit(&session->flags, RFCOMM_SESSION_FLAG_DISCONN_REQ)) {
+		rfcomm_session_disconn_req(session);
+	}
+}
+
 static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 {
 	static const struct bt_l2cap_chan_ops ops = {
@@ -2174,8 +2487,8 @@ static struct bt_rfcomm_session *rfcomm_session_new(bt_rfcomm_role_t role)
 		session->role = role;
 		session->cfc = BT_RFCOMM_CFC_UNKNOWN;
 		sys_slist_init(&session->dlcs);
-		k_work_init_delayable(&session->rtx_work,
-				      rfcomm_session_rtx_timeout);
+		k_work_init_delayable(&session->rtx_work, rfcomm_session_rtx_timeout);
+		k_work_init_delayable(&session->retry_work, rfcomm_session_retry_handler);
 		k_sem_init(&session->fc, 0, 1);
 		atomic_clear(&session->flags);
 		return session;

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -24,6 +24,8 @@ struct bt_rfcomm_session {
 	struct k_work_delayable rtx_work;
 	/* Retry work */
 	struct k_work_delayable retry_work;
+	/* Retry timeout expired timer */
+	struct k_work_delayable retry_timeout_work;
 	/* Binary sem for aggregate fc */
 	struct k_sem fc;
 	/* DLC list */

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -30,6 +30,7 @@ struct bt_rfcomm_session {
 	uint8_t state;
 	bt_rfcomm_role_t role;
 	bt_rfcomm_cfc_t cfc;
+	atomic_t flags;
 };
 
 enum {
@@ -216,4 +217,9 @@ void bt_rfcomm_init(void);
 enum {
 	RFCOMM_FLAG_MSC_FC_CLEARED = 0,
 	RFCOMM_FLAG_MSC_FC_CLEAR_REQ = 1,
+};
+
+enum {
+	RFCOMM_SESSION_FLAG_FC_ON = 0,
+	RFCOMM_SESSION_FLAG_FC_ON_REQ = 1,
 };

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -22,6 +22,8 @@ struct bt_rfcomm_session {
 	struct bt_l2cap_br_chan br_chan;
 	/* Response Timeout eXpired (RTX) timer */
 	struct k_work_delayable rtx_work;
+	/* Retry work */
+	struct k_work_delayable retry_work;
 	/* Binary sem for aggregate fc */
 	struct k_sem fc;
 	/* DLC list */
@@ -36,10 +38,11 @@ struct bt_rfcomm_session {
 enum {
 	BT_RFCOMM_STATE_IDLE,
 	BT_RFCOMM_STATE_INIT,
+	BT_RFCOMM_STATE_SECURITY_FAILED,
 	BT_RFCOMM_STATE_SECURITY_PENDING,
+	BT_RFCOMM_STATE_CONFIG,
 	BT_RFCOMM_STATE_CONNECTING,
 	BT_RFCOMM_STATE_CONNECTED,
-	BT_RFCOMM_STATE_CONFIG,
 	BT_RFCOMM_STATE_USER_DISCONNECT,
 	BT_RFCOMM_STATE_DISCONNECTING,
 	BT_RFCOMM_STATE_DISCONNECTED,
@@ -217,9 +220,19 @@ void bt_rfcomm_init(void);
 enum {
 	RFCOMM_FLAG_MSC_FC_CLEARED = 0,
 	RFCOMM_FLAG_MSC_FC_CLEAR_REQ = 1,
+	RFCOMM_FLAG_PN_REQ = 2,
+	RFCOMM_FLAG_PN_RSP = 3,
+	RFCOMM_FLAG_UA_FOR_SABM = 4,
+	RFCOMM_FLAG_UA_FOR_DISC = 5,
+	RFCOMM_FLAG_DM = 6,
 };
 
 enum {
 	RFCOMM_SESSION_FLAG_FC_ON = 0,
 	RFCOMM_SESSION_FLAG_FC_ON_REQ = 1,
+	RFCOMM_SESSION_FLAG_FC_ON_RSP = 2,
+	RFCOMM_SESSION_FLAG_FC_OFF_RSP = 3,
+	RFCOMM_SESSION_FLAG_UA_FOR_SABM = 4,
+	RFCOMM_SESSION_FLAG_UA_FOR_DISC = 5,
+	RFCOMM_SESSION_FLAG_DISCONN_REQ = 6,
 };


### PR DESCRIPTION
Previously, the timeout `K_FOREVER` is used to allocate the net buffer from the TX buffer pool. It causes the BT workqueue to be blocked by the buffer allocation operations with unpredictable completion times, preventing subsequent work handlers from executing.

Use `K_NO_WAIT` to replace `K_FOREVER`. It means that when the buffer allocation function returns, there's no guarantee that a buffer has been allocated. Therefore, add comprehensive error handling for buffer allocation failures in the RFCOMM implementation.

- Add `rfcomm_create_pdu()` to wrap `bt_l2cap_create_pdu_timeout()`, checking both the allocation result and available tailroom before the buffer is used.
- Check the return value of every `rfcomm_send_*()` call and propagate allocation failures up the call stack as -ENOBUFS.
- Handle send failures in the SABM, DISC, PN, UA, DM, MSC, RLS, RPN, TEST, FCON, FCOFF and NSC paths, logging the error and, on the disconnect paths, rescheduling the retransmission timer immediately so the state machine still recovers instead of waiting on the RTX timeout.
- Extract `rfcomm_dlc_connect()` and `rfcomm_dlc_disconn()` so the connect/disconnect error handling lives in one place instead of being duplicated at each call site.

The change prevents workqueue stalls and crashes when the L2CAP buffer pool is exhausted.

And also improve the FCON/credit/PN/UA retry handling.

The change has been tested by https://github.com/zephyrproject-rtos/zephyr/pull/118404.

The simulation test will be added after the PR https://github.com/zephyrproject-rtos/zephyr/pull/116447 merged.

Fixes: #119409