### PR TITLE
kconfig: Add missing deprecation text

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1306,7 +1306,7 @@ config CACHE_HAS_MIRRORED_MEMORY_REGIONS
 	  sense when MP_MAX_NUM_CPUS > 1.
 
 config CACHE_DOUBLEMAP
-	bool "Cache double-mapping support"
+	bool "Cache double-mapping support [DEPRECATED]"
 	select CACHE_HAS_MIRRORED_MEMORY_REGIONS
 	select DEPRECATED
 	help

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -35,7 +35,7 @@ config UART_NRFX_UARTE_NO_IRQ
 	  to get to the lowest power state after uart_poll_out if receiver is not used.
 
 config UART_NRFX_UARTE_ENHANCED_RX
-	bool "Enhanced RX handling"
+	bool "Enhanced RX handling [DEPRECATED]"
 	select DEPRECATED
 	help
 	  Option is deprecated as it is used as default unless TIMER peripheral is used

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -548,7 +548,7 @@ config BT_RPA_SHARING
 	  period.
 
 config BT_SIGNING
-	bool "Data signing support"
+	bool "Data signing support [DEPRECATED]"
 	select DEPRECATED
 	help
 	  This option enables data signing which is used for transferring


### PR DESCRIPTION
    Adds a missing [DEPRECATED] tag to the Kconfig prompt
