### PR TITLE
Revert "Bluetooth: Host: Fix RPA expire issues for adv"

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -254,7 +254,11 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv, void *data)
 
 static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 {
-	if (atomic_test_bit(adv->flags, BT_ADV_RPA_UPDATE)) {
+	/* RPA of Advertisers limited by timeout or number of packets only expire
+	 * when they are stopped.
+	 */
+	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
+	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
 		adv_rpa_expired(adv, data);
 	}
 }
@@ -720,12 +724,15 @@ static void rpa_timeout(struct k_work *work)
 	adv_enabled = le_adv_rpa_timeout();
 	le_rpa_invalidate();
 
-	/* Update the RPA if we have any active procedures that use it */
-	if ((IS_ENABLED(CONFIG_BT_BROADCASTER) && adv_enabled) ||
-	    (IS_ENABLED(CONFIG_BT_CENTRAL) && atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) ||
-	    (IS_ENABLED(CONFIG_BT_OBSERVER) && bt_le_scan_active_scanner_running())) {
-		le_update_private_addr();
+	/* IF no roles using the RPA is running we can stop the RPA timer */
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		if (!(adv_enabled || atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
+		      bt_le_scan_active_scanner_running())) {
+			return;
+		}
 	}
+
+	le_update_private_addr();
 }
 #endif /* CONFIG_BT_PRIVACY */
 


### PR DESCRIPTION
This reverts commit e55eaf1312ea55f1ad702f35e15a9935814482d0.

Originally added by me in https://github.com/zephyrproject-rtos/zephyr/pull/111676 

Reverting because:
1) This is a behavioral change without a migration guide available
2) The change in behavior breaks downstream users (see https://github.com/nrfconnect/sdk-zephyr/pull/4436) 
3) The change was based on a misconception of the callback. It was assumed that the callback `rpa_expired` indicated that the RPA expired, but the callback can, by returning `false`, keep the existing RPA, and thus prevent the RPA from actually expiring. The `rpa_expired` can thus, by design, be called multiple times, even for inactive advertising sets as the RPA continues to "live" as long as `false` is returned. 

The callback's behavior and name/documentation does not fully match, and a more thorough approach to the design, implementation and documentation of the callback is needed. For now, revert the breaking behavioral change to avoid the change from being in a Zephyr release. 
