### PR TITLE
tests: drivers: can: api: set heap size for dynamic object allocation

### DIFF
--- a/tests/drivers/can/api/prj.conf
+++ b/tests/drivers/can/api/prj.conf
@@ -9,6 +9,7 @@ CONFIG_TEST_USERSPACE=y
 CONFIG_ZTEST=y
 # Needed by test_add_rx_filter_msgq_dynamic, which expects a kernel oops
 CONFIG_ZTEST_FATAL_HOOK=y
+CONFIG_HEAP_MEM_POOL_SIZE=512
 # Global default settings assign both the ZTest thread and the system worker queue to the same
 # cooperative priority. Relying solely on the system worker queue for concurrency management can
 # lead to unwanted interference between the two threads, causing the test to report its expected

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -732,7 +732,6 @@ ZTEST_USER(can_classic, test_max_ext_filters)
 	add_remove_max_filters(true);
 }
 
-#if defined(CONFIG_USERSPACE) && defined(CONFIG_DYNAMIC_OBJECTS)
 /**
  * @brief Test that a dynamically allocated message queue is rejected from user mode.
  *
@@ -748,6 +747,8 @@ ZTEST_USER(can_classic, test_add_rx_filter_msgq_dynamic)
 	struct k_msgq *msgq;
 	int err;
 
+	Z_TEST_SKIP_IFNDEF(CONFIG_DYNAMIC_OBJECTS);
+
 	msgq = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(msgq, "failed to allocate message queue object");
 
@@ -759,7 +760,6 @@ ZTEST_USER(can_classic, test_add_rx_filter_msgq_dynamic)
 
 	zassert_unreachable("dynamically allocated message queue was accepted");
 }
-#endif /* CONFIG_USERSPACE && CONFIG_DYNAMIC_OBJECTS */
 
 /**
  * @brief Test that no message is received when nothing was sent.

--- a/tests/drivers/can/api/tests.yaml
+++ b/tests/drivers/can/api/tests.yaml
@@ -3,6 +3,7 @@ common:
     - drivers
     - can
   depends_on: can
+  ignore_faults: true
 tests:
   drivers.can.api:
     integration_platforms:


### PR DESCRIPTION
Set a heap size of 512 bytes for allocation of dynamic kernel objects.

Use `Z_TEST_SKIP_IFNDEF(CONFIG_DYNAMIC_OBJECTS)` instead of `#ifdef`'s for skipping the `test_add_rx_filter_msgq_dynamic()` test case. Since `CONFIG_DYNAMIC_OBJECTS` already depends on `CONFIG_USERSPACE`, we can leave that out.
    
Using `Z_TEST_SKIP_IFNDEF()` makes it clear that the test was skipped, not  just missing.

Fixes: #118145
