### PR TITLE
MAINTAINERS: add ARM arch (pre-Cortex) area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -339,6 +339,17 @@ ARM arch:
     - arch
     - kernel
 
+ARM arch (pre-Cortex):
+  status: maintained
+  maintainers:
+    - jetpax
+  files-regex:
+    - ^arch/arm/core/armv6/
+  labels:
+    - "area: ARM"
+  tests:
+    - arch.arm
+
 ARM64 arch:
   status: maintained
   maintainers:


### PR DESCRIPTION
Adds a dedicated MAINTAINERS.yml area for classic (pre-Cortex) Arm architecture support, as requested by @ithinuel in #112663: pre-Cortex work (ARMv6/ARM1176 in #112663, ARM9/ARMv5 proposed in #103557) currently falls implicitly under the Cortex-focused ARM arch area, where no reviewers with classic-Arm expertise are available.

Volunteering as maintainer: I authored the ARMv6 port, have twelve merged PRs in-tree including the Raspberry Pi Zero 2 W board and SoC foundation (#110189), maintain downstream hardware that runs this support, and four in-tree dependants are staged behind #112663 (#112673, #112674, #112675, #112728).

Scope starts minimal: the ARMv6 profile directory that #112663 introduces, expressed as `files-regex` because `get_maintainer.py` requires plain `files` globs to match existing files and the directory arrives with that PR. Per the process notes the exact scope and ownership are settled here; drawing it as pre-Cortex generally would also give the ARM9 work a home, and @TonyHan11 would be welcome as a collaborator or co-maintainer on it if they wish.
