### PR TITLE
drivers: spi: mchp: Add Flexcom SPI support for sama7d65

### DIFF
--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.dts
@@ -101,6 +101,18 @@
 	status = "okay";
 };
 
+&flx4 {
+	mchp,flexcom-mode = <SAM_FLEXCOM_MODE_SPI>;
+	status = "okay";
+
+	spi4: spi@400 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_spi4_default>;
+		cs-gpios = <&pioa 15 GPIO_ACTIVE_LOW>, <&pioa 14 GPIO_ACTIVE_LOW>;
+		status = "okay";
+	};
+};
+
 &flx6 {
 	mchp,flexcom-mode = <SAM_FLEXCOM_MODE_USART>;
 	status = "okay";
@@ -262,6 +274,21 @@
 		mikrobus2_pwm1 {
 			pinmux = <PIN_PB17__PWML1>;
 			bias-disable;
+		};
+	};
+
+	pinctrl_spi4_default: spi4_default {
+		group1 {
+			pinmux = <PIN_PA18__FLEXCOM4_IO0>,
+				 <PIN_PA17__FLEXCOM4_IO1>,
+				 <PIN_PA16__FLEXCOM4_IO2>;
+			bias-disable;
+		};
+
+		cs_pins {
+			pinmux = <PIN_PA15__GPIO>, /* GPIO CS 0 */
+				 <PIN_PA14__GPIO>; /* GPIO CS 1 */
+			bias-pull-up;
 		};
 	};
 

--- a/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
+++ b/boards/microchip/sam/sama7d65_curiosity/sama7d65_curiosity.yaml
@@ -20,5 +20,6 @@ supported:
   - pinctrl
   - pwm
   - rtc
+  - spi
   - uart
 vendor: microchip

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -249,16 +249,6 @@
 		pinctrl-0 = <&pinctrl_spi11_default>;
 		cs-gpios = <&piob 6 GPIO_ACTIVE_LOW>, <&piob 7 GPIO_ACTIVE_LOW>;
 		status = "okay";
-
-		nor_flash: sst26vf064@0 {
-			compatible = "jedec,spi-nor";
-			reg = <0>;
-			spi-max-frequency = <10000000>;
-			size = <DT_SIZE_M(64)>; /* 64 Mbits */
-			jedec-id = [bf 26 43];
-			requires-ulbpr;
-			status = "okay";
-		};
 	};
 };
 

--- a/drivers/spi/Kconfig.mchp
+++ b/drivers/spi/Kconfig.mchp
@@ -7,6 +7,7 @@ config SPI_MCHP_FLEXCOM_G1
 	depends on DT_HAS_MICROCHIP_FLEXCOM_G1_SPI_ENABLED
 	select PINCTRL
 	select GPIO
+	select MFD
 	help
 	  Enable support for the Microchip FLEXCOM SPI driver.
 
@@ -19,6 +20,15 @@ config SPI_MCHP_FLEXCOM_DMA_DRIVEN
 	help
 	  This enables DMA driven transfers for the SPI peripheral.
 	  Requires DMA controller and dmas property in device tree.
+
+config SPI_MCHP_FLEXCOM_DMA_BUFFER_SIZE
+	int "Microchip FLEXCOM SPI DMA buffer size"
+	default 512
+	range 512 4096
+	depends on SPI_MCHP_FLEXCOM_DMA_DRIVEN
+	help
+	  This driver use a scratch buffer to handle unaligned accesses.
+	  Specify the DMA buffer size here.
 
 config SPI_MCHP_SERCOM
 	bool

--- a/drivers/spi/spi_mchp_flexcom_g1.c
+++ b/drivers/spi/spi_mchp_flexcom_g1.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2017 Google LLC.
  * Copyright (c) 2018 qianfan Zhao.
  * Copyright (c) 2023 Gerson Fernando Budke.
- * Copyright (c) 2023 Microchip Technology Inc.
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,24 +13,17 @@
 LOG_MODULE_REGISTER(spi_mchp_flexcom_g1, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
-#include <errno.h>
-#include <zephyr/spinlock.h>
-#include <zephyr/cache.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/spi.h>
 #include "spi_rtio.h"
+#include <zephyr/cache.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/atmel_sam_pmc.h>
-#include <zephyr/rtio/rtio.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/util.h>
-#include <soc.h>
 
-#define SAM_SPI_CHIP_SELECT_COUNT			4
+#define SAM_SPI_CHIP_SELECT_COUNT	4
+#define SAM_SPI_MAX_DATA_BITS		16
 
-/* Number of bytes in transfer before using DMA if available */
-#define SAM_SPI_DMA_THRESHOLD                           32
+#define DFS(op)		DIV_ROUND_UP(SPI_WORD_SIZE_GET(op), 8)
+#define DUMMY_DATA	0
 
 /* Device constant configuration parameters */
 struct spi_sam_config {
@@ -38,6 +31,7 @@ struct spi_sam_config {
 	const struct atmel_sam_pmc_config clock_cfg;
 	const struct pinctrl_dev_config *pcfg;
 	bool loopback;
+	uint32_t fifo_size;
 
 #ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
 	const struct device *dma_dev;
@@ -46,31 +40,26 @@ struct spi_sam_config {
 	const uint32_t dma_rx_channel;
 	const uint32_t dma_rx_perid;
 #endif
+
+	void (*irq_config_func)(const struct device *dev);
 };
 
 /* Device run time data */
 struct spi_sam_data {
 	struct spi_context ctx;
-	struct k_spinlock lock;
-
+	uint8_t dfs;
 #ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-	struct k_sem dma_sem;
+	uint8_t dma_tx_buf[CONFIG_SPI_MCHP_FLEXCOM_DMA_BUFFER_SIZE]
+		__aligned(CONFIG_DCACHE_LINE_SIZE);
+	uint8_t dma_rx_buf[CONFIG_SPI_MCHP_FLEXCOM_DMA_BUFFER_SIZE]
+		__aligned(CONFIG_DCACHE_LINE_SIZE);
+	uint32_t dma_buf_size;
+	uint32_t dma_xfer_len;
+	bool dma_tx_nop;
 #endif
 };
 
-static inline k_spinlock_key_t spi_spin_lock(const struct device *dev)
-{
-	struct spi_sam_data *data = dev->data;
-
-	return k_spin_lock(&data->lock);
-}
-
-static inline void spi_spin_unlock(const struct device *dev, k_spinlock_key_t key)
-{
-	struct spi_sam_data *data = dev->data;
-
-	k_spin_unlock(&data->lock, key);
-}
+static void spi_sam_xfer_next(const struct device *dev);
 
 static int spi_peripheral_to_mr_pcs(int peripheral)
 {
@@ -94,8 +83,9 @@ static int spi_sam_configure(const struct device *dev,
 	const struct spi_sam_config *cfg = dev->config;
 	struct spi_sam_data *data = dev->data;
 	Spi *regs = cfg->regs;
+	struct spi_context *ctx = &data->ctx;
 	uint32_t spi_mr = 0U, spi_csr = 0U;
-	uint32_t rate;
+	uint32_t rate, bits;
 	uint16_t spi_csr_idx = spi_cs_is_gpio(config) ? 0 : config->peripheral;
 	int clk_div;
 	int ret;
@@ -103,11 +93,11 @@ static int spi_sam_configure(const struct device *dev,
 	ret = clock_control_get_rate(SAM_DT_PMC_CONTROLLER,
 				     (clock_control_subsys_t)&cfg->clock_cfg,
 				     &rate);
-	if (ret) {
+	if (ret != 0) {
 		return ret;
 	}
 
-	if (spi_context_configured(&data->ctx, config)) {
+	if (spi_context_configured(ctx, config)) {
 		return 0;
 	}
 
@@ -145,11 +135,14 @@ static int spi_sam_configure(const struct device *dev,
 		spi_csr |= SPI_CSR_NCPHA_Msk;
 	}
 
-	if (SPI_WORD_SIZE_GET(config->operation) != 8) {
+	bits = SPI_WORD_SIZE_GET(config->operation);
+	if ((bits < 8U) || (bits > SAM_SPI_MAX_DATA_BITS)) {
+		LOG_ERR("Data frame bits %d not supported", bits);
 		return -ENOTSUP;
 	}
 
-	spi_csr |= SPI_CSR_BITS(SPI_CSR_BITS_8_BIT);
+	spi_csr |= SPI_CSR_BITS(bits - 8);
+	spi_csr |= SPI_CSR_CSAAT_Msk;
 
 	/* Use the requested or next highest possible frequency */
 	clk_div = rate / config->frequency;
@@ -157,520 +150,417 @@ static int spi_sam_configure(const struct device *dev,
 	spi_csr |= SPI_CSR_SCBR(clk_div);
 
 	regs->SPI_CR = SPI_CR_SPIDIS_Msk; /* Disable SPI */
+	regs->SPI_CR = SPI_CR_SWRST_Msk;  /* Reset SPI */
+	regs->SPI_CR = SPI_CR_FIFOEN_Msk;
 	regs->SPI_MR = spi_mr;
 	regs->SPI_CSR[spi_csr_idx] = spi_csr;
 	regs->SPI_CR = SPI_CR_SPIEN_Msk; /* Enable SPI */
 
-	data->ctx.config = config;
+	if (!(regs->SPI_SR & SPI_SR_SPIENS_Msk)) {
+		LOG_ERR("Failed to enable SPI");
+		return -EIO;
+	}
+
+	ctx->config = config;
+	data->dfs = DFS(config->operation);
 
 	return 0;
 }
 
-/* Finish any ongoing writes and drop any remaining read data */
-static void spi_sam_finish(Spi *regs)
-{
-	while ((regs->SPI_SR & SPI_SR_TXEMPTY_Msk) == 0) {
-	}
-
-	while (regs->SPI_SR & SPI_SR_RDRF_Msk) {
-		(void)regs->SPI_RDR;
-	}
-}
-
-/* Fast path that transmits a buf */
-static void spi_sam_fast_tx(Spi *regs, const uint8_t *tx_buf, const uint32_t tx_buf_len)
-{
-	const uint8_t *p = tx_buf;
-	const uint8_t *pend = (uint8_t *)tx_buf + tx_buf_len;
-	uint8_t ch;
-
-	while (p != pend) {
-		ch = *p++;
-
-		while ((regs->SPI_SR & SPI_SR_TDRE_Msk) == 0) {
-		}
-
-		regs->SPI_TDR = SPI_TDR_TD(ch);
-	}
-}
-
-/* Fast path that reads into a buf */
-static void spi_sam_fast_rx(Spi *regs, uint8_t *rx_buf, const uint32_t rx_buf_len)
-{
-	uint8_t *rx = rx_buf;
-	int len = rx_buf_len;
-
-	if (len <= 0) {
-		return;
-	}
-
-	/* Write the first byte */
-	regs->SPI_TDR = SPI_TDR_TD(0);
-	len--;
-
-	while (len) {
-		while ((regs->SPI_SR & SPI_SR_TDRE_Msk) == 0) {
-		}
-
-		/* Read byte N+0 from the receive register */
-		while ((regs->SPI_SR & SPI_SR_RDRF_Msk) == 0) {
-		}
-
-		*rx = (uint8_t)regs->SPI_RDR;
-		rx++;
-
-		/* Load byte N+1 into the transmit register */
-		regs->SPI_TDR = SPI_TDR_TD(0);
-		len--;
-	}
-
-	/* Read the final incoming byte */
-	while ((regs->SPI_SR & SPI_SR_RDRF_Msk) == 0) {
-	}
-
-	*rx = (uint8_t)regs->SPI_RDR;
-}
-
-/* Fast path that writes and reads bufs of the same length */
-static void spi_sam_fast_txrx(Spi *regs,
-			      const uint8_t *tx_buf,
-			      const uint8_t *rx_buf,
-			      const uint32_t len)
-{
-	const uint8_t *tx = tx_buf;
-	const uint8_t *txend = tx_buf + len;
-	uint8_t *rx = (uint8_t *)rx_buf;
-
-	if (len == 0) {
-		return;
-	}
-
-	/*
-	 * The code below interleaves the transmit writes with the
-	 * receive reads to keep the bus fully utilised.  The code is
-	 * equivalent to:
-	 *
-	 * Transmit byte 0
-	 * Loop:
-	 * - Transmit byte n+1
-	 * - Receive byte n
-	 * Receive the final byte
-	 */
-
-	/* Write the first byte */
-	regs->SPI_TDR = SPI_TDR_TD(*tx++);
-
-	while (tx != txend) {
-		while ((regs->SPI_SR & SPI_SR_TDRE_Msk) == 0) {
-		}
-
-		/* Load byte N+1 into the transmit register.  TX is
-		 * single buffered and we have at most one byte in
-		 * flight so skip the DRE check.
-		 */
-		regs->SPI_TDR = SPI_TDR_TD(*tx++);
-
-		/* Read byte N+0 from the receive register */
-		while ((regs->SPI_SR & SPI_SR_RDRF_Msk) == 0) {
-		}
-
-		*rx++ = (uint8_t)regs->SPI_RDR;
-	}
-
-	/* Read the final incoming byte */
-	while ((regs->SPI_SR & SPI_SR_RDRF_Msk) == 0) {
-	}
-
-	*rx = (uint8_t)regs->SPI_RDR;
-
-}
-
-#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-static __aligned(4) uint32_t tx_dummy;
-static __aligned(4) uint32_t rx_dummy;
-
-static void dma_callback(const struct device *dma_dev, void *user_data,
-	uint32_t channel, int status)
-{
-	ARG_UNUSED(dma_dev);
-	ARG_UNUSED(channel);
-	ARG_UNUSED(status);
-
-	const struct device *dev = user_data;
-	struct spi_sam_data *drv_data = dev->data;
-
-	k_sem_give(&drv_data->dma_sem);
-}
-
-
-/* DMA transceive path */
-static int spi_sam_dma_txrx(const struct device *dev,
-			    Spi *regs,
-			    const uint8_t *tx_buf,
-			    const uint8_t *rx_buf,
-			    const uint32_t len)
-{
-	const struct spi_sam_config *drv_cfg = dev->config;
-	struct spi_sam_data *drv_data = dev->data;
-	bool blocking = true;
-
-	int res = 0;
-
-	__ASSERT_NO_MSG(rx_buf != NULL || tx_buf != NULL);
-
-	struct dma_config rx_dma_cfg = {
-		.source_data_size = 1,
-		.dest_data_size = 1,
-		.block_count = 1,
-		.dma_slot = drv_cfg->dma_rx_perid,
-		.channel_direction = PERIPHERAL_TO_MEMORY,
-		.source_burst_length = 1,
-		.dest_burst_length = 1,
-		.complete_callback_en = true,
-		.dma_callback = NULL,
-		.user_data = (void *)dev,
-	};
-
-	uint32_t dest_address, dest_addr_adjust;
-
-	if (rx_buf != NULL) {
-		sys_cache_data_invd_range((void *)rx_buf, len);
-
-		dest_address = (uint32_t)rx_buf;
-		dest_addr_adjust = DMA_ADDR_ADJ_INCREMENT;
-	} else {
-		dest_address = (uint32_t)&rx_dummy;
-		dest_addr_adjust = DMA_ADDR_ADJ_NO_CHANGE;
-	}
-
-	struct dma_block_config rx_block_cfg = {
-		.dest_addr_adj = dest_addr_adjust,
-		.block_size = len,
-		.source_address = (uint32_t)&regs->SPI_RDR,
-		.dest_address = dest_address
-	};
-
-	rx_dma_cfg.head_block = &rx_block_cfg;
-
-	struct dma_config tx_dma_cfg = {
-		.source_data_size = 1,
-		.dest_data_size = 1,
-		.block_count = 1,
-		.dma_slot = drv_cfg->dma_tx_perid,
-		.channel_direction = MEMORY_TO_PERIPHERAL,
-		.source_burst_length = 1,
-		.dest_burst_length = 1,
-		.complete_callback_en = true,
-		.dma_callback = dma_callback,
-		.user_data = (void *)dev,
-	};
-
-	uint32_t source_address, source_addr_adjust;
-
-	if (tx_buf != NULL) {
-		sys_cache_data_flush_range((void *)tx_buf, len);
-
-		source_address = (uint32_t)tx_buf;
-		source_addr_adjust = DMA_ADDR_ADJ_INCREMENT;
-	} else {
-		source_address = (uint32_t)&tx_dummy;
-		source_addr_adjust = DMA_ADDR_ADJ_NO_CHANGE;
-	}
-
-	struct dma_block_config tx_block_cfg = {
-		.source_addr_adj = source_addr_adjust,
-		.block_size = len,
-		.source_address = source_address,
-		.dest_address = (uint32_t)&regs->SPI_TDR
-	};
-
-	tx_dma_cfg.head_block = &tx_block_cfg;
-
-	res = dma_config(drv_cfg->dma_dev, drv_cfg->dma_rx_channel, &rx_dma_cfg);
-	if (res != 0) {
-		LOG_ERR("failed to configure SPI DMA RX");
-		goto out;
-	}
-
-	res = dma_config(drv_cfg->dma_dev, drv_cfg->dma_tx_channel, &tx_dma_cfg);
-	if (res != 0) {
-		LOG_ERR("failed to configure SPI DMA TX");
-		goto out;
-	}
-
-	/* Clocking begins on tx, so start rx first */
-	res = dma_start(drv_cfg->dma_dev, drv_cfg->dma_rx_channel);
-	if (res != 0) {
-		LOG_ERR("failed to start SPI DMA RX");
-		goto out;
-	}
-
-	res = dma_start(drv_cfg->dma_dev, drv_cfg->dma_tx_channel);
-	if (res != 0) {
-		LOG_ERR("failed to start SPI DMA TX");
-		dma_stop(drv_cfg->dma_dev, drv_cfg->dma_rx_channel);
-	}
-
-	/* Move up a level or wrap in branch when blocking */
-	if (blocking) {
-		k_sem_take(&drv_data->dma_sem, K_FOREVER);
-		spi_sam_finish(regs);
-
-		if (rx_buf) {
-			sys_cache_data_invd_range((void *)rx_buf, len);
-		}
-	} else {
-		res = -EWOULDBLOCK;
-	}
-
-out:
-	return res;
-}
-#endif
-
-static inline int spi_sam_rx(const struct device *dev,
-			      Spi *regs,
-			      uint8_t *rx_buf,
-			      uint32_t rx_buf_len)
-{
-	k_spinlock_key_t key;
-
-#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-	const struct spi_sam_config *cfg = dev->config;
-
-	if ((rx_buf_len < SAM_SPI_DMA_THRESHOLD || cfg->dma_dev == NULL) &&
-	    !IS_ENABLED(CONFIG_SPI_RTIO)) {
-		key = spi_spin_lock(dev);
-		spi_sam_fast_rx(regs, rx_buf, rx_buf_len);
-	} else {
-		/* RTIO Transfers should always fall here */
-		return spi_sam_dma_txrx(dev, regs, NULL, rx_buf, rx_buf_len);
-	}
-#else
-	key = spi_spin_lock(dev);
-	spi_sam_fast_rx(regs, rx_buf, rx_buf_len);
-#endif
-	spi_sam_finish(regs);
-
-	spi_spin_unlock(dev, key);
-	return 0;
-}
-
-static inline int spi_sam_tx(const struct device *dev,
-			     Spi *regs,
-			     const uint8_t *tx_buf,
-			     uint32_t tx_buf_len)
-{
-	k_spinlock_key_t key;
-
-#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-	const struct spi_sam_config *cfg = dev->config;
-
-	if ((tx_buf_len < SAM_SPI_DMA_THRESHOLD || cfg->dma_dev == NULL) &&
-	    !IS_ENABLED(CONFIG_SPI_RTIO)) {
-		key = spi_spin_lock(dev);
-		spi_sam_fast_tx(regs, tx_buf, tx_buf_len);
-	} else {
-		/* RTIO Transfers should always fall here */
-		return spi_sam_dma_txrx(dev, regs, tx_buf, NULL, tx_buf_len);
-	}
-#else
-	key = spi_spin_lock(dev);
-	spi_sam_fast_tx(regs, tx_buf, tx_buf_len);
-#endif
-	spi_sam_finish(regs);
-	spi_spin_unlock(dev, key);
-	return 0;
-}
-
-
-static inline int spi_sam_txrx(const struct device *dev,
-				Spi *regs,
-				const uint8_t *tx_buf,
-				const uint8_t *rx_buf,
-				uint32_t buf_len)
-{
-	k_spinlock_key_t key;
-
-#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-	const struct spi_sam_config *cfg = dev->config;
-
-	if ((buf_len < SAM_SPI_DMA_THRESHOLD || cfg->dma_dev == NULL) &&
-	    !IS_ENABLED(CONFIG_SPI_RTIO)) {
-		key = spi_spin_lock(dev);
-		spi_sam_fast_txrx(regs, tx_buf, rx_buf, buf_len);
-	} else {
-		/* RTIO Transfers should always fall here */
-		return spi_sam_dma_txrx(dev, regs, tx_buf, rx_buf, buf_len);
-	}
-#else
-	key = spi_spin_lock(dev);
-	spi_sam_fast_txrx(regs, tx_buf, rx_buf, buf_len);
-#endif
-	spi_sam_finish(regs);
-	spi_spin_unlock(dev, key);
-	return 0;
-}
-
-/* Fast path where every overlapping tx and rx buffer is the same length */
-static void spi_sam_fast_transceive(const struct device *dev,
-				    const struct spi_config *config,
-				    const struct spi_buf_set *tx_bufs,
-				    const struct spi_buf_set *rx_bufs)
+static void spi_sam_complete(const struct device *dev, int status)
 {
 	const struct spi_sam_config *cfg = dev->config;
-	size_t tx_count = 0;
-	size_t rx_count = 0;
+	struct spi_sam_data *data = dev->data;
 	Spi *regs = cfg->regs;
-	const struct spi_buf *tx = NULL;
-	const struct spi_buf *rx = NULL;
+	struct spi_context *ctx = &data->ctx;
 
-	if (tx_bufs) {
-		tx = tx_bufs->buffers;
-		tx_count = tx_bufs->count;
-	}
+	/* De-asserted NPCS line */
+	regs->SPI_CR = SPI_CR_LASTXFER_Msk;
+	/* Disable all enabled interrupts */
+	regs->SPI_IDR = regs->SPI_IMR;
 
-	if (rx_bufs) {
-		rx = rx_bufs->buffers;
-		rx_count = rx_bufs->count;
-	}
-
-	while (tx_count != 0 && rx_count != 0) {
-		if (tx->buf == NULL) {
-			spi_sam_rx(dev, regs, rx->buf, rx->len);
-		} else if (rx->buf == NULL) {
-			spi_sam_tx(dev, regs, tx->buf, tx->len);
-		} else if (rx->len == tx->len) {
-			spi_sam_txrx(dev, regs, tx->buf, rx->buf, rx->len);
-		} else {
-			__ASSERT_NO_MSG("Invalid fast transceive configuration");
-		}
-
-		tx++;
-		tx_count--;
-		rx++;
-		rx_count--;
-	}
-
-	for (; tx_count != 0; tx_count--) {
-		spi_sam_tx(dev, regs, tx->buf, tx->len);
-		tx++;
-	}
-
-	for (; rx_count != 0; rx_count--) {
-		spi_sam_rx(dev, regs, rx->buf, rx->len);
-		rx++;
-	}
+	spi_context_cs_control(ctx, false);
+	spi_context_complete(ctx, dev, status);
 }
 
-static bool spi_sam_transfer_ongoing(struct spi_sam_data *data)
+#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
+static bool tx_bufs_is_nop(const struct spi_buf_set *tx_bufs)
 {
-	return spi_context_tx_on(&data->ctx) || spi_context_rx_on(&data->ctx);
-}
-
-static void spi_sam_shift_controller(Spi *regs, struct spi_sam_data *data)
-{
-	uint8_t tx;
-	uint8_t rx;
-
-	if (spi_context_tx_buf_on(&data->ctx)) {
-		tx = *(uint8_t *)(data->ctx.tx_buf);
-	} else {
-		tx = 0U;
-	}
-
-	while ((regs->SPI_SR & SPI_SR_TDRE_Msk) == 0) {
-	}
-
-	regs->SPI_TDR = SPI_TDR_TD(tx);
-	spi_context_update_tx(&data->ctx, 1, 1);
-
-	while ((regs->SPI_SR & SPI_SR_RDRF_Msk) == 0) {
-	}
-
-	rx = (uint8_t)regs->SPI_RDR;
-
-	if (spi_context_rx_buf_on(&data->ctx)) {
-		*data->ctx.rx_buf = rx;
-	}
-	spi_context_update_rx(&data->ctx, 1, 1);
-}
-
-/* Returns true if the request is suitable for the fast
- * path. Specifically, the bufs are a sequence of:
- *
- * - Zero or more RX and TX buf pairs where each is the same length.
- * - Zero or more trailing RX only bufs
- * - Zero or more trailing TX only bufs
- */
-static bool spi_sam_is_regular(const struct spi_buf_set *tx_bufs,
-			       const struct spi_buf_set *rx_bufs)
-{
-	const struct spi_buf *tx = NULL;
-	const struct spi_buf *rx = NULL;
-	size_t tx_count = 0;
-	size_t rx_count = 0;
-
-	if (tx_bufs) {
-		tx = tx_bufs->buffers;
-		tx_count = tx_bufs->count;
-	}
-
-	if (rx_bufs) {
-		rx = rx_bufs->buffers;
-		rx_count = rx_bufs->count;
-	}
-
-	if (!tx || !rx) {
+	if (tx_bufs == NULL ||
+	    tx_bufs->buffers == NULL ||
+	    tx_bufs->count == 0U) {
 		return true;
 	}
 
-	while (tx_count != 0 && rx_count != 0) {
-		if (tx->len != rx->len) {
+	for (size_t i = 0U; i < tx_bufs->count; i++) {
+		const struct spi_buf *buf = &tx_bufs->buffers[i];
+
+		if (buf->buf != NULL && buf->len != 0U) {
 			return false;
 		}
-
-		tx++;
-		tx_count--;
-		rx++;
-		rx_count--;
 	}
 
 	return true;
 }
 
-static int spi_sam_transceive(const struct device *dev,
-			      const struct spi_config *config,
-			      const struct spi_buf_set *tx_bufs,
-			      const struct spi_buf_set *rx_bufs)
+static bool dma_check_nop_tx(const struct device *dev,
+			     const struct spi_buf_set *tx_bufs)
+{
+	struct spi_sam_data *data = dev->data;
+
+	if (tx_bufs_is_nop(tx_bufs)) {
+		memset(data->dma_tx_buf, DUMMY_DATA, sizeof(long long));
+
+		sys_cache_data_flush_range(data->dma_tx_buf, sizeof(long long));
+		__DSB();
+
+		return true;
+	}
+
+	return false;
+}
+
+static void dma_callback(const struct device *dma_dev,
+			 void *user_data, uint32_t channel, int status)
+{
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	const struct device *dev = user_data;
+	struct spi_sam_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+
+	if (status != 0) {
+		LOG_ERR("DMA callback return error, status=%08x", status);
+		spi_sam_complete(dev, status);
+
+		return;
+	}
+
+	if (spi_context_rx_on(ctx)) {
+		uint32_t xfer_len = data->dma_xfer_len;
+		uint8_t *rx_buf = data->dma_rx_buf;
+
+		sys_cache_data_invd_range(rx_buf, xfer_len * data->dfs);
+		__DSB();
+
+		while (spi_context_rx_on(ctx) && (xfer_len > 0U)) {
+			uint32_t rx_len = MIN(xfer_len, ctx->rx_len);
+
+			if (spi_context_rx_buf_on(ctx)) {
+				memcpy(ctx->rx_buf, rx_buf, rx_len * data->dfs);
+			}
+
+			spi_context_update_rx(ctx, data->dfs, rx_len);
+			rx_buf += rx_len * data->dfs;
+			xfer_len -= rx_len;
+		}
+	}
+
+	spi_sam_xfer_next(dev);
+}
+
+static void spi_sam_xfer_dma(const struct device *dev)
 {
 	const struct spi_sam_config *cfg = dev->config;
 	struct spi_sam_data *data = dev->data;
-	int err = 0;
+	Spi *regs = cfg->regs;
+	struct spi_context *ctx = &data->ctx;
+	uint32_t xfer_len, len;
+	int ret;
 
-	spi_context_lock(&data->ctx, false, NULL, NULL, config);
+	data->dma_xfer_len = MIN(spi_context_longest_current_buf(ctx),
+				 data->dma_buf_size / data->dfs);
+	xfer_len = data->dma_xfer_len;
+	len = data->dma_xfer_len * data->dfs;
 
-	err = spi_sam_configure(dev, config);
-	if (err != 0) {
+	struct dma_block_config tx_block_cfg = {
+		.source_address = (uintptr_t)data->dma_tx_buf,
+		.dest_address = (uintptr_t)&regs->SPI_TDR,
+		.block_size = len,
+		.source_addr_adj = (data->dma_tx_nop || !spi_context_tx_on(ctx)) ?
+				   DMA_ADDR_ADJ_NO_CHANGE :
+				   DMA_ADDR_ADJ_INCREMENT,
+	};
+
+	struct dma_config tx_dma_cfg = {
+		.dma_slot = cfg->dma_tx_perid,
+		.channel_direction = MEMORY_TO_PERIPHERAL,
+		.complete_callback_en = false,
+		.source_data_size = data->dfs,
+		.dest_data_size = data->dfs,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &tx_block_cfg,
+		.user_data = NULL,
+		.dma_callback = NULL,
+	};
+
+	struct dma_block_config rx_block_cfg = {
+		.source_address = (uintptr_t)&regs->SPI_RDR,
+		.dest_address = (uintptr_t)data->dma_rx_buf,
+		.block_size = len,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
+
+	struct dma_config rx_dma_cfg = {
+		.dma_slot = cfg->dma_rx_perid,
+		.channel_direction = PERIPHERAL_TO_MEMORY,
+		.complete_callback_en = true,
+		.source_data_size = data->dfs,
+		.dest_data_size = data->dfs,
+		.source_burst_length = 1,
+		.dest_burst_length = 1,
+		.block_count = 1,
+		.head_block = &rx_block_cfg,
+		.user_data = (void *)dev,
+		.dma_callback = dma_callback,
+	};
+
+	if (data->dma_tx_nop) {
+		/* Dump TX buffers because this is a NOP TX */
+		while (spi_context_tx_on(ctx) && (xfer_len > 0U)) {
+			uint32_t tx_len = MIN(xfer_len, ctx->tx_len);
+
+			spi_context_update_tx(ctx, data->dfs, tx_len);
+			xfer_len -= tx_len;
+		}
+	} else if (spi_context_tx_on(ctx)) {
+		uint8_t *tx_buf = data->dma_tx_buf;
+
+		while (xfer_len > 0U) {
+			if (spi_context_tx_on(ctx)) {
+				uint32_t tx_len = MIN(xfer_len, ctx->tx_len);
+
+				if (spi_context_tx_buf_on(ctx)) {
+					memcpy(tx_buf, ctx->tx_buf, tx_len * data->dfs);
+				} else {
+					memset(tx_buf, DUMMY_DATA, tx_len * data->dfs);
+				}
+
+				spi_context_update_tx(ctx, data->dfs, tx_len);
+				tx_buf += tx_len * data->dfs;
+				xfer_len -= tx_len;
+			} else {
+				memset(tx_buf, DUMMY_DATA, xfer_len * data->dfs);
+				xfer_len = 0;
+			}
+		}
+
+		sys_cache_data_flush_range(data->dma_tx_buf, len);
+		__DSB();
+	} else {
+		/*
+		 * FIXME
+		 * Use data->dfs as size doesn't work
+		 * Why sizeof(long long) must be used when fixed address is enabled?
+		 */
+		memset(data->dma_tx_buf, DUMMY_DATA, sizeof(long long));
+
+		sys_cache_data_flush_range(data->dma_tx_buf, sizeof(long long));
+		__DSB();
+	}
+
+	/* Enable relevant interrupts */
+	regs->SPI_IER = SPI_IER_OVRES_Msk;
+
+	ret = dma_config(cfg->dma_dev, cfg->dma_rx_channel, &rx_dma_cfg);
+	if (ret != 0) {
+		LOG_ERR("failed to configure SPI DMA RX");
+		goto err;
+	}
+
+	ret = dma_config(cfg->dma_dev, cfg->dma_tx_channel, &tx_dma_cfg);
+	if (ret != 0) {
+		LOG_ERR("failed to configure SPI DMA TX");
+		goto err;
+	}
+
+	/* Clocking begins on tx, so start rx first */
+	ret = dma_start(cfg->dma_dev, cfg->dma_rx_channel);
+	if (ret != 0) {
+		LOG_ERR("failed to start SPI DMA RX");
+		goto err;
+	}
+
+	ret = dma_start(cfg->dma_dev, cfg->dma_tx_channel);
+	if (ret != 0) {
+		LOG_ERR("failed to start SPI DMA TX");
+		dma_stop(cfg->dma_dev, cfg->dma_rx_channel);
+	}
+
+	return;
+err:
+	spi_sam_complete(dev, ret);
+}
+#endif
+
+static void spi_sam_pump_fifo(const struct device *dev)
+{
+	const struct spi_sam_config *cfg = dev->config;
+	struct spi_sam_data *data = dev->data;
+	Spi *regs = cfg->regs;
+	struct spi_context *ctx = &data->ctx;
+	uint32_t xfer_len = FIELD_GET(SPI_FLR_RXFL_Msk, regs->SPI_FLR);
+
+	while (spi_context_rx_on(ctx) && (xfer_len != 0U)) {
+		if (spi_context_rx_buf_on(ctx)) {
+			if (data->dfs > 1U) {
+				*(uint16_t *)ctx->rx_buf = (uint16_t)regs->SPI_RDR;
+			} else {
+				*ctx->rx_buf = (uint8_t)regs->SPI_RDR;
+			}
+		} else {
+			(void)regs->SPI_RDR;
+		}
+
+		spi_context_update_rx(ctx, data->dfs, 1);
+		xfer_len--;
+	}
+
+	if (xfer_len != 0U) {
+		/* Flush RX FIFO */
+		regs->SPI_CR = SPI_CR_RXFCLR_Msk;
+		while (regs->SPI_FLR & SPI_FLR_RXFL_Msk) {
+		}
+	}
+}
+
+static void spi_sam_xfer_fifo(const struct device *dev)
+{
+	const struct spi_sam_config *cfg = dev->config;
+	struct spi_sam_data *data = dev->data;
+	Spi *regs = cfg->regs;
+	struct spi_context *ctx = &data->ctx;
+	uint32_t xfer_len = MIN(spi_context_longest_current_buf(ctx),
+				cfg->fifo_size);
+	uint32_t tdr = 0, td_idx = 0;
+	uint16_t td;
+
+	if (regs->SPI_FLR != 0U) {
+		LOG_ERR("FIFO is not empty! FLR=0x%08x\n", regs->SPI_FLR);
+
+		/* Flush TX and RX FIFOs */
+		regs->SPI_CR = SPI_CR_RXFCLR_Msk | SPI_CR_TXFCLR_Msk;
+		while (regs->SPI_FLR) {
+		}
+	}
+
+	regs->SPI_FMR = (regs->SPI_FMR & ~SPI_FMR_RXFTHRES_Msk) |
+			SPI_FMR_RXFTHRES(xfer_len);
+	(void)regs->SPI_SR;
+
+	while (xfer_len > 0U) {
+		if (spi_context_tx_on(ctx)) {
+			if (spi_context_tx_buf_on(ctx)) {
+				if (data->dfs > 1U) {
+					td = *(uint16_t *)(ctx->tx_buf);
+				} else {
+					td = *ctx->tx_buf;
+				}
+			} else {
+				td = DUMMY_DATA;
+			}
+
+			spi_context_update_tx(ctx, data->dfs, 1);
+		} else {
+			td = DUMMY_DATA;
+		}
+
+		tdr |= td << (td_idx++ * 16);
+		if (td_idx >= 2U) {
+			regs->SPI_TDR = tdr;
+			tdr = 0;
+			td_idx = 0;
+		}
+
+		xfer_len--;
+	}
+
+	if (td_idx >= 1U) {
+		sys_write16(td, (uintptr_t)&regs->SPI_TDR);
+	}
+
+	regs->SPI_IER = SPI_IER_RXFTHF_Msk | SPI_IER_OVRES_Msk;
+}
+
+static void spi_sam_xfer_next(const struct device *dev)
+{
+#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
+	const struct spi_sam_config *cfg = dev->config;
+#endif
+	struct spi_sam_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+
+	if (!spi_context_tx_on(ctx) && !spi_context_rx_on(ctx)) {
+		spi_sam_complete(dev, 0);
+		return;
+	}
+
+#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
+	if (spi_context_longest_current_buf(ctx) > cfg->fifo_size) {
+		spi_sam_xfer_dma(dev);
+	} else {
+		spi_sam_xfer_fifo(dev);
+	}
+#else
+	spi_sam_xfer_fifo(dev);
+#endif
+}
+
+static void spi_sam_isr(const struct device *dev)
+{
+	const struct spi_sam_config *cfg = dev->config;
+	Spi *regs = cfg->regs;
+	uint32_t status, pending;
+
+	status = regs->SPI_SR;
+	pending = status & regs->SPI_IMR;
+	regs->SPI_IDR = regs->SPI_IMR;
+
+	if (pending & SPI_SR_OVRES_Msk) {
+		spi_sam_complete(dev, -EIO);
+		return;
+	}
+
+	if (pending & SPI_IER_RXFTHF_Msk) {
+		spi_sam_pump_fifo(dev);
+		spi_sam_xfer_next(dev);
+	}
+}
+
+static int spi_sam_transceive(const struct device *dev,
+			      const struct spi_config *spi_cfg,
+			      const struct spi_buf_set *tx_bufs,
+			      const struct spi_buf_set *rx_bufs,
+			      bool async, spi_callback_t cb, void *userdata)
+{
+	struct spi_sam_data *data = dev->data;
+	struct spi_context *ctx = &data->ctx;
+	int ret = 0;
+
+	spi_context_lock(ctx, async, cb, userdata, spi_cfg);
+
+	ret = spi_sam_configure(dev, spi_cfg);
+	if (ret != 0) {
 		goto done;
 	}
 
-	spi_context_cs_control(&data->ctx, true);
+#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
+	data->dma_tx_nop = dma_check_nop_tx(dev, tx_bufs);
+#endif
 
-	if (spi_sam_is_regular(tx_bufs, rx_bufs)) {
-		spi_sam_fast_transceive(dev, config, tx_bufs, rx_bufs);
-	} else {
-		spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
+	spi_context_buffers_setup(ctx, tx_bufs, rx_bufs, data->dfs);
+	spi_context_cs_control(ctx, true);
 
-		do {
-			spi_sam_shift_controller(cfg->regs, data);
-		} while (spi_sam_transfer_ongoing(data));
-	}
+	spi_sam_xfer_next(dev);
 
-	spi_context_cs_control(&data->ctx, false);
+	ret = spi_context_wait_for_completion(ctx);
 done:
-	spi_context_release(&data->ctx, err);
-	return err;
+	spi_context_release(ctx, ret);
+
+	return ret;
 }
 
 static int spi_sam_transceive_sync(const struct device *dev,
@@ -678,7 +568,7 @@ static int spi_sam_transceive_sync(const struct device *dev,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs)
 {
-	return spi_sam_transceive(dev, config, tx_bufs, rx_bufs);
+	return spi_sam_transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -689,8 +579,7 @@ static int spi_sam_transceive_async(const struct device *dev,
 				    spi_callback_t cb,
 				    void *userdata)
 {
-	/* TODO: implement async transceive */
-	return -ENOTSUP;
+	return spi_sam_transceive(dev, config, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 
@@ -706,47 +595,49 @@ static int spi_sam_release(const struct device *dev,
 
 static int spi_sam_init(const struct device *dev)
 {
-	int err;
 	const struct spi_sam_config *cfg = dev->config;
 	struct spi_sam_data *data = dev->data;
+	Spi *regs = cfg->regs;
+	struct spi_context *ctx = &data->ctx;
+	int ret;
 
 #ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
 	if (cfg->dma_dev == NULL) {
-		if (IS_ENABLED(CONFIG_SPI_RTIO)) {
-			LOG_ERR("No DMA channel found, RTIO is not supported");
-			return -ENOTSUP;
-		}
-
-		LOG_WRN("No DMA channel found, polling mode will be used");
+		LOG_WRN("No DMA channel found, FIFO mode will be used");
 	} else {
 		if (device_is_ready(cfg->dma_dev) != true) {
 			LOG_ERR("DMA device is not ready!");
 			return -ENODEV;
 		}
 	}
+
+	data->dma_buf_size = ROUND_DOWN(CONFIG_SPI_MCHP_FLEXCOM_DMA_BUFFER_SIZE,
+					sys_cache_data_line_size_get());
+
+	sys_cache_data_invd_range(data->dma_rx_buf, data->dma_buf_size);
+	__DSB();
 #endif
 
 	/* Enable SPI clock in PMC */
 	(void)clock_control_on(SAM_DT_PMC_CONTROLLER,
 			       (clock_control_subsys_t)&cfg->clock_cfg);
 
-	err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
-	if (err < 0) {
-		return err;
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
 	}
 
-	err = spi_context_cs_configure_all(&data->ctx);
-	if (err < 0) {
-		return err;
+	/* Reset Flexcom SPI controller */
+	regs->SPI_CR = SPI_CR_SWRST_Msk;
+
+	ret = spi_context_cs_configure_all(ctx);
+	if (ret < 0) {
+		return ret;
 	}
 
-#ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
-	if (cfg->dma_dev != NULL) {
-		k_sem_init(&data->dma_sem, 0, K_SEM_MAX_LIMIT);
-	}
-#endif
+	cfg->irq_config_func(dev);
 
-	spi_context_unlock_unconditionally(&data->ctx);
+	spi_context_unlock_unconditionally(ctx);
 
 	/* The device will be configured and enabled when transceive
 	 * is called.
@@ -766,11 +657,11 @@ static DEVICE_API(spi, spi_sam_driver_api) = {
 	.release = spi_sam_release,
 };
 
-#define SPI_DMA_INIT(n)										\
-	.dma_dev = DEVICE_DT_GET_OR_NULL(DT_INST_DMAS_CTLR_BY_NAME(n, tx)),			\
-	.dma_tx_channel = DT_INST_DMAS_CELL_BY_NAME(n, tx, channel),				\
-	.dma_tx_perid = DT_INST_DMAS_CELL_BY_NAME(n, tx, perid),				\
-	.dma_rx_channel = DT_INST_DMAS_CELL_BY_NAME(n, rx, channel),				\
+#define SPI_SAM_DMA_INIT(n)							\
+	.dma_dev = DEVICE_DT_GET_OR_NULL(DT_INST_DMAS_CTLR_BY_NAME(n, tx)),	\
+	.dma_tx_channel = DT_INST_DMAS_CELL_BY_NAME(n, tx, channel),		\
+	.dma_tx_perid = DT_INST_DMAS_CELL_BY_NAME(n, tx, perid),		\
+	.dma_rx_channel = DT_INST_DMAS_CELL_BY_NAME(n, rx, channel),		\
 	.dma_rx_perid = DT_INST_DMAS_CELL_BY_NAME(n, rx, perid),
 
 #ifdef CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN
@@ -779,26 +670,40 @@ static DEVICE_API(spi, spi_sam_driver_api) = {
 #define SPI_USE_DMA(n) 0
 #endif
 
-#define SPI_SAM_DEFINE_CONFIG(n)								\
-	static const struct spi_sam_config spi_sam_config_##n = {				\
-		.regs = (Spi *)DT_INST_REG_ADDR(n),						\
-		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),					\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
-		.loopback = DT_INST_PROP(n, loopback),						\
-		COND_CODE_1(SPI_USE_DMA(n), (SPI_DMA_INIT(n)), ())				\
+#define SPI_SAM_DEFINE_CONFIG(n)						\
+	static const struct spi_sam_config spi_sam_config_##n = {		\
+		.regs      = (Spi *)DT_INST_REG_ADDR(n),			\
+		.clock_cfg = SAM_DT_INST_CLOCK_PMC_CFG(n),			\
+		.pcfg      = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
+		.loopback  = DT_INST_PROP(n, loopback),				\
+		.fifo_size = DT_INST_PROP(n, fifo_size),			\
+		COND_CODE_1(SPI_USE_DMA(n), (SPI_SAM_DMA_INIT(n)), ())		\
+		.irq_config_func = &spi_sam_irq_config_func_##n,		\
 	}
 
-#define SPI_SAM_DEVICE_INIT(n)									\
-	PINCTRL_DT_INST_DEFINE(n);								\
-	SPI_SAM_DEFINE_CONFIG(n);								\
-	static struct spi_sam_data spi_sam_dev_data_##n = {					\
-		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),				\
-		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),				\
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)				\
-	};											\
-	SPI_DEVICE_DT_INST_DEFINE(n, &spi_sam_init, NULL,					\
-			    &spi_sam_dev_data_##n,						\
-			    &spi_sam_config_##n, POST_KERNEL,					\
-			    CONFIG_SPI_INIT_PRIORITY, &spi_sam_driver_api);
+#define SPI_SAM_DEVICE_INIT(n)							\
+	static void spi_sam_irq_config_func_##n(const struct device *dev);	\
+										\
+	PINCTRL_DT_INST_DEFINE(n);						\
+	SPI_SAM_DEFINE_CONFIG(n);						\
+										\
+	static struct spi_sam_data spi_sam_dev_data_##n = {			\
+		SPI_CONTEXT_INIT_LOCK(spi_sam_dev_data_##n, ctx),		\
+		SPI_CONTEXT_INIT_SYNC(spi_sam_dev_data_##n, ctx),		\
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(n), ctx)		\
+	};									\
+										\
+	SPI_DEVICE_DT_INST_DEFINE(n, &spi_sam_init, NULL,			\
+				  &spi_sam_dev_data_##n,			\
+				  &spi_sam_config_##n, POST_KERNEL,		\
+				  CONFIG_SPI_INIT_PRIORITY,			\
+				  &spi_sam_driver_api);				\
+										\
+	static void spi_sam_irq_config_func_##n(const struct device *dev)	\
+	{									\
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),		\
+			    spi_sam_isr, DEVICE_DT_INST_GET(n), 0);		\
+		irq_enable(DT_INST_IRQN(n));					\
+	}
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_SAM_DEVICE_INIT)

--- a/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7d6/sama7d6.dtsi
@@ -420,6 +420,19 @@
 				status = "disabled";
 			};
 
+			spi4: spi@400 {
+				compatible = "microchip,flexcom-g1-spi";
+				reg = <0x400 0x200>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 38>;
+				clock-names = "pclk";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				fifo-size = <32>;
+				status = "disabled";
+			};
+
 			uart4: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;

--- a/dts/arm/microchip/sam/sama7/sama7g5/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7/sama7g5/sama7g5.dtsi
@@ -871,6 +871,7 @@
 				clock-names = "pclk";
 				#address-cells = <1>;
 				#size-cells = <0>;
+				fifo-size = <32>;
 				status = "disabled";
 			};
 

--- a/dts/bindings/spi/microchip,flexcom-g1-spi.yaml
+++ b/dts/bindings/spi/microchip,flexcom-g1-spi.yaml
@@ -55,6 +55,12 @@ properties:
       Connects TX to RX internally creating a loop back connection. Useful
       for testing.
 
+  fifo-size:
+    type: int
+    required: true
+    description: |
+      The size of SPI transmit FIFO and receive FIFO.
+
   dmas:
     description: |
       TX & RX dma specifiers.  Each specifier will have a phandle

--- a/tests/drivers/spi/spi_loopback/boards/sama7d65_curiosity.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sama7d65_curiosity.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+&spi4 {
+	loopback;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+
+	fast@1 {
+		compatible = "test-spi-loopback-fast";
+		reg = <1>;
+		spi-max-frequency = <10000000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.conf
+++ b/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.conf
@@ -1,2 +1,0 @@
-# enable DMA mode
-CONFIG_SPI_MCHP_FLEXCOM_DMA_DRIVEN=y

--- a/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/sama7g54_ek.overlay
@@ -18,9 +18,9 @@
 		spi-max-frequency = <1000000>;
 	};
 
-	fast@0 {
+	fast@1 {
 		compatible = "test-spi-loopback-fast";
-		reg = <0>;
+		reg = <1>;
 		spi-max-frequency = <10000000>;
 	};
 };


### PR DESCRIPTION
Update mchp_flexcom_spi driver:
1. Add fifo transfer support
2. Update DMA transfer.

Add SPI support for sama7d65, verified with spi_loopback test.

Please help review.

Many thanks.
Xing.