### PR TITLE
arch: arm64: fix arch_early_memset() for unaligned dst and short lengths

### DIFF
--- a/arch/arm64/core/early_mem_funcs.S
+++ b/arch/arm64/core/early_mem_funcs.S
@@ -46,7 +46,7 @@ SECTION_FUNC(TEXT, arch_early_memset)
 
 3:	/* one byte at a time */
 	subs	x2, x2, #1
-	strb	w8, [x0], #1
+	strb	w1, [x0], #1
 	b.ne	3b
 
 4:	ret

--- a/tests/arch/arm64/arm64_early_mem_funcs/CMakeLists.txt
+++ b/tests/arch/arm64/arm64_early_mem_funcs/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(early_mem_funcs)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/arch/arm64/arm64_early_mem_funcs/prj.conf
+++ b/tests/arch/arm64/arm64_early_mem_funcs/prj.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y

--- a/tests/arch/arm64/arm64_early_mem_funcs/src/main.c
+++ b/tests/arch/arm64/arm64_early_mem_funcs/src/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/arch/common/init.h>
+
+#define BUF_SIZE 64
+
+static ZTEST_BMEM __aligned(8) uint8_t buf[BUF_SIZE];
+
+/*
+ * Fill buf with zeros, call arch_early_memset() on buf[off .. off + n) and
+ * verify that exactly those bytes hold the fill value.
+ */
+static void check_early_memset(size_t off, uint8_t val, size_t n)
+{
+	zassert_true(off + n <= BUF_SIZE, "test case overruns buf");
+
+	memset(buf, 0, sizeof(buf));
+
+	arch_early_memset(buf + off, val, n);
+
+	for (size_t i = 0; i < BUF_SIZE; i++) {
+		uint8_t expect = (i >= off && i < off + n) ? val : 0x00;
+
+		zassert_equal(buf[i], expect,
+			      "byte %zu: got 0x%02x, want 0x%02x",
+			      i, buf[i], expect);
+	}
+}
+
+ZTEST(early_mem_funcs, test_unaligned_dst)
+{
+	/* unaligned destination, length < 8 */
+	check_early_memset(1, 0xAA, 4);
+	/* unaligned destination, length > 8 */
+	check_early_memset(3, 0x5A, 17);
+}
+
+ZTEST(early_mem_funcs, test_aligned_dst)
+{
+	/* aligned destination, length < 8 */
+	check_early_memset(0, 0xC3, 3);
+	/* aligned destination, 8-byte loop plus a tail */
+	check_early_memset(0, 0x11, 21);
+	/* aligned destination, exact multiple of 8 */
+	check_early_memset(8, 0x80, 32);
+	/* aligned destination, exact fast-path boundary (n == 8) */
+	check_early_memset(0, 0x33, 8);
+	/* 0xFF through the 8-byte loop (all-ones multiplication boundary) */
+	check_early_memset(0, 0xFF, 9);
+	/* fill value 0x00 through both the loop and the byte path */
+	check_early_memset(0, 0x00, 9);
+}
+
+ZTEST(early_mem_funcs, test_zero_length)
+{
+	/* nothing must be written, aligned or not */
+	check_early_memset(0, 0xFF, 0);
+	check_early_memset(2, 0xFF, 0);
+}
+
+ZTEST_SUITE(early_mem_funcs, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/arm64/arm64_early_mem_funcs/tests.yaml
+++ b/tests/arch/arm64/arm64_early_mem_funcs/tests.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - arm64
+tests:
+  arch.arm64.early_mem_funcs:
+    platform_allow:
+      - qemu_cortex_a53
+      - qemu_cortex_a53/qemu_cortex_a53/smp
+    integration_platforms:
+      - qemu_cortex_a53


### PR DESCRIPTION
`arch_early_memset()` writes garbage instead of the requested fill value whenever the destination is not 8-byte aligned or the length is less than 8 bytes: the fill register `x8` is only initialized inside the "aligned dst && n >= 8" branch, so the trailing byte loop stores stale register content. 

1. **arch: arm64: fix arch_early_memset() for unaligned dst and short lengths** — moves the fill-value initialization above the alignment/size tests so `x8` is always valid. Behavior of the aligned fast path is unchanged (same instructions, earlier  scheduling). 
2. **tests: arm64: add regression test for arch_early_memset()** — new Ztest suite `tests/arch/arm64/arm64_early_mem_funcs` covering both  the fast path and the byte loop: unaligned destinations, short lengths, 8-byte loop tails, the exact `n == 8` fast-path boundary, zero length and zero fill, with full-buffer expected-byte checking.

Fixes #118341