### PR TITLE
cmake: Fix build type warning after optimization flag rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2386,9 +2386,9 @@ if((CMAKE_BUILD_TYPE IN_LIST build_types) AND (NOT NO_BUILD_TYPE_WARNING))
   # optimization flag is present in that string.
   # To avoid false-positive matches, the flag must either be matched first
   # or last in string, or come after / followed by minimum a space.
-  if(NOT (CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase} MATCHES "(^| )${OPTIMIZATION_FLAG}($| )"))
+  if(NOT (CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_uppercase} MATCHES "(^| )${COMPILER_OPTIMIZATION_FLAG}($| )"))
     message(WARNING "
-      The CMake build type was set to '${CMAKE_BUILD_TYPE}', but the optimization flag was set to '${OPTIMIZATION_FLAG}'.
+      The CMake build type was set to '${CMAKE_BUILD_TYPE}', but the optimization flag was set to '${COMPILER_OPTIMIZATION_FLAG}'.
       This may be intentional and the warning can be turned off by setting the CMake variable 'NO_BUILD_TYPE_WARNING'"
       )
   endif()


### PR DESCRIPTION
The `CMAKE_BUILD_TYPE` / optimization mismatch check matches `CMAKE_C_FLAGS_<build_type>`
against `OPTIMIZATION_FLAG`, which is no longer set: commit a4b66f921405 ("cmake: assembler
optimization options") renamed it to `COMPILER_OPTIMIZATION_FLAG`, and this check was not
updated.

The empty expansion reduces the regex to `(^| )($| )`, which matches only an empty string or
one starting with a space. The warning therefore fires for every `CMAKE_BUILD_TYPE`, whatever
optimization level Kconfig selected - including when the two agree, e.g. `MinSizeRel` with the
default `CONFIG_SIZE_OPTIMIZATIONS` - and reports an empty flag:

```
cmake -B /tmp/foo -S zephyr/samples/hello_world/ -DBOARD=native_sim -DCMAKE_BUILD_TYPE=MinSizeRel
The CMake build type was set to 'Debug', but the optimization flag was set to ''.
```

Broken since v4.3.0; v4.2.0 still sets the old name. Match against
`COMPILER_OPTIMIZATION_FLAG` instead, the flag applied to the C compiler and therefore the
counterpart of `CMAKE_C_FLAGS_*`.

Verified by evaluating the comparison for every build type against CMake's GNU defaults:
afterwards `MinSizeRel`/`-Os` and `RelWithDebInfo`/`-O2` are silent, and real mismatches still
warn.
