### PR TITLE
soc: espressif: load all rtc data sections on esp32, esp32s2 and esp32s3

### DIFF
--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -175,7 +175,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.text))
     LONG(LOADADDR(.rtc.text))
-    LONG(SIZEOF(.rtc.text))
+    LONG(LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text))
 
     /* RTC_DRAM metadata:
      * 11. Destination address (VMA) for RTC_DRAM region
@@ -184,7 +184,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.data))
     LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -211,7 +211,7 @@ SECTIONS
 
   /* --- RTC BEGIN --- */
 
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.literal .rtc.literal.*)
@@ -219,20 +219,21 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
-  /*
-    This section is required to skip rtc.text area because rtc_iram_seg and
-    rtc_data_seg reflect the same address space on different buses.
-  */
-  .rtc.dummy :
+  /* This section is required to skip rtc.text area because rtc_iram_seg and
+   * rtc_data_seg reflect the same address space on different buses. It is
+   * NOLOAD so the flash image keeps .rtc.text and .rtc.force_fast adjacent,
+   * letting one load descriptor place both through the instruction bus alias.
+   */
+  .rtc.dummy (NOLOAD) :
   {
     . = SIZEOF(.rtc.text);
-  } GROUP_DATA_LINK_IN(rtc_data_seg, ROMABLE_REGION)
+  } GROUP_LINK_IN(rtc_data_seg)
 
   /* This section located in RTC FAST Memory area.
      It holds data marked with RTC_FAST_ATTR attribute.
      See the file "esp_attr.h" for more information.
   */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.force_fast .rtc.force_fast.*)
@@ -244,13 +245,25 @@ SECTIONS
      named rtc_wake_stub*.c and the data marked with
      RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
   */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4) ;
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -265,21 +278,10 @@ SECTIONS
     . = ALIGN(4);
     *(.rtc_noinit .rtc_noinit.*)
     . = ALIGN(4) ;
+    _rtc_noinit_end = ABSOLUTE(.);
  } GROUP_LINK_IN(rtc_slow_seg)
 
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4) ;
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
-
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  _rtc_slow_length = (_rtc_noinit_end - _rtc_data_start);
 
   /**
    * This section holds RTC SLOW data that should have fixed addresses.
@@ -298,6 +300,21 @@ SECTIONS
   _rtc_slow_reserved_length = 0;
 #endif
   _rtc_reserved_length = _rtc_slow_reserved_length;
+
+  /* The RTC_IRAM load descriptor above spans .rtc.text through .rtc.force_fast,
+   * copying both through the instruction bus alias of RTC FAST memory, and the
+   * RTC_DRAM one spans .rtc.data through .rtc.force_slow. The bootloader can
+   * only place those sections correctly while the physical and LMA layouts of
+   * each span agree. ALIGN_WITH_INPUT on the loadable RTC sections keeps them
+   * in step; this catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text)) ==
+         ((ADDR(.rtc.force_fast) - rtc_data_org) + SIZEOF(.rtc.force_fast) -
+          (ADDR(.rtc.text) - rtc_iram_org)),
+         "RTC FAST loadable sections must stay contiguous across the bus alias")
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.data)),
+         "RTC SLOW loadable sections must be contiguous with equal VMA and LMA offsets")
   ASSERT((_rtc_reserved_length <= CONFIG_RESERVE_RTC_MEM),
          "RTC reserved segment does not fit CONFIG_RESERVE_RTC_MEM.")
 

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -171,7 +171,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.text))
     LONG(LOADADDR(.rtc.text))
-    LONG(SIZEOF(.rtc.text))
+    LONG(LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text))
 
     /* RTC_DRAM metadata:
      * 11. Destination address (VMA) for RTC_DRAM region
@@ -180,7 +180,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.data))
     LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -208,7 +208,7 @@ SECTIONS
 
   /* --- START OF RTC --- */
 
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.literal .rtc.literal.*)
@@ -216,20 +216,21 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
 
-  /*
-    This section is required to skip rtc.text area because rtc_iram_seg and
-    rtc_data_seg reflect the same address space on different buses.
-  */
-  .rtc.dummy :
+  /* This section is required to skip rtc.text area because rtc_iram_seg and
+   * rtc_data_seg reflect the same address space on different buses. It is
+   * NOLOAD so the flash image keeps .rtc.text and .rtc.force_fast adjacent,
+   * letting one load descriptor place both through the instruction bus alias.
+   */
+  .rtc.dummy (NOLOAD) :
   {
     . = SIZEOF(.rtc.text);
-  } GROUP_DATA_LINK_IN(rtc_data_seg, ROMABLE_REGION)
+  } GROUP_LINK_IN(rtc_data_seg)
 
   /* This section located in RTC FAST Memory area.
      It holds data marked with RTC_FAST_ATTR attribute.
      See the file "esp_attr.h" for more information.
   */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     *(.rtc.force_fast .rtc.force_fast.*)
@@ -241,13 +242,25 @@ SECTIONS
      named rtc_wake_stub*.c and the data marked with
      RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
   */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     . = ALIGN(4);
+  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -262,22 +275,11 @@ SECTIONS
     . = ALIGN(4);
     *(.rtc_noinit .rtc_noinit.*)
     . = ALIGN(4) ;
+    _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(rtc_slow_seg)
 
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_iram_seg, ROMABLE_REGION)
-
   /* Get size of rtc slow data */
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  _rtc_slow_length = (_rtc_noinit_end - _rtc_data_start);
 
   /**
    * This section holds RTC data that should have fixed addresses.
@@ -297,6 +299,21 @@ SECTIONS
 #else
   _rtc_reserved_length = 0;
 #endif
+
+  /* The RTC_IRAM load descriptor above spans .rtc.text through .rtc.force_fast,
+   * copying both through the instruction bus alias of RTC FAST memory, and the
+   * RTC_DRAM one spans .rtc.data through .rtc.force_slow. The bootloader can
+   * only place those sections correctly while the physical and LMA layouts of
+   * each span agree. ALIGN_WITH_INPUT on the loadable RTC sections keeps them
+   * in step; this catches any future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text)) ==
+         ((ADDR(.rtc.force_fast) - rtc_data_org) + SIZEOF(.rtc.force_fast) -
+          (ADDR(.rtc.text) - rtc_iram_org)),
+         "RTC FAST loadable sections must stay contiguous across the bus alias")
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.data)),
+         "RTC SLOW loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -189,7 +189,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.text))
     LONG(LOADADDR(.rtc.text))
-    LONG(SIZEOF(.rtc.text))
+    LONG(LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text))
 
     /* RTC_DRAM metadata:
      * 11. Destination address (VMA) for RTC_DRAM region
@@ -198,7 +198,7 @@ SECTIONS
      */
     LONG(ADDR(.rtc.data))
     LONG(LOADADDR(.rtc.data))
-    LONG(SIZEOF(.rtc.data))
+    LONG(LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data))
 
     /* IROM metadata:
      * 14. Destination address (VMA) for IROM region
@@ -227,7 +227,7 @@ SECTIONS
   /* --- START OF RTC --- */
 
   /* RTC fast memory holds RTC wake stub code */
-  .rtc.text :
+  .rtc.text : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_text_start = ABSOLUTE(.);
@@ -243,7 +243,7 @@ SECTIONS
    * It holds data marked with RTC_FAST_ATTR attribute.
    * See the file "esp_attr.h" for more information.
    */
-  .rtc.force_fast :
+  .rtc.force_fast : ALIGN_WITH_INPUT
   {
     . = ALIGN(4);
     _rtc_force_fast_start = ABSOLUTE(.);
@@ -255,13 +255,26 @@ SECTIONS
   /* RTC data section holds data marked with
    * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
    */
-  .rtc.data :
+  .rtc.data : ALIGN_WITH_INPUT
   {
   . = ALIGN(4);
     _rtc_data_start = ABSOLUTE(.);
     *(.rtc.data .rtc.data.*)
     *(.rtc.rodata .rtc.rodata.*)
     _rtc_data_end = ABSOLUTE(.);
+  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
+
+  /* This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow : ALIGN_WITH_INPUT
+  {
+    . = ALIGN(4);
+    _rtc_force_slow_start = ABSOLUTE(.);
+    *(.rtc.force_slow .rtc.force_slow.*)
+    . = ALIGN(4);
+    _rtc_force_slow_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
   .rtc.bss (NOLOAD) :
@@ -281,20 +294,8 @@ SECTIONS
     . = ALIGN(4);
     *(.rtc_noinit .rtc_noinit.*)
     . = ALIGN(4) ;
+    _rtc_noinit_end = ABSOLUTE(.);
   } GROUP_LINK_IN(rtc_slow_seg)
-
-  /* This section located in RTC SLOW Memory area.
-   * It holds data marked with RTC_SLOW_ATTR attribute.
-   * See the file "esp_attr.h" for more information.
-   */
-  .rtc.force_slow :
-  {
-    . = ALIGN(4);
-    _rtc_force_slow_start = ABSOLUTE(.);
-    *(.rtc.force_slow .rtc.force_slow.*)
-    . = ALIGN(4);
-    _rtc_force_slow_end = ABSOLUTE(.);
-  } GROUP_DATA_LINK_IN(rtc_slow_seg, ROMABLE_REGION)
 
  /**
    * This section holds RTC data that should have fixed addresses.
@@ -316,8 +317,21 @@ SECTIONS
 #endif
 
   /* Get size of rtc slow data based on rtc_data_location alias */
-  _rtc_slow_length = (_rtc_force_slow_end - _rtc_data_start);
+  _rtc_slow_length = (_rtc_noinit_end - _rtc_data_start);
   _rtc_fast_length = (_rtc_force_fast_end - _rtc_fast_start);
+
+  /* The RTC_IRAM load descriptor above spans .rtc.text through .rtc.force_fast and the
+   * RTC_DRAM one spans .rtc.data through .rtc.force_slow, so the bootloader can only
+   * place those sections correctly while the VMA and LMA layouts of each span agree.
+   * ALIGN_WITH_INPUT on the loadable RTC sections keeps them in step; this catches any
+   * future change that reintroduces a skew.
+   */
+  ASSERT((LOADADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - LOADADDR(.rtc.text)) ==
+         (ADDR(.rtc.force_fast) + SIZEOF(.rtc.force_fast) - ADDR(.rtc.text)),
+         "RTC FAST loadable sections must be contiguous with equal VMA and LMA offsets")
+  ASSERT((LOADADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - LOADADDR(.rtc.data)) ==
+         (ADDR(.rtc.force_slow) + SIZEOF(.rtc.force_slow) - ADDR(.rtc.data)),
+         "RTC SLOW loadable sections must be contiguous with equal VMA and LMA offsets")
 
   /* --- END OF RTC --- */
 


### PR DESCRIPTION
The MCUboot load header on these SoCs describes only .rtc.text and .rtc.data, so .rtc.force_fast and .rtc.force_slow are flashed but never copied to RTC memory. Data marked RTC_FAST_ATTR or RTC_SLOW_ATTR then starts from whatever the RAM last held, which on esp32 also leaves the chip resetting through the timer group watchdog on every deep sleep wake. 
Widen both descriptors to span their full loadable range, move .rtc.force_slow ahead of the NOLOAD sections to keep those ranges contiguous, and mark the loadable sections ALIGN_WITH_INPUT so alignment padding applies to the load address too. 

Follows https://github.com/zephyrproject-rtos/zephyr/pull/117359