### PR TITLE
west.yml: update hal_stm32 + associated changes

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -39,13 +39,13 @@
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_rxd0_pc4
-		     &eth_rxd1_pc5
-		     &eth_ref_clk_pa1
-		     &eth_crs_dv_pa7
-		     &eth_tx_en_pg11
-		     &eth_txd0_pg13
-		     &eth_txd1_pb15>;
+	pinctrl-0 = <&eth_rmii_rxd0_pc4
+		     &eth_rmii_rxd1_pc5
+		     &eth_rmii_ref_clk_pa1
+		     &eth_rmii_crs_dv_pa7
+		     &eth_rmii_tx_en_pg11
+		     &eth_rmii_txd0_pg13
+		     &eth_rmii_txd1_pb15>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;

--- a/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk-common.dtsi
@@ -263,13 +263,13 @@
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_rxd0_pc4
-		     &eth_rxd1_pc5
-		     &eth_ref_clk_pa1
-		     &eth_crs_dv_pa7
-		     &eth_tx_en_pg11
-		     &eth_txd0_pg13
-		     &eth_txd1_pg12>;
+	pinctrl-0 = <&eth_rmii_rxd0_pc4
+		     &eth_rmii_rxd1_pc5
+		     &eth_rmii_ref_clk_pa1
+		     &eth_rmii_crs_dv_pa7
+		     &eth_rmii_tx_en_pg11
+		     &eth_rmii_txd0_pg13
+		     &eth_rmii_txd1_pg12>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1448,6 +1448,79 @@ STM32
   property has been removed. This should have no impact since the property was not used except for the
   wake-up pins feature, which is now handled by :dtcompatible:`st,stm32-pwr-wkupctrl`. (:github:`114092`)
 
+* All Ethernet pinctrl nodes for STM32H5 series except :samp:`eth_mdc_{px0}`, :samp:`eth_mdio_{px0}`
+  and :samp:`eth_pps_out_{px0}` have been renamed to match the Data Sheet names (:github:`118318`).
+
+  The following table indicates the mapping between old and new names and can be used to migrate:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 30 35 35
+
+     * - Old name
+       - New name (``mii`` PHY)
+       - New name (``rmii`` PHY)
+     * - :samp:`eth_crs_dv_{px0}`
+       - *N/A for MII*
+       - :samp:`eth_rmii_crs_dv_{px0}`
+     * - :samp:`eth_ref_clk_{px0}`
+       - *N/A for MII*
+       - :samp:`eth_rmii_ref_clk_{px0}`
+     * - :samp:`eth_col_{px0}`
+       - :samp:`eth_mii_col_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_crs_{px0}`
+       - :samp:`eth_mii_crs_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_rx_clk_{px0}`
+       - :samp:`eth_mii_rx_clk_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_rx_dv_{px0}`
+       - :samp:`eth_mii_rx_dv_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_rx_er_{px0}`
+       - :samp:`eth_mii_rx_er_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_rxd0_{px0}`
+       - :samp:`eth_mii_rxd0_{px0}`
+       - :samp:`eth_rmii_rxd0_{px0}`
+     * - :samp:`eth_rxd1_{px0}`
+       - :samp:`eth_mii_rxd1_{px0}`
+       - :samp:`eth_rmii_rxd1_{px0}`
+     * - :samp:`eth_rxd2_{px0}`
+       - :samp:`eth_mii_rxd2_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_rxd3_{px0}`
+       - :samp:`eth_mii_rxd3_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_tx_clk_{px0}`
+       - :samp:`eth_mii_tx_clk_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_tx_en_{px0}`
+       - :samp:`eth_mii_tx_en_{px0}`
+       - :samp:`eth_rmii_tx_en_{px0}`
+     * - :samp:`eth_txd0_{px0}`
+       - :samp:`eth_mii_txd0_{px0}`
+       - :samp:`eth_rmii_txd0_{px0}`
+     * - :samp:`eth_txd1_{px0}`
+       - :samp:`eth_mii_txd1_{px0}`
+       - :samp:`eth_rmii_txd1_{px0}`
+     * - :samp:`eth_txd2_{px0}`
+       - :samp:`eth_mii_txd2_{px0}`
+       - *N/A for RMII*
+     * - :samp:`eth_txd3_{px0}`
+       - :samp:`eth_mii_txd3_{px0}`
+       - *N/A for RMII*
+
+  .. note::
+    Pin names now vary depending on whether an MII PHY or an RMII PHY is used; this is indicated
+    by property ``phy-connection-type`` (``mii`` or ``rmii``) on the Ethernet node in Devicetree.
+
+    :samp:`{px0}` is a placeholder and should be replaced with actual pin names (e.g., ``pa1``).
+
+    SoCs of the STM32H5Ex/STM32H5Fx line are not affected by this change as they have always used
+    the new names since their introduction in Zephyr.
+
 Syscon
 ======
 

--- a/soc/st/stm32/stm32f0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f0x/Kconfig.defconfig
@@ -10,8 +10,8 @@ if SOC_SERIES_STM32F0X
 # STM32F030x4 must be exposed as STM32F030x6 at HAL level.
 # STM32F072x8 must be exposed as STM32F072xB at HAL level.
 configdefault STM32CUBE_SOC_NAME_OVERRIDE
-	default "stm32f030x6" if SOC_STM32F030X4
-	default "stm32f072xb" if SOC_STM32F072X8
+	default "STM32F030x6" if SOC_STM32F030X4
+	default "STM32F072xB" if SOC_STM32F072X8
 
 config SRAM_VECTOR_TABLE
 	default y

--- a/soc/st/stm32/stm32f1x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f1x/Kconfig.defconfig
@@ -10,8 +10,8 @@ if SOC_SERIES_STM32F1X
 # STM32F103x8 must be exposed as STM32F103xB at HAL level.
 # STM32F105xB must be exposed as STM32F105xC at HAL level.
 configdefault STM32CUBE_SOC_NAME_OVERRIDE
-	default "stm32f103xb" if SOC_STM32F103X8
-	default "stm32f105xc" if SOC_STM32F105XB
+	default "STM32F103xB" if SOC_STM32F103X8
+	default "STM32F105xC" if SOC_STM32F105XB
 
 # adjust the fallback because of the LSI oscaillator characteristics
 config TASK_WDT_HW_FALLBACK_DELAY

--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig
@@ -9,7 +9,7 @@ if SOC_SERIES_STM32F4X
 
 # STM32F401xD must be exposed as STM32F401xE at HAL level.
 configdefault STM32CUBE_SOC_NAME_OVERRIDE
-	default "stm32f401xe" if SOC_STM32F401XD
+	default "STM32F401xE" if SOC_STM32F401XD
 
 configdefault SHARED_INTERRUPTS
 	default y if $(dt_nodelabel_enabled,timers1) && $(dt_nodelabel_enabled,timers9)

--- a/soc/st/stm32/stm32wl3x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wl3x/Kconfig.defconfig
@@ -6,9 +6,7 @@
 if SOC_SERIES_STM32WL3X
 
 # STM32WL30x/31x/33x must be exposed as STM32WL3XX at HAL level.
-# FIXME: not currently possible. "stm32wl33" is used temporarily
-# instead as it is recognized as STM32WL3XX due to a legacy alias.
 configdefault STM32CUBE_SOC_NAME_OVERRIDE
-	default "stm32wl33" if SOC_STM32WL30XX || SOC_STM32WL31XX || SOC_STM32WL33XX
+	default "STM32WL3XX" if SOC_STM32WL30XX || SOC_STM32WL31XX || SOC_STM32WL33XX
 
 endif # SOC_SERIES_STM32WL3X

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 02baa06ccea3304d1f65ec6550c68e5e300fcc58
+      revision: 9e579a021d6ed794a7c2a4777a4c5be552769035
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update the hal_stm32 module to a new revision which changes how the Kconfig option STM32CUBE_SOC_NAME_OVERRIDE works. This requires a few changes in SoC Kconfig where it is used, but allows getting rid of a hack in the STM32WL3 Kconfig (which was the aim of the change).

HAL side PR: https://github.com/zephyrproject-rtos/hal_stm32/pull/406