### PR TITLE
include: unify and correct the empty-struct C/C++ comments

### DIFF
--- a/include/zephyr/arch/arm/structs.h
+++ b/include/zephyr/arch/arm/structs.h
@@ -29,8 +29,8 @@ struct _cpu_arch {
 /* Per CPU architecture specifics (empty) */
 struct _cpu_arch {
 #ifdef __cplusplus
-	/* This struct will have a size 0 in C which is not allowed in C++ (it'll have a size 1). To
-	 * prevent this, we add a 1 byte dummy variable.
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
 	 */
 	uint8_t dummy;
 #endif

--- a/include/zephyr/arch/arm64/structs.h
+++ b/include/zephyr/arch/arm64/structs.h
@@ -20,8 +20,8 @@ struct _cpu_arch {
 #endif
 #if !defined(CONFIG_FPU_SHARING) && !defined(CONFIG_ARM64_SAFE_EXCEPTION_STACK) &&                 \
 	defined(__cplusplus)
-	/* This struct will have a size 0 in C which is not allowed in C++ (it'll have a size 1). To
-	 * prevent this, we add a 1 byte dummy variable.
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
 	 */
 	uint8_t dummy;
 #endif

--- a/include/zephyr/arch/structs.h
+++ b/include/zephyr/arch/structs.h
@@ -40,8 +40,8 @@
 /* Per CPU architecture specifics (empty) */
 struct _cpu_arch {
 #ifdef __cplusplus
-	/* This struct will have a size 0 in C which is not allowed in C++ (it'll have a size 1). To
-	 * prevent this, we add a 1 byte dummy variable.
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
 	 */
 	uint8_t dummy;
 #endif

--- a/include/zephyr/arch/x86/ia32/structs.h
+++ b/include/zephyr/arch/x86/ia32/structs.h
@@ -32,7 +32,9 @@ struct _cpu_arch {
 #endif
 #if defined(__cplusplus) && !defined(CONFIG_FPU_SHARING) && \
 		!defined(CONFIG_HW_SHADOW_STACK)
-	/* Ensure this struct does not have a size of 0 which is not allowed in C++. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t dummy;
 #endif
 };

--- a/include/zephyr/arch/xtensa/structs.h
+++ b/include/zephyr/arch/xtensa/structs.h
@@ -15,7 +15,9 @@ struct _cpu_arch {
 	atomic_ptr_val_t save_hifi;  /* Save HiFi on IPI if match hifi_owner */
 #endif
 #elif defined(__cplusplus)
-	/* Ensure this struct does not have a size of 0 which is not allowed in C++. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t dummy;
 #endif
 };

--- a/include/zephyr/drivers/display/color_dither.h
+++ b/include/zephyr/drivers/display/color_dither.h
@@ -193,7 +193,9 @@ struct display_color_dither_state {
 	/** Number of elements in each error-diffusion row buffer. */
 	size_t err_row_len;
 #elif defined(CONFIG_CPP)
-	/* C++ does not allow empty structs, add an extra 1 byte. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif /* CONFIG_DISPLAY_COLOR_DITHER */
 };

--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -239,9 +239,8 @@ typedef struct k_thread_runtime_stats {
 
 #if defined(__cplusplus) && !defined(CONFIG_SCHED_THREAD_USAGE) &&                                 \
 	!defined(CONFIG_SCHED_THREAD_USAGE_ANALYSIS) && !defined(CONFIG_SCHED_THREAD_USAGE_ALL)
-	/* If none of the above Kconfig values are defined, this struct will have a size 0 in C
-	 * which is not allowed in C++ (it'll have a size 1). To prevent this, we add a 1 byte dummy
-	 * variable when the struct would otherwise be empty.
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
 	 */
 	uint8_t dummy;
 #endif

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -272,7 +272,9 @@ struct mqtt_topic_alias {
 	/** Topic name size. */
 	uint16_t topic_size;
 #elif defined(CONFIG_CPP)
-	/* C++ does not allow empty structs, add an extra 1 byte. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
@@ -437,7 +439,9 @@ struct mqtt_common_ack_properties {
 		bool has_user_prop;
 	} rx;
 #elif defined(CONFIG_CPP)
-	/* C++ does not allow empty structs, add an extra 1 byte. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
@@ -658,7 +662,9 @@ struct mqtt_disconnect_param {
 		} rx;
 	} prop;
 #elif defined(CONFIG_CPP)
-	/* C++ does not allow empty structs, add an extra 1 byte. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };
@@ -695,7 +701,9 @@ struct mqtt_auth_param {
 		} rx;
 	} prop;
 #elif defined(CONFIG_CPP)
-	/* C++ does not allow empty structs, add an extra 1 byte. */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif /* CONFIG_MQTT_VERSION_5_0 */
 };

--- a/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
+++ b/subsys/testsuite/ztest/unittest/include/zephyr/arch/cpu.h
@@ -15,7 +15,9 @@ extern "C" {
 /* Architecture thread structure */
 struct _callee_saved {
 #ifdef CONFIG_CPP
-	/* C++ does not allow empty structs, add an extra 1 byte */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif
 };
@@ -24,7 +26,9 @@ typedef struct _callee_saved _callee_saved_t;
 
 struct _thread_arch {
 #ifdef CONFIG_CPP
-	/* C++ does not allow empty structs, add an extra 1 byte */
+	/* An empty struct is not valid C, and compilers that accept it give
+	 * it size 0 while C++ gives 1. Keep a byte so both languages agree.
+	 */
 	uint8_t c;
 #endif
 };


### PR DESCRIPTION
Copies of this comment variously claim that C++ does not allow empty structs, or that a size of zero is not allowed in C++. Both have it backwards: C++ allows an empty struct and gives it size 1, while ISO C does not allow one at all, and the compilers that accept it as an extension give it size 0. That disagreement is the actual reason these padding members exist in the first place.