### PR TITLE
hal_nxp: caam: update caam driver to version 2.4.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 14d44be6e81e0e98582f9bf3eb202e055309badf
+      revision: pull/809/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Newer version supports Zephyr __nocache attribute for generating
non-cacheable regions. CAAM uses these regions for its entropy related
buffers.
