### PR TITLE
drivers: ethernet: dwc_mac: xmc: document the MAC reset in bus init

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_xmc_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_xmc_dwc_ether_1000.c
@@ -55,6 +55,11 @@ int dwmac_bus_init(const struct device *dev)
 {
 	int ret;
 
+	/*
+	 * Hold the MAC in reset while the pins, the PHY interface mode and the
+	 * clocks are configured. The PHY interface mode must be selected while
+	 * the MAC is under reset.
+	 */
 	XMC_ETH_MAC_Disable(NULL);
 	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {


### PR DESCRIPTION
`XMC_ETH_MAC_Disable()` asserts the ETH0 peripheral reset and gates the MAC clock, so the driver already configures the pins and the PHY interface mode while the MAC is under reset. Document that, as it is not apparent from its name.