### PR TITLE
net: http: client: report every body fragment of a receive buffer

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1577,6 +1577,11 @@ Bluetooth Services
 Networking
 **********
 
+* The HTTP client response callback (:c:type:`http_response_cb_t`) may now be
+  invoked more than once for a single received buffer, once per body fragment,
+  for example once per chunk of a chunked response. Applications that assumed a
+  single callback per receive must append every fragment they are handed.
+
 * The ``struct dns_server`` type nested in :c:struct:`dns_resolve_context` has been
   renamed to ``struct dns_server_info``. A C++ class member cannot share the name of
   its enclosing class, so the old tag made ``<zephyr/net/dns_resolve.h>`` impossible to

--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -22,6 +22,8 @@
  * @{
  */
 
+#include <stdbool.h>
+
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/http/parser.h>
@@ -90,6 +92,10 @@ typedef int (*http_header_cb_t)(int sock,
  * @typedef http_response_cb_t
  * @brief Callback used when data is received from the server.
  *
+ * The callback may run several times for one received buffer, for example
+ * once per chunk of a chunked body. Each call carries one contiguous
+ * fragment in @c body_frag_start and @c body_frag_len.
+ *
  * @param rsp HTTP response information
  * @param final_data Does this data buffer contain all the data or
  *        is there still more data to come.
@@ -141,7 +147,11 @@ struct http_response {
 	 *          body_frag_start
 	 *
 	 * body_frag_start >= recv_buf
-	 * body_frag_len = data_len - (body_frag_start - recv_buf)
+	 *
+	 * The relation body_frag_len = data_len - (body_frag_start - recv_buf)
+	 * only holds for the last fragment reported from a receive buffer. A
+	 * chunked body may report several fragments from one buffer, each one
+	 * covering the payload of a single chunk.
 	 */
 	/** Start address of the body fragment contained in the recv_buf */
 	uint8_t *body_frag_start;
@@ -231,6 +241,9 @@ struct http_client_internal_data {
 
 	/** HTTP socket */
 	int sock;
+
+	/** Set when the response callback aborted the transfer */
+	bool aborted;
 };
 
 /**

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -290,11 +290,30 @@ static int on_header_value(struct http_parser *parser, const char *at,
 	return 0;
 }
 
+static int http_report_progress(struct http_request *req);
+
 static int on_body(struct http_parser *parser, const char *at, size_t length)
 {
 	struct http_request *req = CONTAINER_OF(parser,
 						struct http_request,
 						internal.parser);
+
+	/* A chunked body yields one fragment per chunk, separated by the chunk
+	 * framing, so a single receive buffer can hold several of them. Hand
+	 * a pending fragment to the application before starting a new one,
+	 * otherwise only the last one would be reported.
+	 */
+	if (req->internal.response.body_frag_start != NULL &&
+	    req->internal.response.body_frag_start +
+	    req->internal.response.body_frag_len != (const uint8_t *)at) {
+		if (http_report_progress(req) < 0) {
+			req->internal.aborted = true;
+			return -1;
+		}
+
+		req->internal.response.body_frag_start = NULL;
+		req->internal.response.body_frag_len = 0;
+	}
 
 	req->internal.response.body_found = 1;
 	req->internal.response.processed += length;
@@ -307,13 +326,12 @@ static int on_body(struct http_parser *parser, const char *at, size_t length)
 		req->internal.response.http_cb->on_body(parser, at, length);
 	}
 
-	/* Reset the body_frag_start pointer for each fragment. */
-	if (!req->internal.response.body_frag_start) {
+	if (req->internal.response.body_frag_start == NULL) {
 		req->internal.response.body_frag_start = (uint8_t *)at;
+		req->internal.response.body_frag_len = length;
+	} else {
+		req->internal.response.body_frag_len += length;
 	}
-
-	/* Use the parser-decoded length. */
-	req->internal.response.body_frag_len = length;
 
 	return 0;
 }
@@ -545,6 +563,11 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 				goto error;
 			}
 
+			if (req->internal.aborted) {
+				LOG_DBG("Connection aborted by the application");
+				return -ECONNABORTED;
+			}
+
 			if (req->internal.parser.http_errno != HPE_OK) {
 				LOG_ERR("HTTP parsing error, %d",
 					req->internal.parser.http_errno);
@@ -652,6 +675,7 @@ int http_client_req(int sock, struct http_request *req,
 	req->internal.response.recv_buf_len = req->recv_buf_len;
 	req->internal.user_data = user_data;
 	req->internal.sock = sock;
+	req->internal.aborted = false;
 
 	method = http_method_str(req->method);
 

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -465,6 +465,30 @@ static const char chunked_te_response[] =
 	"0\r\n"
 	"\r\n";
 
+/* Three chunks delivered in one recv call. Before every chunk was reported,
+ * only the last fragment reached the application.
+ */
+#define MULTI_CHUNKED_BODY_SIZE 32
+
+static const char multi_chunked_te_response[] =
+	"HTTP/1.1 200 OK\r\n"
+	"Transfer-Encoding: chunked\r\n"
+	"\r\n"
+	"10\r\n"
+	"AAAAAAAAAAAAAAAA"
+	"\r\n"
+	"a\r\n"
+	"BBBBBBBBBB"
+	"\r\n"
+	"6\r\n"
+	"CCCCCC"
+	"\r\n"
+	"0\r\n"
+	"\r\n";
+
+static const char *chunked_srv_response;
+static size_t chunked_srv_response_len;
+
 static K_THREAD_STACK_DEFINE(chunked_srv_stack, 2048 + CONFIG_TEST_EXTRA_STACK_SIZE);
 static struct k_thread chunked_srv_thread;
 static K_SEM_DEFINE(chunked_srv_ready, 0, 1);
@@ -504,8 +528,7 @@ static void chunked_srv_fn(void *p1, void *p2, void *p3)
 	conn = zsock_accept(srv, NULL, NULL);
 	if (conn >= 0) {
 		(void)zsock_recv(conn, req_buf, sizeof(req_buf) - 1, 0);
-		(void)zsock_send(conn, chunked_te_response,
-				 sizeof(chunked_te_response) - 1, 0);
+		(void)zsock_send(conn, chunked_srv_response, chunked_srv_response_len, 0);
 		zsock_close(conn);
 	}
 
@@ -525,6 +548,8 @@ static void chunked_tests_before(void *fixture)
 
 	memset(chunked_recv_buf, 0, sizeof(chunked_recv_buf));
 	memset(chunked_response_buf, 0, sizeof(chunked_response_buf));
+	chunked_srv_response = chunked_te_response;
+	chunked_srv_response_len = sizeof(chunked_te_response) - 1;
 
 	k_thread_create(&chunked_srv_thread, chunked_srv_stack,
 			K_THREAD_STACK_SIZEOF(chunked_srv_stack),
@@ -585,6 +610,58 @@ ZTEST(http_client_chunked_te, test_body_frag_len_chunked_te)
 		      ctx.offset, CHUNKED_BODY_SIZE);
 	zassert_mem_equal(chunked_response_buf, "AAAAAAAAAAAAAAAA",
 			  CHUNKED_BODY_SIZE, "Body content mismatch");
+}
+
+static void multi_chunked_request_init(struct http_request *req)
+{
+	req->method = HTTP_GET;
+	req->url = "/firmware/app.bin";
+	req->host = SERVER_IPV6_ADDR;
+	req->protocol = "HTTP/1.1";
+	req->response = response_cb;
+	req->recv_buf = chunked_recv_buf;
+	req->recv_buf_len = sizeof(chunked_recv_buf);
+
+	chunked_srv_response = multi_chunked_te_response;
+	chunked_srv_response_len = sizeof(multi_chunked_te_response) - 1;
+}
+
+ZTEST(http_client_chunked_te, test_body_multi_chunk_single_recv)
+{
+	struct http_request req = { 0 };
+	struct test_ctx ctx = { 0 };
+	int ret;
+
+	multi_chunked_request_init(&req);
+
+	ctx.buf = chunked_response_buf;
+	ctx.buflen = sizeof(chunked_response_buf);
+
+	ret = http_client_req(chunked_client_fd, &req, -1, &ctx);
+	zassert_true(ret > 0, "http_client_req() failed (%d)", ret);
+	zassert_true(ctx.final, "No final event received");
+	zassert_equal(ctx.status, 200, "Unexpected HTTP status code");
+
+	zassert_equal(ctx.offset, MULTI_CHUNKED_BODY_SIZE,
+		      "body length mismatch: got %zu, expected %d",
+		      ctx.offset, MULTI_CHUNKED_BODY_SIZE);
+	zassert_mem_equal(chunked_response_buf, "AAAAAAAAAAAAAAAABBBBBBBBBBCCCCCC",
+			  MULTI_CHUNKED_BODY_SIZE, "Body content mismatch");
+}
+
+ZTEST(http_client_chunked_te, test_abort_multi_chunk_single_recv)
+{
+	struct http_request req = { 0 };
+	struct test_ctx ctx = { 0 };
+	int ret;
+
+	multi_chunked_request_init(&req);
+
+	ctx.abort = true;
+
+	ret = http_client_req(chunked_client_fd, &req, -1, &ctx);
+	zassert_equal(ret, -ECONNABORTED,
+		      "http_client_req() should've reported abort (%d)", ret);
 }
 
 ZTEST_SUITE(http_client_chunked_te, NULL, NULL,


### PR DESCRIPTION
The HTTP parser calls the body callback once per chunk, so a chunked response can put several fragments in one receive buffer. The client kept the start of the first fragment and the length of the last one and reported that as a single fragment, silently dropping everything in between. Any application reassembling a chunked body got corrupted data, including hawkbit downloads.

The client now reports a pending fragment before starting a new one, so every chunk reaches the callback. An abort returned from that callback is propagated as a connection abort. The callback can now run more than once per receive, which the header docs and the migration guide now state. Two regression tests cover the multi chunk case and the mid buffer abort; they fail without the fix and the suite passes on native_sim.