### PR TITLE
net: ethernet: mcast: remove mcast address on device fail

### DIFF
--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -394,7 +394,11 @@ out:
 	if (program) {
 		ret = ethernet_mcast_filter_set(iface, addr, true);
 		if (ret == -ENOTSUP) {
-			ret = 0;
+			return 0;
+		}
+
+		if (ret < 0) {
+			(void)net_eth_mcast_addr_rm(iface, addr);
 		}
 	}
 

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -720,14 +720,6 @@ static int mcast_membership_add(struct net_context *ctx, struct net_if *iface,
 
 	ret = mcast_membership_l2(iface, addr, true);
 	if (ret < 0) {
-		/* The group was not joined, so give the entry back. The L2 is
-		 * told to leave the group as well, as it takes the address
-		 * into use before it programs it and keeps it if the device
-		 * refuses. Leaving a group that was never joined is harmless,
-		 * it just fails with -ENOENT.
-		 */
-		(void)mcast_membership_l2(iface, addr, false);
-
 		k_mutex_lock(&mcast_lock, K_FOREVER);
 
 		if (free_entry->ctx == ctx &&

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -2144,12 +2144,7 @@ ZTEST(socket_packet, test_packet_sock_membership_eth_filter_mgmt_errors)
 
 	eth_filter_ret = 0;
 
-	/* The address was taken into use even though the device refused it,
-	 * so it can be given back.
-	 */
-	ret = net_eth_mac_filter(ud.first, &mac,
-				 ETHERNET_FILTER_TYPE_DST_MAC_ADDRESS, false);
-	zassert_ok(ret, "Cannot unset the filter (%d)", ret);
+	/* The address was removed because the device refused it. */
 	zassert_equal(eth_filter_data.count, 2, "Filter not removed");
 	zassert_false(eth_filter_data.set, "Filter not disabled");
 }


### PR DESCRIPTION
Don't leave it up to the user to remove that address, if programming that address to the ethernet controller fails.
