### PR TITLE
shell: Minor improvements in the remote shell

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -434,7 +434,7 @@ config SHELL_REMOTE_EP_NAME
 
 config SHELL_REMOTE_TIMEOUT_MS
 	int "Shell remote timeout in milliseconds"
-	default 100
+	default 5000
 	help
 	  The timeout in milliseconds for the IPC communication.
 

--- a/subsys/shell/shell_remote_cli.c
+++ b/subsys/shell/shell_remote_cli.c
@@ -159,12 +159,14 @@ static void cmd_get(struct shell_remote_cli *sh_remote, const struct shell_remot
 	entry = z_shell_cmd_get(msg->parent, msg->idx, &sh_remote->loc);
 
 	if (entry == NULL) {
-		LOG_DBG("Command not found parent:%s, idx:%d", msg->parent->syntax, msg->idx);
+		LOG_DBG("Command not found parent:%s, idx:%d",
+			msg->parent ? msg->parent->syntax : "NULL", msg->idx);
 		cmd_result(&sh_remote->ept, -ENODEV);
 		/* Failed to get the command. */
 		return;
 	} else if (strlen(entry->syntax) == 0) {
-		LOG_DBG("Empty syntax, parent:%s, idx:%d", msg->parent->syntax, msg->idx);
+		LOG_DBG("Empty syntax, parent:%s, idx:%d",
+			msg->parent ? msg->parent->syntax : "NULL", msg->idx);
 		cmd_result(&sh_remote->ept, -ENOEXEC);
 		/* Command is empty. */
 		return;


### PR DESCRIPTION
Minor improvements:
- increase remote command execution timeout as 100 ms may often not be enough (if command for example prints a lot).
- fix case where remote client may crash if logging is enabled and there are not shell commands compiled into the binary