### PR TITLE
scripts: ci: request reviewers in batches of 15

### DIFF
--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -147,11 +147,11 @@ change.  What keeps the request meaningful is the tier ordering above, not a
 count: if a PR is broad enough to need thirty reviewers, all thirty own part of
 it.
 
-Should GitHub refuse the full set anyway (some undocumented limit, or a
-candidate who lost collaborator status between the check and the request), the
-call is retried once with the first REVIEWER_RETRY_BATCH (15) candidates.
-Because the list is ordered highest-signal first, that retry keeps the area
-maintainers and drops only the tail.
+A single review request call does cap out at REVIEWER_REQUEST_BATCH (15) users,
+so the candidates are requested in batches of that size.  Should GitHub refuse a
+batch anyway (a candidate who lost collaborator status between the check and the
+request, say), that batch is retried one user at a time so a single bad
+candidate does not cost the others their review request.
 
 Mention fallback
 ----------------
@@ -162,7 +162,8 @@ for their review, which notifies them regardless of their permissions.
 
 The comment carries a hidden MENTION_MARKER so that repeated runs over the same
 PR find their own previous comment and edit it in place, instead of posting a
-duplicate every time the PR is updated.  Users who removed themselves from the
+duplicate every time the PR is updated.  It is deleted once a later run has
+nobody left to mention.  Users who removed themselves from the
 review request are never mentioned, since a mention would route around an
 explicit opt-out.
 
@@ -306,10 +307,10 @@ MAX_FILES = 500
 
 # GitHub does not document a cap on how many reviewers a pull request may have,
 # and PRs carrying more than 15 are observable in the wild, so no cap is imposed
-# here: every eligible candidate is requested.  Should GitHub reject the full
-# set anyway, the request is retried with this many of the highest-ranked
-# candidates so that a rejection cannot cost the review request entirely.
-REVIEWER_RETRY_BATCH = 15
+# here: every eligible candidate is requested.  A single review request call,
+# however, accepts at most 15 users, so the candidates are requested in batches
+# of this size rather than in one call.
+REVIEWER_REQUEST_BATCH = 15
 
 # Hidden marker identifying the comment used to mention reviewers who could not
 # be added to the review request.  It lets a re-run find and update its own
@@ -899,39 +900,71 @@ def _add_reviewers(gh, gh_repo, pr, args, collab: list):
     # Anyone the review request could not accommodate still gets asked, by
     # name, in a comment.  Users who removed themselves are deliberately not
     # mentioned: they opted out, and a mention would route around that.
-    _mention_reviewers(pr, args, non_collaborators + unrequested)
+    _mention_reviewers(gh, pr, args, non_collaborators + unrequested)
 
 
 def _request_reviews(pr, args, reviewers: list) -> list:
     """Request reviews from *reviewers*; return those that could not be added.
 
-    A rejected bulk request is retried once with the highest-ranked
-    REVIEWER_RETRY_BATCH candidates, so that hitting an undocumented per-PR
-    reviewer limit cannot leave the PR with no reviewers at all.  Whoever is
-    left out is returned for the caller to mention instead.
+    A single review request accepts at most REVIEWER_REQUEST_BATCH users, so
+    the candidates are requested in batches of that size instead of in one
+    call.  Requesting them all at once made GitHub reject the request, which
+    used to leave everyone past the first batch unrequested until a later run
+    of this script picked them up -- the reason a PR ended up with only a
+    subset of its reviewers on the first run.
+
+    A validation-rejected batch (HTTP 422) is retried one user at a time, so
+    that a single bad candidate (a deleted account, or someone who lost
+    collaborator status between the check and the request) cannot cost the
+    whole batch its reviewers.  Systemic failures are not fanned out: the
+    failed batch and any remaining batches are returned for mention fallback.
     """
     if args.dry_run:
         return []
 
-    try:
-        pr.create_review_request(reviewers=reviewers)
-        return []
-    except GithubException as exc:
-        logger.error("Failed to add reviewers %s: %s", reviewers, exc)
-
-    if len(reviewers) > REVIEWER_RETRY_BATCH:
-        retry = reviewers[:REVIEWER_RETRY_BATCH]
-        logger.info("Retrying with the first %d: %s", len(retry), retry)
+    unrequested = []
+    batches = [
+        reviewers[i : i + REVIEWER_REQUEST_BATCH]
+        for i in range(0, len(reviewers), REVIEWER_REQUEST_BATCH)
+    ]
+    for index, batch in enumerate(batches):
+        if index:
+            # Courtesy sleep: consecutive write calls risk a secondary rate limit.
+            time.sleep(API_SLEEP_SECONDS)
         try:
-            pr.create_review_request(reviewers=retry)
-            return reviewers[REVIEWER_RETRY_BATCH:]
-        except GithubException as retry_exc:
-            logger.error("Retry failed for reviewers %s: %s", retry, retry_exc)
+            pr.create_review_request(reviewers=batch)
+            continue
+        except GithubException as exc:
+            logger.error("Failed to add reviewers %s: %s", batch, exc)
+            status = getattr(exc, "status", None)
 
-    return list(reviewers)
+            if status != 422:
+                logger.error(
+                    "Stopping reviewer requests after systemic API failure (HTTP %s)",
+                    status,
+                )
+                unrequested += batch
+                for remaining in batches[index + 1 :]:
+                    unrequested += remaining
+                break
+
+        if len(batch) == 1:
+            unrequested += batch
+            continue
+
+        logger.info("Retrying %d reviewer(s) individually", len(batch))
+        for reviewer in batch:
+            time.sleep(API_SLEEP_SECONDS)
+            try:
+                pr.create_review_request(reviewers=[reviewer])
+            except GithubException as retry_exc:
+                logger.error("Failed to add reviewer '%s': %s", reviewer, retry_exc)
+                unrequested.append(reviewer)
+
+    return unrequested
 
 
-def _mention_reviewers(pr, args, logins: list):
+def _mention_reviewers(gh, pr, args, logins: list):
     """Ask *logins* for a review in a PR comment.
 
     Used for people who cannot receive a formal review request: those who are
@@ -942,10 +975,15 @@ def _mention_reviewers(pr, args, logins: list):
 
     The comment is maintained in place: one is created the first time and
     edited afterwards, keyed on MENTION_MARKER, so that re-running over the
-    same PR does not spam it with duplicates.
+    same PR does not spam it with duplicates.  Once there is nobody left to
+    mention -- everyone it named has since been added to the review request --
+    a comment left by an earlier run is deleted, so the PR does not keep
+    claiming that people could not be requested when they were.
     """
     logins = list(dict.fromkeys(logins))
     if not logins:
+        if not args.dry_run:
+            _delete_mention_comment(gh, pr)
         return
 
     mentions = " ".join(f"@{login}" for login in logins)
@@ -975,6 +1013,19 @@ def _mention_reviewers(pr, args, logins: list):
         pr.create_issue_comment(body)
     except GithubException as exc:
         logger.error("Failed to mention reviewers %s: %s", logins, exc)
+
+
+def _delete_mention_comment(gh, pr):
+    """Delete the reviewer-mention comment left by an earlier run, if any."""
+    try:
+        bot_login = gh.get_user().login
+        for comment in pr.get_issue_comments():
+            if MENTION_MARKER in comment.body and getattr(comment.user, 'login', None) == bot_login:
+                logger.info("Deleting obsolete reviewer-mention comment")
+                comment.delete()
+                return
+    except GithubException as exc:
+        logger.error("Failed to delete the reviewer-mention comment: %s", exc)
 
 
 def _assign_maintainers(gh, pr, args, assignees: list):

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -51,6 +51,13 @@ for _name, _mod in [
 import set_assignees as sut  # noqa: E402, I001  (import after sys.modules manipulation)
 
 
+@pytest.fixture(autouse=True)
+def _no_api_sleep():
+    """The courtesy sleeps between API calls only slow the tests down."""
+    with patch.object(sut.time, "sleep"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -563,7 +570,8 @@ def _make_process_pr_harness(areas_per_file, pr_user="someone"):
     # _add_reviewers which stores them in a set).
     user_cache = {}
 
-    def _get_user(login):
+    def _get_user(login=None):
+        login = "copilot-bot" if login is None else login
         if login not in user_cache:
             u = MagicMock()
             u.login = login
@@ -1225,7 +1233,8 @@ def _make_add_reviewers_stubs(author="author"):
 
     cache = {}
 
-    def _get_user(login):
+    def _get_user(login=None):
+        login = "copilot-bot" if login is None else login
         if login not in cache:
             user = MagicMock()
             user.login = login
@@ -1290,36 +1299,114 @@ class TestNoReviewerCap:
         pr.create_review_request.assert_not_called()
 
 
-class TestReviewRequestRetry:
-    """A rejected bulk request must not cost the PR all of its reviewers."""
+class TestReviewRequestBatching:
+    """A single review request accepts at most REVIEWER_REQUEST_BATCH users,
+    so a long candidate list must be split across several calls rather than
+    losing everyone past the first batch until a later run."""
 
-    def test_rejection_retries_with_highest_ranked_candidates(self):
+    def test_long_list_is_split_into_batches(self):
         gh, gh_repo, pr, args = _make_add_reviewers_stubs()
         candidates = [f"u{i}" for i in range(25)]
-        pr.create_review_request.side_effect = [sut.GithubException("too many"), None]
 
         sut._add_reviewers(gh, gh_repo, pr, args, candidates)
 
-        assert pr.create_review_request.call_count == 2
-        retried = pr.create_review_request.call_args_list[1].kwargs["reviewers"]
-        assert retried == candidates[: sut.REVIEWER_RETRY_BATCH]
+        batches = [call.kwargs["reviewers"] for call in pr.create_review_request.call_args_list]
+        assert batches == [
+            candidates[: sut.REVIEWER_REQUEST_BATCH],
+            candidates[sut.REVIEWER_REQUEST_BATCH :],
+        ]
+        assert _reviewers_requested(pr) == candidates
 
-    def test_small_request_is_not_retried(self):
+    def test_short_list_is_requested_in_one_call(self):
         gh, gh_repo, pr, args = _make_add_reviewers_stubs()
-        pr.create_review_request.side_effect = sut.GithubException("nope")
 
         sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b"])
 
-        # Nothing to trim, so a retry would just repeat the failing call.
         assert pr.create_review_request.call_count == 1
 
-    def test_failing_retry_does_not_raise(self):
+    def test_nobody_is_left_for_the_next_run_to_pick_up(self):
+        """The bug this guards against: the first run requested only a subset,
+        and a second run of the script added the rest."""
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(40)]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert _reviewers_requested(pr) == candidates
+        pr.create_issue_comment.assert_not_called()
+
+    def test_rejected_batch_is_retried_one_user_at_a_time(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+
+        def _reject_bulk(reviewers):
+            if len(reviewers) > 1:
+                exc = sut.GithubException("nope")
+                exc.status = 422
+                raise exc
+
+        pr.create_review_request.side_effect = _reject_bulk
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b", "c"])
+
+        assert _reviewers_requested(pr) == ["a", "b", "c", "a", "b", "c"]
+        pr.create_issue_comment.assert_not_called()
+
+    def test_only_the_bad_candidate_is_mentioned(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+
+        def _reject(reviewers):
+            if len(reviewers) > 1 or reviewers == ["bad"]:
+                exc = sut.GithubException("nope")
+                exc.status = 422
+                raise exc
+
+        pr.create_review_request.side_effect = _reject
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["good", "bad"])
+
+        assert _mentioned(pr) == ["bad"]
+
+    def test_validation_failure_does_not_stop_the_others(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(25)]
+        first = set(candidates[: sut.REVIEWER_REQUEST_BATCH])
+
+        def _reject_first_batch(reviewers):
+            if set(reviewers) <= first:
+                exc = sut.GithubException("nope")
+                exc.status = 422
+                raise exc
+
+        pr.create_review_request.side_effect = _reject_first_batch
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert candidates[sut.REVIEWER_REQUEST_BATCH :] == [
+            login for login in _reviewers_requested(pr) if login not in first
+        ]
+        assert _mentioned(pr) == candidates[: sut.REVIEWER_REQUEST_BATCH]
+
+    def test_systemic_failure_stops_following_batches(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(25)]
+
+        def _always_fail(_reviewers):
+            exc = sut.GithubException("nope")
+            exc.status = 500
+            raise exc
+
+        pr.create_review_request.side_effect = _always_fail
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert pr.create_review_request.call_count == 1
+        assert _mentioned(pr) == candidates
+
+    def test_failing_request_does_not_raise(self):
         gh, gh_repo, pr, args = _make_add_reviewers_stubs()
         pr.create_review_request.side_effect = sut.GithubException("nope")
 
         sut._add_reviewers(gh, gh_repo, pr, args, [f"u{i}" for i in range(25)])
-
-        assert pr.create_review_request.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -1686,6 +1773,7 @@ def _mentioned(pr):
 def _existing_comment(body):
     comment = MagicMock()
     comment.body = body
+    comment.user = SimpleNamespace(login="copilot-bot")
     return comment
 
 
@@ -1702,14 +1790,20 @@ class TestMentionFallback:
         assert _reviewers_requested(pr) == ["insider"]
         assert _mentioned(pr) == ["outsider"]
 
-    def test_candidates_dropped_by_retry_are_mentioned(self):
+    def test_candidates_a_failing_batch_could_not_take_are_mentioned(self):
         gh, gh_repo, pr, args = _make_add_reviewers_stubs()
         candidates = [f"u{i}" for i in range(25)]
-        pr.create_review_request.side_effect = [sut.GithubException("too many"), None]
+        tail = set(candidates[sut.REVIEWER_REQUEST_BATCH :])
+
+        def _reject_last_batch(reviewers):
+            if set(reviewers) <= tail:
+                raise sut.GithubException("nope")
+
+        pr.create_review_request.side_effect = _reject_last_batch
 
         sut._add_reviewers(gh, gh_repo, pr, args, candidates)
 
-        assert _mentioned(pr) == candidates[sut.REVIEWER_RETRY_BATCH :]
+        assert _mentioned(pr) == candidates[sut.REVIEWER_REQUEST_BATCH :]
 
     def test_everyone_is_mentioned_when_the_request_fails_outright(self):
         gh, gh_repo, pr, args = _make_add_reviewers_stubs()
@@ -1813,6 +1907,34 @@ class TestMentionCommentIsIdempotent:
         pr, _ = self._run("just a normal review comment, no marker")
 
         assert len(_posted_comments(pr)) == 1
+
+    def test_obsolete_comment_is_deleted_when_nobody_is_left(self):
+        """Everyone it named has since been requested, so the comment is wrong."""
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        existing = _existing_comment(f"{sut.MENTION_MARKER}\n@outsider\n\nold text")
+        pr.get_issue_comments.return_value = [existing]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["insider"])
+
+        existing.delete.assert_called_once()
+
+    def test_nothing_is_deleted_in_dry_run(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        args.dry_run = True
+        existing = _existing_comment(f"{sut.MENTION_MARKER}\n@outsider\n\nold text")
+        pr.get_issue_comments.return_value = [existing]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["insider"])
+
+        existing.delete.assert_not_called()
+
+    def test_comment_deletion_failure_does_not_raise(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        existing = _existing_comment(f"{sut.MENTION_MARKER}\n@outsider\n\nold text")
+        existing.delete.side_effect = sut.GithubException("no write access")
+        pr.get_issue_comments.return_value = [existing]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["insider"])
 
     def test_maintainer_outside_the_org_reaches_the_comment(self):
         """End-to-end: an area maintainer without push access is still asked."""


### PR DESCRIPTION
A single GitHub review request accepts at most 15 users, but _request_reviews() sent the whole candidate list in one call and, when GitHub rejected it, retried with only the first 15 and gave up on the rest. Those left over were merely mentioned in a comment, and only a later run of the script - where the first 15 are filtered out as existing reviewers - added them. That is why a PR received a subset of its reviewers on the first run and more on the second.

Split the candidates into batches of REVIEWER_REQUEST_BATCH (15) and issue one request per batch, so every eligible reviewer is added on the first run. A rejected batch is now retried one user at a time, so a single bad candidate (deleted account, lost collaborator status) no longer costs the rest of its batch their review request; only the users that still fail are mentioned instead.

Also delete the reviewer-mention comment once a run has nobody left to mention, so the PR stops claiming that people could not be requested after they have been.

Verified with scripts/tests/ci/test_set_assignees.py, extended with tests for the batching, the per-user fallback and the comment cleanup.