### PR TITLE
net: tcp: fix frag chain UAF in tcp_pkt_linearize

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -171,11 +171,18 @@ static int tcp_pkt_linearize(struct net_pkt *pkt, size_t pos, size_t len)
 
 		len2 -= pull_len;
 		net_buf_pull(second, pull_len);
-		next = second->frags;
+
+		/* Only discard an emptied buffer. Detach its frag chain first:
+		 * net_buf_unref() frees the entire frags list, which would
+		 * otherwise drop remaining payload buffers still needed below.
+		 * If second still has data, it holds leftover payload - keep it.
+		 */
 		if (second->len == 0) {
+			next = second->frags;
+			second->frags = NULL;
 			net_buf_unref(second);
+			second = next;
 		}
-		second = next;
 	}
 
 	buf->frags = second;

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -38,6 +38,10 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_TCP_LOG_LEVEL);
 #define MY_PORT 4242
 #define PEER_PORT 4242
 
+#define LINEARIZE_TCP_FIRST 8
+#define LINEARIZE_TCP_REST  (NET_TCPH_LEN - LINEARIZE_TCP_FIRST)
+#define LINEARIZE_PAYLOAD   16
+
 /* Data (1280 bytes) to be sent */
 static const char lorem_ipsum[] = LOREM_IPSUM;
 
@@ -118,6 +122,7 @@ static enum test_case_no {
 	TEST_SERVER_FIN_ACK_AFTER_DATA = 21,
 	TEST_SERVER_RST_ON_CLOSED_PORT_FIN = 22,
 	TEST_ADVERTISED_RECV_WINDOW = 23,
+	TEST_TCP_PKT_LINEARIZE_FRAG_CHAIN = 24,
 } test_case_no;
 
 static enum test_state t_state;
@@ -562,6 +567,9 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 		break;
 	case TEST_SERVER_FIN_ACK_AFTER_DATA:
 		handle_server_fin_ack_after_data_test(net_pkt_family(pkt), &th);
+		break;
+	case TEST_TCP_PKT_LINEARIZE_FRAG_CHAIN:
+		/* Ignore RST/response TX while exercising tcp_pkt_linearize(). */
 		break;
 	default:
 		zassert_true(false, "Undefined test case");
@@ -3441,6 +3449,98 @@ ZTEST(net_tcp, test_contiguous_tx)
 
 	zassert_equal(data_payload_len, 1,
 		      "Unexpected data segment payload length %zu (expected 1)", data_payload_len);
+}
+
+/*
+ * Reproduce tcp_pkt_linearize() frag-chain UAF/double-free:
+ * TCP header split across net_buf fragments with leftover payload frags.
+ *
+ * Layout after rebuild:
+ *   b0: [IPv4 20][TCP first 8]
+ *   b1: [TCP last 12]          <- emptied then unref'd (bug frees b2 too)
+ *   b2: [payload]
+ *
+ * Path: net_recv_data -> net_tcp_input (stack copy OK) -> no listener ->
+ *        net_tcp_reply_rst -> th_get -> tcp_pkt_linearize.
+ */
+
+static void tcp_pkt_rebuild_split_tcp_header(struct net_pkt *pkt)
+{
+	uint8_t copy[NET_IPV4H_LEN + NET_TCPH_LEN + LINEARIZE_PAYLOAD];
+	struct net_buf *frag;
+	struct net_buf *b0;
+	struct net_buf *b1;
+	struct net_buf *b2;
+	size_t len;
+
+	len = net_pkt_get_len(pkt);
+	zassert_equal(len, sizeof(copy), "unexpected pkt len %zu", len);
+
+	net_pkt_cursor_init(pkt);
+	zassert_ok(net_pkt_read(pkt, copy, len));
+
+	while (pkt->buffer) {
+		frag = pkt->buffer;
+		pkt->buffer = frag->frags;
+		frag->frags = NULL;
+		net_buf_unref(frag);
+	}
+
+	b0 = net_pkt_get_frag(pkt, NET_IPV4H_LEN + LINEARIZE_TCP_FIRST, K_NO_WAIT);
+	zassert_not_null(b0);
+	net_buf_add_mem(b0, copy, NET_IPV4H_LEN + LINEARIZE_TCP_FIRST);
+	net_pkt_frag_add(pkt, b0);
+
+	b1 = net_pkt_get_frag(pkt, LINEARIZE_TCP_REST, K_NO_WAIT);
+	zassert_not_null(b1);
+	net_buf_add_mem(b1, copy + NET_IPV4H_LEN + LINEARIZE_TCP_FIRST, LINEARIZE_TCP_REST);
+	net_pkt_frag_add(pkt, b1);
+
+	b2 = net_pkt_get_frag(pkt, LINEARIZE_PAYLOAD, K_NO_WAIT);
+	zassert_not_null(b2);
+	net_buf_add_mem(b2, copy + NET_IPV4H_LEN + NET_TCPH_LEN, LINEARIZE_PAYLOAD);
+	net_pkt_frag_add(pkt, b2);
+
+	net_pkt_set_overwrite(pkt, true);
+	net_pkt_set_ip_hdr_len(pkt, NET_IPV4H_LEN);
+	net_pkt_set_ipv4_opts_len(pkt, 0);
+	net_pkt_cursor_init(pkt);
+	zassert_ok(net_pkt_skip(pkt, NET_IPV4H_LEN));
+	zassert_false(net_pkt_is_contiguous(pkt, NET_TCPH_LEN),
+		      "TCP header unexpectedly contiguous");
+	net_pkt_cursor_init(pkt);
+}
+
+ZTEST(net_tcp, test_tcp_pkt_linearize_frag_chain)
+{
+	struct net_pkt *pkt;
+	uint8_t payload[LINEARIZE_PAYLOAD];
+	int ret;
+	int i;
+
+	test_case_no = TEST_TCP_PKT_LINEARIZE_FRAG_CHAIN;
+	seq = 1U;
+	ack = 0U;
+
+	for (i = 0; i < LINEARIZE_PAYLOAD; i++) {
+		payload[i] = (uint8_t)i;
+	}
+
+	/* Unbound dst port -> RST path calls th_get()/tcp_pkt_linearize(). */
+	pkt = tester_prepare_tcp_pkt(NET_AF_INET, net_htons(PEER_PORT),
+				     net_htons(9999), SYN, payload,
+				     sizeof(payload));
+	zassert_not_null(pkt, "failed to allocate TCP pkt");
+
+	tcp_pkt_rebuild_split_tcp_header(pkt);
+
+	ret = net_recv_data(net_iface, pkt);
+	zassert_equal(ret, 0, "net_recv_data failed (%d)", ret);
+
+	/* Allow RX/TCP work to finish (RST reply, pkt teardown).
+	 * On the buggy code path this panics with a net_buf double-free.
+	 */
+	k_msleep(50);
 }
 
 /* Always clear the TX intercept hook after every test so a test that installs


### PR DESCRIPTION
## Problem

`tcp_pkt_linearize()` (used by `th_get()` when a received TCP header is not
contiguous in a single `net_buf`) could corrupt the packet's fragment chain
on the RX path.

## Root Cause

While removing TCP header bytes from following `net_buf` fragments, the loop:

1. Called `net_buf_unref()` on each emptied buffer **without** clearing
   `second->frags` first. `net_buf_unref()` frees the **entire** frag list, so
   remaining payload buffers linked from that fragment were freed too. The
   code then reattached that freed pointer (`buf->frags = second`), causing
   **use-after-free / double-free** during later packet teardown.

2. Always advanced to `second->frags` even when the current buffer still held
   data after the header bytes were pulled. If the TCP header remainder and
   payload shared one `net_buf`, that leftover payload was orphaned/dropped.

This can occur on RX when the frame is split across buffers (e.g. small RX
buffers, IP reassembly)

## Fix

- Detach the frag list before unref: save `next`, set `second->frags = NULL`,
  then `net_buf_unref(second)`.
- Advance to the next fragment only when `second->len == 0`; if data remains,
  keep that buffer as the start of the payload chain.

This matches the usual net stack ownership pattern (detach before unref).

## Validation

Added regression test in `tests/net/tcp`:
- `test_tcp_pkt_linearize_frag_chain`

It rebuilds an IPv4 TCP packet so the TCP header spans multiple `net_buf`s
with payload in a following fragment, then injects it toward an unbound port
so `th_get()` / `tcp_pkt_linearize()` runs via the RST path.

- Before fix: panics with `net_buf` double-free
- After fix: test passes

Also ran the full `tests/net/tcp` suite successfully.

## Commits

1. Fix in `subsys/net/ip/tcp.c`
2. Regression test in `tests/net/tcp/src/main.c`