### PR TITLE
boards: alif: use standard <function>_<state> pinctrl node names

### DIFF
--- a/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk-pinctrl.dtsi
@@ -6,7 +6,7 @@
 #include <zephyr/dt-bindings/pinctrl/alif-balletto-b1-pinctrl.h>
 
 &pinctrl {
-	pinctrl_uart2: pinctrl_uart2 {
+	uart2_default: uart2_default {
 		group0 {
 			pinmux = <PIN_P5_2__UART2_RX_B>;
 			input-enable;
@@ -17,7 +17,7 @@
 		};
 	};
 
-	pinctrl_i2c0: pinctrl_i2c0 {
+	i2c0_default: i2c0_default {
 		group0 {
 			pinmux = <PIN_P7_0__I2C0_SDA_C>,
 				 <PIN_P7_1__I2C0_SCL_C>;
@@ -26,7 +26,7 @@
 		};
 	};
 
-	pinctrl_i2c1: pinctrl_i2c1 {
+	i2c1_default: i2c1_default {
 		group0 {
 			pinmux = <PIN_P7_2__I2C1_SDA_C>,
 				 <PIN_P7_3__I2C1_SCL_C>;
@@ -35,7 +35,7 @@
 		};
 	};
 
-	pinctrl_gpio4: pinctrl_gpio4 {
+	gpio4_default: gpio4_default {
 		group0 {
 			/* Multicolor LED0: blue on P4_3, green on P4_5, red on P4_7 */
 			pinmux = <PIN_P4_3__GPIO>,
@@ -44,7 +44,7 @@
 		};
 	};
 
-	pinctrl_gpio5: pinctrl_gpio5 {
+	gpio5_default: gpio5_default {
 		group0 {
 			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW3 */
 			pinmux = <PIN_P5_0__GPIO>,

--- a/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
+++ b/boards/alif/balletto_b1_dk/balletto_b1_dk_ab1c1f4m51820ph0.dts
@@ -89,25 +89,25 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };
 
 &gpio4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio4>;
+	pinctrl-0 = <&gpio4_default>;
 	pinctrl-names = "default";
 };
 
 &gpio5 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio5>;
+	pinctrl-0 = <&gpio5_default>;
 	pinctrl-names = "default";
 };
 
 &i2c1 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_i2c1>;
+	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk-pinctrl.dtsi
@@ -6,7 +6,7 @@
 #include <zephyr/dt-bindings/pinctrl/alif-ensemble-e1c-pinctrl.h>
 
 &pinctrl {
-	pinctrl_uart2: pinctrl_uart2 {
+	uart2_default: uart2_default {
 		group0 {
 			pinmux = <PIN_P5_2__UART2_RX_B>;
 			input-enable;
@@ -17,7 +17,7 @@
 		};
 	};
 
-	pinctrl_i2c0: pinctrl_i2c0 {
+	i2c0_default: i2c0_default {
 		group0 {
 			pinmux = <PIN_P7_0__I2C0_SDA_C>,
 				 <PIN_P7_1__I2C0_SCL_C>;
@@ -26,7 +26,7 @@
 		};
 	};
 
-	pinctrl_i2c1: pinctrl_i2c1 {
+	i2c1_default: i2c1_default {
 		group0 {
 			pinmux = <PIN_P7_2__I2C1_SDA_C>,
 				 <PIN_P7_3__I2C1_SCL_C>;
@@ -35,7 +35,7 @@
 		};
 	};
 
-	pinctrl_gpio4: pinctrl_gpio4 {
+	gpio4_default: gpio4_default {
 		group0 {
 			/* Multicolor LED0: blue on P4_3, green on P4_5, red on P4_7 */
 			pinmux = <PIN_P4_3__GPIO>,
@@ -44,7 +44,7 @@
 		};
 	};
 
-	pinctrl_gpio5: pinctrl_gpio5 {
+	gpio5_default: gpio5_default {
 		group0 {
 			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW3 */
 			pinmux = <PIN_P5_0__GPIO>,

--- a/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
+++ b/boards/alif/ensemble_e1c_dk/ensemble_e1c_dk_ae1c1f4051920ph0_rtss_he.dts
@@ -90,25 +90,25 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };
 
 &gpio4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio4>;
+	pinctrl-0 = <&gpio4_default>;
 	pinctrl-names = "default";
 };
 
 &gpio5 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio5>;
+	pinctrl-0 = <&gpio5_default>;
 	pinctrl-names = "default";
 };
 
 &i2c1 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_i2c1>;
+	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/alif/ensemble_e8_ak/ensemble_e8_ak-pinctrl.dtsi
+++ b/boards/alif/ensemble_e8_ak/ensemble_e8_ak-pinctrl.dtsi
@@ -6,7 +6,7 @@
 #include <zephyr/dt-bindings/pinctrl/alif-ensemble-pinctrl.h>
 
 &pinctrl {
-	pinctrl_uart2: pinctrl_uart2 {
+	uart2_default: uart2_default {
 		group0 {
 			pinmux = <PIN_P1_0__UART2_RX_A>;
 			input-enable;
@@ -17,7 +17,7 @@
 		};
 	};
 
-	pinctrl_uart4: pinctrl_uart4 {
+	uart4_default: uart4_default {
 		group0 {
 			pinmux = <PIN_P12_1__UART4_RX_B>;
 			input-enable;
@@ -28,14 +28,14 @@
 		};
 	};
 
-	pinctrl_gpio7: pinctrl_gpio7 {
+	gpio7_default: gpio7_default {
 		group0 {
 			/* Multicolor LED0: green on P7_4 */
 			pinmux = <PIN_P7_4__GPIO>;
 		};
 	};
 
-	pinctrl_gpio12: pinctrl_gpio12 {
+	gpio12_default: gpio12_default {
 		group0 {
 			/* Multicolor LED0: blue on P12_0, red on P12_3 */
 			pinmux = <PIN_P12_0__GPIO>,
@@ -43,7 +43,7 @@
 		};
 	};
 
-	pinctrl_lpgpio: pinctrl_lpgpio {
+	lpgpio_default: lpgpio_default {
 		group0 {
 			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW2 */
 			pinmux = <PIN_P15_0__LPGPIO>,

--- a/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_apss.dts
+++ b/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_apss.dts
@@ -24,6 +24,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_rtss_he.dts
@@ -24,6 +24,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_ak/ensemble_e8_ak_ae822fa0e5597bs0_rtss_hp.dts
@@ -24,6 +24,6 @@
 
 &uart4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart4>;
+	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_ak/ensemble_e8_ak_common.dtsi
+++ b/boards/alif/ensemble_e8_ak/ensemble_e8_ak_common.dtsi
@@ -82,18 +82,18 @@
 
 &gpio7 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio7>;
+	pinctrl-0 = <&gpio7_default>;
 	pinctrl-names = "default";
 };
 
 &gpio12 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio12>;
+	pinctrl-0 = <&gpio12_default>;
 	pinctrl-names = "default";
 };
 
 &lpgpio {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_lpgpio>;
+	pinctrl-0 = <&lpgpio_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk-pinctrl.dtsi
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/pinctrl/alif-ensemble-pinctrl.h>
 
 &pinctrl {
-	pinctrl_uart0: pinctrl_uart0 {
+	uart0_default: uart0_default {
 		group0 {
 			pinmux = <PIN_P0_0__UART0_RX_A>;
 			input-enable;
@@ -18,7 +18,7 @@
 		};
 	};
 
-	pinctrl_uart1: pinctrl_uart1 {
+	uart1_default: uart1_default {
 		group0 {
 			pinmux = <PIN_P0_4__UART1_RX_A>;
 			input-enable;
@@ -29,7 +29,7 @@
 		};
 	};
 
-	pinctrl_uart2: pinctrl_uart2 {
+	uart2_default: uart2_default {
 		group0 {
 			pinmux = <PIN_P1_0__UART2_RX_A>;
 			input-enable;
@@ -40,7 +40,7 @@
 		};
 	};
 
-	pinctrl_uart3: pinctrl_uart3 {
+	uart3_default: uart3_default {
 		group0 {
 			pinmux = <PIN_P1_2__UART3_RX_A>;
 			input-enable;
@@ -51,7 +51,7 @@
 		};
 	};
 
-	pinctrl_uart4: pinctrl_uart4 {
+	uart4_default: uart4_default {
 		group0 {
 			pinmux = <PIN_P12_1__UART4_RX_B>;
 			input-enable;
@@ -62,7 +62,7 @@
 		};
 	};
 
-	pinctrl_uart5: pinctrl_uart5 {
+	uart5_default: uart5_default {
 		group0 {
 			pinmux = <PIN_P3_4__UART5_RX_A>;
 			input-enable;
@@ -73,7 +73,7 @@
 		};
 	};
 
-	pinctrl_uart6: pinctrl_uart6 {
+	uart6_default: uart6_default {
 		group0 {
 			pinmux = <PIN_P10_5__UART6_RX_A>;
 			input-enable;
@@ -84,7 +84,7 @@
 		};
 	};
 
-	pinctrl_uart7: pinctrl_uart7 {
+	uart7_default: uart7_default {
 		group0 {
 			pinmux = <PIN_P9_3__UART7_RX_B>;
 			input-enable;
@@ -95,7 +95,7 @@
 		};
 	};
 
-	pinctrl_i2c0: pinctrl_i2c0 {
+	i2c0_default: i2c0_default {
 		group0 {
 			pinmux = <PIN_P3_5__I2C0_SDA_B>,
 				 <PIN_P3_4__I2C0_SCL_B>;
@@ -104,7 +104,7 @@
 		};
 	};
 
-	pinctrl_i2c1: pinctrl_i2c1 {
+	i2c1_default: i2c1_default {
 		group0 {
 			pinmux = <PIN_P7_2__I2C1_SDA_C>,
 				 <PIN_P7_3__I2C1_SCL_C>;
@@ -113,7 +113,7 @@
 		};
 	};
 
-	pinctrl_i2c2: pinctrl_i2c2 {
+	i2c2_default: i2c2_default {
 		group0 {
 			pinmux = <PIN_P0_7__I2C2_SDA_A>,
 				 <PIN_P0_6__I2C2_SCL_A>;
@@ -122,7 +122,7 @@
 		};
 	};
 
-	pinctrl_i2c3: pinctrl_i2c3 {
+	i2c3_default: i2c3_default {
 		group0 {
 			pinmux = <PIN_P9_6__I2C3_SDA_B>,
 				 <PIN_P9_7__I2C3_SCL_B>;
@@ -131,7 +131,7 @@
 		};
 	};
 
-	pinctrl_gpio6: pinctrl_gpio6 {
+	gpio6_default: gpio6_default {
 		group0 {
 			/* Multicolor LED1: red on P6_2, green on P6_4, blue on P6_6 */
 			pinmux = <PIN_P6_2__GPIO>,
@@ -140,14 +140,14 @@
 		};
 	};
 
-	pinctrl_gpio7: pinctrl_gpio7 {
+	gpio7_default: gpio7_default {
 		group0 {
 			/* Multicolor LED0: green on P7_4 */
 			pinmux = <PIN_P7_4__GPIO>;
 		};
 	};
 
-	pinctrl_gpio12: pinctrl_gpio12 {
+	gpio12_default: gpio12_default {
 		group0 {
 			/* Multicolor LED0: blue on P12_0, red on P12_3 */
 			pinmux = <PIN_P12_0__GPIO>,
@@ -155,7 +155,7 @@
 		};
 	};
 
-	pinctrl_lpgpio: pinctrl_lpgpio {
+	lpgpio_default: lpgpio_default {
 		group0 {
 			/* Navigation joystick JOY_SW1 to JOY_SW5 on SW2 */
 			pinmux = <PIN_P15_0__LPGPIO>,

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_he.dts
@@ -24,6 +24,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae402fa0e5597le0_rtss_hp.dts
@@ -24,6 +24,6 @@
 
 &uart4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart4>;
+	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_he.dts
@@ -24,6 +24,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae612fa0e5597ls0_rtss_hp.dts
@@ -24,6 +24,6 @@
 
 &uart4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart4>;
+	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_apss.dts
@@ -24,6 +24,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_he.dts
@@ -25,6 +25,6 @@
 
 &uart2 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart2>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_ae822fa0e5597ls0_rtss_hp.dts
@@ -25,6 +25,6 @@
 
 &uart4 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_uart4>;
+	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";
 };

--- a/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
+++ b/boards/alif/ensemble_e8_dk/ensemble_e8_dk_common.dtsi
@@ -100,31 +100,31 @@
 
 &gpio6 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio6>;
+	pinctrl-0 = <&gpio6_default>;
 	pinctrl-names = "default";
 };
 
 &gpio7 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio7>;
+	pinctrl-0 = <&gpio7_default>;
 	pinctrl-names = "default";
 };
 
 &gpio12 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_gpio12>;
+	pinctrl-0 = <&gpio12_default>;
 	pinctrl-names = "default";
 };
 
 &lpgpio {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_lpgpio>;
+	pinctrl-0 = <&lpgpio_default>;
 	pinctrl-names = "default";
 };
 
 &i2c0 {
 	status = "okay";
-	pinctrl-0 = <&pinctrl_i2c0>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 


### PR DESCRIPTION
### Summary

Renames the pin control nodes on the four Alif boards from `pinctrl_<function>` to the `<function>_<state>` form documented in the pin control guide, for example `pinctrl_uart2` becomes `uart2_default`. Naming the state explicitly also leaves room  for a "sleep" state later without a second rename.

Addresses https://github.com/zephyrproject-rtos/zephyr/pull/117753#discussion_r3901889804 .

Cleanup only, no functional change. 

### Contents

One commit:

1. `boards: alif: use standard <function>_<state> pinctrl node names` -  renames the nodes and their labels in the four board pinctrl dtsi files (Ensemble E8 DevKit, Ensemble E8 AI/ML AppKit, Ensemble E1C    DevKit, Balletto B1 DevKit) and updates the 17 `pinctrl-0` references to them. Nothing outside `boards/alif/` refers to these labels.

### Testing

Build-tested on all twelve Alif board targets - Ensemble E8 DevKit (seven), Ensemble E8 AI/ML AppKit (three), Ensemble E1C DevKit and Balletto B1 DevKit - with `samples/hello_world`, `samples/basic/blinky` and `samples/basic/button`.
