### PR TITLE
mgmt: mcumgr: route SMP responses only to their own transport

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1900,6 +1900,16 @@ MCUmgr
   :ref:`mcumgr_os_application_info` command now always reports the board target as hardware
   platform; the pre-4.3 board and board revision output is no longer available.
 
+* :c:func:`smp_client_single_response` takes the SMP transport the response arrived on as its
+  first argument, so that a response can only complete a command that was sent on that same
+  transport. Callers outside the SMP stack, which are expected to be rare, need to pass the
+  transport; an SMP client has it in ``smp_client->smpt``.
+
+  A response is also now required to carry the same management group and command id as the
+  command it completes, where a matching sequence number and operation used to be enough. A
+  client that relied on a response completing a command it does not answer will see that
+  command time out and retry instead.
+
 Random
 ======
 

--- a/include/zephyr/mgmt/mcumgr/smp/smp_client.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp_client.h
@@ -92,13 +92,18 @@ typedef int (*smp_client_res_fn)(struct net_buf *nb, void *user_data);
 /**
  * @brief SMP client response handler.
  *
+ * Only a command that was sent on @p smpt can be completed by this response, so a
+ * response arriving on one transport never completes a command issued on another.
+ *
+ * @param smpt SMP transport the response arrived on
  * @param nb response net_buf
  * @param res_hdr Parsed SMP header
  *
  * @return 0 on success.
  * @return @ref mcumgr_err_t code on failure.
  */
-int smp_client_single_response(struct net_buf *nb, const struct smp_hdr *res_hdr);
+int smp_client_single_response(const struct smp_transport *smpt, struct net_buf *nb,
+			       const struct smp_hdr *res_hdr);
 
 /**
  * @brief Allocate buffer and initialize with SMP header.

--- a/subsys/mgmt/mcumgr/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/smp/src/smp.c
@@ -518,7 +518,7 @@ int smp_process_request_packet(struct smp_streamer *streamer, void *vreq)
 #endif
 
 #if defined(CONFIG_SMP_CLIENT)
-			rc = smp_client_single_response(req, &req_hdr);
+			rc = smp_client_single_response(streamer->smpt, req, &req_hdr);
 
 			if (rc == MGMT_ERR_EOK) {
 				handler_found = true;

--- a/subsys/mgmt/mcumgr/smp_client/src/client.c
+++ b/subsys/mgmt/mcumgr/smp_client/src/client.c
@@ -181,7 +181,8 @@ static void smp_client_cmd_req_free(struct smp_client_cmd_req *cmd_req)
 	}
 }
 
-static struct smp_client_cmd_req *smp_client_response_discover(const struct smp_hdr *res_hdr)
+static struct smp_client_cmd_req *smp_client_response_discover(const struct smp_transport *smpt,
+							       const struct smp_hdr *res_hdr)
 {
 	struct smp_hdr smp_header;
 	enum mcumgr_op_t response;
@@ -192,6 +193,17 @@ static struct smp_client_cmd_req *smp_client_response_discover(const struct smp_
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&smp_client_data.cmd_list, cmd_req, node) {
+		/* A response is only an answer to a command that went out on the same
+		 * transport. Without this the sequence number, which is eight bits and
+		 * per client rather than per transport, is the only thing standing
+		 * between a pending command and a response injected by whoever else can
+		 * reach this device on another transport. It is also the cheapest and
+		 * most selective of the tests, so it runs before the header is parsed.
+		 */
+		if (cmd_req->smp_client->smpt != smpt) {
+			continue;
+		}
+
 		smp_read_hdr(cmd_req->nb, &smp_header);
 		if (smp_header.nh_op == MGMT_OP_READ) {
 			response = MGMT_OP_READ_RSP;
@@ -202,6 +214,19 @@ static struct smp_client_cmd_req *smp_client_response_discover(const struct smp_
 		if (smp_header.nh_seq != res_hdr->nh_seq) {
 			continue;
 		} else if (res_hdr->nh_op != response) {
+			continue;
+		}
+
+		/* The sequence number wraps every 256 commands and every group client
+		 * on a device shares this one command list, so the sequence number
+		 * alone does not tell one pending command from another. None of the
+		 * response callbacks re-check the group or the command they asked for,
+		 * which makes this the only place a mismatch can be caught. An error
+		 * response carries the request's group and id, so matching on them does
+		 * not lose it.
+		 */
+		if (smp_header.nh_group != res_hdr->nh_group ||
+		    smp_header.nh_id != res_hdr->nh_id) {
 			continue;
 		}
 
@@ -224,14 +249,15 @@ int smp_client_object_init(struct smp_client_object *smp_client, int smp_type)
 	return MGMT_ERR_EOK;
 }
 
-int smp_client_single_response(struct net_buf *nb, const struct smp_hdr *res_hdr)
+int smp_client_single_response(const struct smp_transport *smpt, struct net_buf *nb,
+			       const struct smp_hdr *res_hdr)
 {
 	struct smp_client_cmd_req *cmd_req;
 	smp_client_res_fn cb;
 	void *user_data;
 
 	/* Discover request for incoming response */
-	cmd_req = smp_client_response_discover(res_hdr);
+	cmd_req = smp_client_response_discover(smpt, res_hdr);
 	LOG_DBG("Response Header len %d, flags %d OP: %d group %d id %d seq %d", res_hdr->nh_len,
 		res_hdr->nh_flags, res_hdr->nh_op, res_hdr->nh_group, res_hdr->nh_id,
 		res_hdr->nh_seq);

--- a/tests/subsys/mgmt/mcumgr/mcumgr_client/src/smp_stub.c
+++ b/tests/subsys/mgmt/mcumgr/mcumgr_client/src/smp_stub.c
@@ -98,7 +98,7 @@ static int smp_uart_tx_pkt(struct net_buf *nb)
 static void smp_client_handle_reqs(struct k_work *work)
 {
 	if (response_buf) {
-		smp_client_single_response(response_buf, &res_hdr);
+		smp_client_single_response(&smpt_test, response_buf, &res_hdr);
 	}
 }
 

--- a/tests/subsys/mgmt/mcumgr/smp_client/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/smp_client/src/main.c
@@ -92,19 +92,112 @@ ZTEST(smp_client, test_msg_response_handler)
 	zassert_not_null(b, "Buffer was Null");
 	/* Read Pushed packet Header */
 	smp_transport_read_hdr(a, &dst_hdr);
-	smp_client_single_response(b, &dst_hdr);
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
 	zassert_is_null(res_buf, "NULL pointer was not returned");
 	zassert_is_null(response_ptr, "NULL pointer was not returned");
 	/* Set Correct OP */
 	dst_hdr.nh_op = MGMT_OP_WRITE_RSP;
-	smp_client_single_response(b, &dst_hdr);
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
 	zassert_equal_ptr(res_buf, b, "Response Buf not correct");
 	zassert_equal_ptr(response_ptr, &testing_user_data, "User data not returned correctly");
 	response_ptr = NULL;
 	res_buf = NULL;
-	smp_client_single_response(b, &dst_hdr);
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
 	zassert_is_null(res_buf, "NULL pointer was not returned");
 	zassert_is_null(response_ptr, "NULL pointer was not returned");
+}
+
+/*
+ * A response is only an answer to a command that went out on the same transport. On a
+ * device that is an SMP server on one transport and an SMP client on another, whoever can
+ * reach the server transport must not be able to answer for the client's peer by guessing
+ * the eight bit sequence number.
+ */
+ZTEST(smp_client, test_msg_response_wrong_transport)
+{
+	struct smp_hdr dst_hdr;
+	struct net_buf *a, *b;
+	int rc;
+
+	response_ptr = NULL;
+	res_buf = NULL;
+
+	a = smp_client_buf_allocation(&smp_client, MGMT_GROUP_ID_IMAGE, 1, MGMT_OP_WRITE,
+				      SMP_MCUMGR_VERSION_1);
+	zassert_not_null(a, "Buffer was Null");
+	rc = smp_client_send_cmd(&smp_client, a, smp_client_res_cb, &testing_user_data, 8);
+	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
+	b = smp_client_buf_allocation(&smp_client, MGMT_GROUP_ID_IMAGE, 1, MGMT_OP_WRITE,
+				      SMP_MCUMGR_VERSION_1);
+	zassert_not_null(b, "Buffer was Null");
+
+	/* Everything about this response matches the pending command, including the
+	 * sequence number, the operation, the group and the command id. Only the
+	 * transport it arrives on is different.
+	 */
+	smp_transport_read_hdr(a, &dst_hdr);
+	dst_hdr.nh_op = MGMT_OP_WRITE_RSP;
+	smp_client_single_response(stub_smp_other_transport_get(), b, &dst_hdr);
+	zassert_is_null(res_buf, "A response on another transport completed the command");
+	zassert_is_null(response_ptr, "A response on another transport completed the command");
+
+	/* The command was not consumed, so its own transport still completes it. */
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
+	zassert_equal_ptr(res_buf, b, "Response Buf not correct");
+	zassert_equal_ptr(response_ptr, &testing_user_data, "User data not returned correctly");
+
+	response_ptr = NULL;
+	res_buf = NULL;
+	smp_client_buf_free(b);
+}
+
+/*
+ * The sequence number wraps every 256 commands and every group client shares one command
+ * list, so a response also has to be for the group and the command that was asked for.
+ */
+ZTEST(smp_client, test_msg_response_wrong_group)
+{
+	struct smp_hdr dst_hdr;
+	struct net_buf *a, *b;
+	int rc;
+
+	response_ptr = NULL;
+	res_buf = NULL;
+
+	a = smp_client_buf_allocation(&smp_client, MGMT_GROUP_ID_IMAGE, 1, MGMT_OP_WRITE,
+				      SMP_MCUMGR_VERSION_1);
+	zassert_not_null(a, "Buffer was Null");
+	rc = smp_client_send_cmd(&smp_client, a, smp_client_res_cb, &testing_user_data, 8);
+	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
+	b = smp_client_buf_allocation(&smp_client, MGMT_GROUP_ID_IMAGE, 1, MGMT_OP_WRITE,
+				      SMP_MCUMGR_VERSION_1);
+	zassert_not_null(b, "Buffer was Null");
+
+	smp_transport_read_hdr(a, &dst_hdr);
+	dst_hdr.nh_op = MGMT_OP_WRITE_RSP;
+
+	/* Right transport, right sequence number, right operation, wrong group. */
+	dst_hdr.nh_group = MGMT_GROUP_ID_OS;
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
+	zassert_is_null(res_buf, "A response for another group completed the command");
+	zassert_is_null(response_ptr, "A response for another group completed the command");
+
+	/* Right group, wrong command id. */
+	dst_hdr.nh_group = MGMT_GROUP_ID_IMAGE;
+	dst_hdr.nh_id = 2;
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
+	zassert_is_null(res_buf, "A response for another command completed the command");
+	zassert_is_null(response_ptr, "A response for another command completed the command");
+
+	/* The command was not consumed, so its own response still completes it. */
+	dst_hdr.nh_id = 1;
+	smp_client_single_response(smp_client.smpt, b, &dst_hdr);
+	zassert_equal_ptr(res_buf, b, "Response Buf not correct");
+	zassert_equal_ptr(response_ptr, &testing_user_data, "User data not returned correctly");
+
+	response_ptr = NULL;
+	res_buf = NULL;
+	smp_client_buf_free(b);
 }
 
 static void *setup_custom_os(void)

--- a/tests/subsys/mgmt/mcumgr/smp_client/src/smp_transport_stub.c
+++ b/tests/subsys/mgmt/mcumgr/smp_client/src/smp_transport_stub.c
@@ -15,6 +15,13 @@
 static struct smp_transport smpt_test;
 static struct smp_client_transport_entry smp_client_transport;
 
+/*
+ * A second transport, registered nowhere and owned by no client. It stands in for the
+ * other transport a device that is both an SMP server and an SMP client has, and exists
+ * so that a response can be fed in on a transport that no pending command went out on.
+ */
+static struct smp_transport smpt_other;
+
 /* Stubbed functions */
 
 void smp_transport_read_hdr(const struct net_buf *nb, struct smp_hdr *dst_hdr)
@@ -48,4 +55,13 @@ void stub_smp_client_transport_register(void)
 	smp_client_transport.smpt = &smpt_test;
 	smp_client_transport.smpt_type = SMP_SERIAL_TRANSPORT;
 	smp_client_transport_register(&smp_client_transport);
+
+	smpt_other.functions.output = smp_uart_tx_pkt;
+	smpt_other.functions.get_mtu = smp_uart_get_mtu;
+	smp_transport_init(&smpt_other);
+}
+
+struct smp_transport *stub_smp_other_transport_get(void)
+{
+	return &smpt_other;
 }

--- a/tests/subsys/mgmt/mcumgr/smp_client/src/smp_transport_stub.h
+++ b/tests/subsys/mgmt/mcumgr/smp_client/src/smp_transport_stub.h
@@ -16,6 +16,7 @@ extern "C" {
 
 void smp_transport_read_hdr(const struct net_buf *nb, struct smp_hdr *dst_hdr);
 void stub_smp_client_transport_register(void);
+struct smp_transport *stub_smp_other_transport_get(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
smp_client_response_discover() matched a pending client command to an
incoming response on the sequence number and the operation alone. The
transport the response arrived on was not considered, so any transport
on the device could complete a command issued on any other, and neither
were the group and the command id checked.

That is reachable whenever a device is both an SMP server and an SMP
client, which is a supported configuration: a peer that can reach the
server transport can answer a command the client sent somewhere else,
by guessing an eight bit sequence number that is counted per client
rather than per transport. A forged response can complete a command
early or, for an image upload, acknowledge an offset that was never
written.

Match the transport, and the group and the command id with it. A
response now only completes a command whose client sent it on the same
transport and which actually asked the question being answered.

smp_client_single_response() takes the receiving transport to do this,
so its signature changes; the only in-tree caller is the SMP layer
itself, which has the transport in the streamer. Noted in the migration
guide.

The smp_client and mcumgr_client test suites pass, including new
cases that offer a well formed response on a second transport, and one
carrying another group, and require that neither answers the command
while the genuine response still does.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Jeff Welder <Jeff.Welder@ellenbytech.com>