### PR TITLE
net: sockets: validate the getsockopt optlen pointer

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -912,9 +912,12 @@ int z_impl_zsock_getsockopt(int sock, int level, int optname,
 int z_vrfy_zsock_getsockopt(int sock, int level, int optname,
 			    void *optval, net_socklen_t *optlen)
 {
-	net_socklen_t kernel_optlen = *(net_socklen_t *)optlen;
+	net_socklen_t kernel_optlen;
 	void *kernel_optval;
 	int ret;
+
+	K_OOPS(k_usermode_from_copy(&kernel_optlen, optlen,
+		sizeof(net_socklen_t)));
 
 	if (K_SYSCALL_MEMORY_WRITE(optval, kernel_optlen)) {
 		errno = -EPERM;


### PR DESCRIPTION
z_vrfy_zsock_getsockopt() dereferenced the userspace optlen pointer directly, giving a user thread an arbitrary kernel read or causing the kernel to dereference a null pointer.