### PR TITLE
drivers: ethernet: dwc_mac: nxp: reset the MAC during bus init

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -62,6 +62,7 @@ config ETH_NXP_DWC_ETHER_QOS
 	select ETH_DWC_ETHER_QOS_CORE
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select PINCTRL
+	select RESET if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_ENET_QOS),resets)
 	select HWINFO
 	select CRC
 	default y

--- a/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_nxp_dwc_ether_qos.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/reset.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/irq.h>
 #include <fsl_device_registers.h>
@@ -59,6 +60,16 @@ DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
 PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
+/*
+ * The PHY interface selection is sampled when the MAC leaves reset, so the MAC
+ * has to be held there while dwmac_bus_init() sets it. MCXE31x is the one SoC
+ * without a reset line, where gating the MAC clocks takes that role instead.
+ */
+BUILD_ASSERT(DT_INST_NODE_HAS_PROP(0, resets) || IS_ENABLED(CONFIG_SOC_SERIES_MCXE31X),
+	     "Ethernet node is missing the resets property");
+
+static const struct reset_dt_spec eth_reset = RESET_DT_SPEC_INST_GET_OR(0, {0});
+
 /* The mc_cgm clock cell is itself named "name", hence the repetition. */
 #define NXP_ETH_CLOCK_SUBSYS(clk)                                                                 \
 	(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(0, clk, name)
@@ -76,6 +87,36 @@ int dwmac_bus_init(const struct device *dev)
 {
 	const struct dwmac_config *cfg = dev->config;
 	int ret;
+
+	/*
+	 * Hold the MAC in reset while the pads, the PHY interface and the
+	 * clocks are set up: the interface selection is sampled by the MAC
+	 * when it leaves reset.
+	 */
+	if (eth_reset.dev != NULL) {
+		ret = reset_line_assert_dt(&eth_reset);
+		if (ret != 0) {
+			LOG_ERR("Could not assert ethernet reset (%d)", ret);
+			return ret;
+		}
+	}
+
+#if defined(CONFIG_SOC_SERIES_MCXE31X)
+	/*
+	 * MCXE31x has no reset line for the MAC: its MC_ME block clock is the
+	 * only gate, and the MAC leaves reset when that clock is turned on.
+	 * Gate the clocks off here in case they were left on, so that the
+	 * interface selection below is in place before the loop turns them on
+	 * again.
+	 */
+	for (size_t n = 0; n < ARRAY_SIZE(eth0_clocks); n++) {
+		ret = clock_control_off(cfg->clock, eth0_clocks[n]);
+		if (ret != 0) {
+			LOG_ERR("Failed to disable ethernet clock #%zu (%d)", n, ret);
+			return ret;
+		}
+	}
+#endif
 
 	/* Mux the pads first: the clocks below are derived from what they carry. */
 	ret = pinctrl_apply_state(eth0_pcfg, PINCTRL_STATE_DEFAULT);
@@ -107,6 +148,14 @@ int dwmac_bus_init(const struct device *dev)
 		ret = clock_control_on(cfg->clock, eth0_clocks[n]);
 		if (ret != 0) {
 			LOG_ERR("Failed to enable ethernet clock #%zu (%d)", n, ret);
+			return ret;
+		}
+	}
+
+	if (eth_reset.dev != NULL) {
+		ret = reset_line_deassert_dt(&eth_reset);
+		if (ret != 0) {
+			LOG_ERR("Could not deassert ethernet reset (%d)", ret);
 			return ret;
 		}
 	}

--- a/dts/arm/nxp/mcx/mcxa/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxa/nxp_mcxa5x_common.dtsi
@@ -857,6 +857,7 @@
 		reg = <0x1c000 0x1000>;
 		clocks = <&syscon MCUX_ENET_QOS_CLK>, <&syscon MCUX_ENET_QOS_PTP_CLK>;
 		clock-names = "mac", "ptp";
+		resets = <&reset NXP_SYSCON_RESET(2, 10)>;
 		interrupts = <90 0>, <91 0>;
 		interrupt-names = "mac", "power";
 		snps,perfect-filter-entries = <1>;

--- a/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
@@ -959,6 +959,7 @@
 		reg = <0x40100000 0x1200>;
 		clocks = <&syscon MCUX_ENET_QOS_CLK>, <&syscon MCUX_ENET_QOS_PTP_CLK>;
 		clock-names = "mac", "ptp";
+		resets = <&reset NXP_SYSCON_RESET(2, 2)>;
 		interrupts = <139 0>, <140 0>, <141 0>;
 		interrupt-names = "mac", "power", "lpi";
 		snps,perfect-filter-entries = <1>;

--- a/dts/bindings/ethernet/nxp,enet-qos.yaml
+++ b/dts/bindings/ethernet/nxp,enet-qos.yaml
@@ -8,6 +8,7 @@ compatible: "nxp,enet-qos"
 include:
   - snps,dwmac.yaml
   - pinctrl-device.yaml
+  - reset-device.yaml
 
 properties:
   reg:


### PR DESCRIPTION
The PHY interface mode must be selected while the MAC is under reset and before its clocks are enabled.

This constraint is not MCX specific, it comes from the Synopsys DesignWare Ethernet IP core. Other glue drivers, such as the one for the Infineon XMC4xxx, already perform the sequence in this order.

Until now the MCX glue drivers configured the PHY interface mode, without ever asserting the reset line.