### PR TITLE
usb: device_next: simplify the endpoint bitmap helpers

### DIFF
--- a/subsys/usb/device_next/usbd_endpoint.h
+++ b/subsys/usb/device_next/usbd_endpoint.h
@@ -10,43 +10,43 @@
 #include <zephyr/usb/usbd.h>
 
 /**
- * @brief Set bit associated with the endpoint
+ * @brief Get the endpoint bitmap bit associated with an endpoint address
  *
- * The IN endpoints are mapped in the upper nibble.
+ * OUT endpoints are mapped to bits 0 to 15, IN endpoints to bits 16 to 31.
+ *
+ * @param[in] ep  Endpoint address
+ *
+ * @return Bit position in an endpoint bitmap
+ */
+static inline unsigned int usbd_ep_bm_bit(const uint8_t ep)
+{
+	return USB_EP_GET_IDX(ep) + (USB_EP_DIR_IS_IN(ep) ? 16U : 0U);
+}
+
+/**
+ * @brief Set bit associated with the endpoint
  *
  * @param[in] ep_bm  Pointer to endpoint bitmap
  * @param[in] ep     Endpoint address
  */
 static inline void usbd_ep_bm_set(uint32_t *const ep_bm, const uint8_t ep)
 {
-	if (USB_EP_DIR_IS_IN(ep)) {
-		*ep_bm |= BIT(USB_EP_GET_IDX(ep) + 16U);
-	} else {
-		*ep_bm |= BIT(USB_EP_GET_IDX(ep));
-	}
+	*ep_bm |= BIT(usbd_ep_bm_bit(ep));
 }
 
 /**
  * @brief Clear bit associated with the endpoint
- *
- * The IN endpoints are mapped in the upper nibble.
  *
  * @param[in] ep_bm  Pointer to endpoint bitmap
  * @param[in] ep     Endpoint address
  */
 static inline void usbd_ep_bm_clear(uint32_t *const ep_bm, const uint8_t ep)
 {
-	if (USB_EP_DIR_IS_IN(ep)) {
-		*ep_bm &= ~BIT(USB_EP_GET_IDX(ep) + 16U);
-	} else {
-		*ep_bm &= ~BIT(USB_EP_GET_IDX(ep));
-	}
+	*ep_bm &= ~BIT(usbd_ep_bm_bit(ep));
 }
 
 /**
  * @brief Check whether bit associated with the endpoint is set
- *
- * The IN endpoints are mapped in the upper nibble.
  *
  * @param[in] ep_bm  Pointer to endpoint bitmap
  * @param[in] ep     Endpoint address
@@ -55,15 +55,25 @@ static inline void usbd_ep_bm_clear(uint32_t *const ep_bm, const uint8_t ep)
  */
 static inline bool usbd_ep_bm_is_set(const uint32_t *const ep_bm, const uint8_t ep)
 {
-	unsigned int bit;
+	return (*ep_bm & BIT(usbd_ep_bm_bit(ep))) ? true : false;
+}
 
-	if (USB_EP_DIR_IS_IN(ep)) {
-		bit = USB_EP_GET_IDX(ep) + 16U;
-	} else {
-		bit = USB_EP_GET_IDX(ep);
+/**
+ * @brief Get the address of the lowest numbered endpoint in a bitmap
+ *
+ * @param[in] ep_bm  Endpoint bitmap, must not be zero
+ *
+ * @return Endpoint address
+ */
+static inline uint8_t usbd_ep_bm_get_first(const uint32_t ep_bm)
+{
+	const unsigned int bit = find_lsb_set(ep_bm) - 1U;
+
+	if (bit >= 16U) {
+		return USB_EP_DIR_IN | (bit - 16U);
 	}
 
-	return (*ep_bm & BIT(bit)) ? true : false;
+	return bit;
 }
 
 /**

--- a/subsys/usb/device_next/usbd_init.c
+++ b/subsys/usb/device_next/usbd_init.c
@@ -62,34 +62,19 @@ static int assign_ep_addr(const struct device *dev,
 }
 
 /* Unassign all endpoint of a class instance based on class_ep_bm */
-static int unassign_eps(struct usbd_context *const uds_ctx,
-			uint32_t *const config_ep_bm,
+static int unassign_eps(uint32_t *const config_ep_bm,
 			uint32_t *const class_ep_bm)
 {
-	for (unsigned int idx = 1; idx < 16U && *class_ep_bm; idx++) {
-		uint8_t ep_in = USB_EP_DIR_IN | idx;
-		uint8_t ep_out = idx;
+	const uint32_t not_assigned = *class_ep_bm & ~*config_ep_bm;
 
-		if (usbd_ep_bm_is_set(class_ep_bm, ep_in)) {
-			if (!usbd_ep_bm_is_set(config_ep_bm, ep_in)) {
-				LOG_ERR("Endpoing 0x%02x not assigned", ep_in);
-				return -EINVAL;
-			}
-
-			usbd_ep_bm_clear(config_ep_bm, ep_in);
-			usbd_ep_bm_clear(class_ep_bm, ep_in);
-		}
-
-		if (usbd_ep_bm_is_set(class_ep_bm, ep_out)) {
-			if (!usbd_ep_bm_is_set(config_ep_bm, ep_out)) {
-				LOG_ERR("Endpoing 0x%02x not assigned", ep_out);
-				return -EINVAL;
-			}
-
-			usbd_ep_bm_clear(config_ep_bm, ep_out);
-			usbd_ep_bm_clear(class_ep_bm, ep_out);
-		}
+	if (not_assigned != 0U) {
+		LOG_ERR("Endpoint 0x%02x not assigned",
+			usbd_ep_bm_get_first(not_assigned));
+		return -EINVAL;
 	}
+
+	*config_ep_bm &= ~*class_ep_bm;
+	*class_ep_bm = 0U;
 
 	return 0;
 }
@@ -159,7 +144,7 @@ static int init_configuration_inst(struct usbd_context *const uds_ctx,
 				 * characteristics of endpoints in alternate
 				 * interfaces are ascending.
 				 */
-				unassign_eps(uds_ctx, config_ep_bm, &class_ep_bm);
+				unassign_eps(config_ep_bm, &class_ep_bm);
 			}
 
 			class_ep_bm = 0;
@@ -245,7 +230,7 @@ static int init_configuration(struct usbd_context *const uds_ctx,
 	/* Finally reset configuration's endpoint assignment */
 	SYS_SLIST_FOR_EACH_CONTAINER(&cfg_nd->class_list, c_nd, node) {
 		c_nd->ep_assigned = c_nd->ep_active;
-		ret = unassign_eps(uds_ctx, &config_ep_bm, &c_nd->ep_active);
+		ret = unassign_eps(&config_ep_bm, &c_nd->ep_active);
 		if (ret != 0) {
 			return ret;
 		}

--- a/subsys/usb/device_next/usbd_interface.c
+++ b/subsys/usb/device_next/usbd_interface.c
@@ -115,23 +115,14 @@ int usbd_interface_shutdown(struct usbd_context *const uds_ctx,
 	SYS_SLIST_FOR_EACH_CONTAINER(&cfg_nd->class_list, c_nd, node) {
 		uint32_t *ep_bm = &c_nd->ep_active;
 
-		for (int idx = 1; idx < 16 && *ep_bm; idx++) {
-			uint8_t ep_in = USB_EP_DIR_IN | idx;
-			uint8_t ep_out = idx;
+		while (*ep_bm) {
+			const uint8_t ep = usbd_ep_bm_get_first(*ep_bm);
 			int ret;
 
-			if (usbd_ep_bm_is_set(ep_bm, ep_in)) {
-				ret = usbd_ep_disable(uds_ctx->dev, ep_in, ep_bm);
-				if (ret) {
-					return ret;
-				}
-			}
-
-			if (usbd_ep_bm_is_set(ep_bm, ep_out)) {
-				ret = usbd_ep_disable(uds_ctx->dev, ep_out, ep_bm);
-				if (ret) {
-					return ret;
-				}
+			/* usbd_ep_disable() clears the bit whenever it returns success */
+			ret = usbd_ep_disable(uds_ctx->dev, ep, ep_bm);
+			if (ret) {
+				return ret;
 			}
 		}
 	}


### PR DESCRIPTION
The endpoint bitmap maps OUT endpoints to bits 0 to 15 and IN endpoints to bits 16 to 31, but every helper rediscovered that mapping, and both walks over a whole bitmap iterated indices 1 to 15 testing the IN and the OUT bit separately.

Add `usbd_ep_bm_bit()` and `usbd_ep_bm_get_first()` and build on them. `unassign_eps()` becomes three bitmask operations, `usbd_interface_shutdown()` loops over the lowest set bit. Endpoints are now disabled in ascending bit order instead of interleaved per index, and the unreachable `unassign_eps()` error path no longer partially clears what it processed.

**<ins>Saves 96 bytes of ROM</ins>** in a cdc_acm build for nrf52840dk/nrf52840. `tests/subsys/usb/device_next` passes on qemu_cortex_m3.