### PR TITLE
dts: ethernet: wch: drop the Synopsys DWMAC compatibles

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -582,7 +582,7 @@ Ethernet
   (:dtcompatible:`infineon,xmc4xxx-ethernet`). (:github:`114899`)
 
 * The compatibles ``espressif,esp32-mdio``, ``infineon,xmc4xxx-mdio``, ``nxp,enet-qos-mdio``,
-  ``nxp,s32-gmac-mdio``, ``st,stm32-mdio`` and ``wch,mdio`` have been replaced by
+  ``nxp,s32-gmac-mdio`` and ``st,stm32-mdio`` have been replaced by
   :dtcompatible:`snps,dwmac-mdio`. (:github:`114899`)
 
 * The NXP ENET-QOS Ethernet controller (:dtcompatible:`nxp,enet-qos`) devicetree structure has been

--- a/drivers/ethernet/mdio/Kconfig.wch
+++ b/drivers/ethernet/mdio/Kconfig.wch
@@ -4,7 +4,6 @@
 config MDIO_WCH
 	bool "WCH MDIO controller driver"
 	default y
-	depends on SOC_FAMILY_CH32V
-	depends on DT_HAS_SNPS_DWMAC_MDIO_ENABLED
+	depends on DT_HAS_WCH_MDIO_ENABLED
 	help
 	  Enable WCH MDIO support.

--- a/drivers/ethernet/mdio/mdio_wch.c
+++ b/drivers/ethernet/mdio/mdio_wch.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT snps_dwmac_mdio
+#define DT_DRV_COMPAT wch_mdio
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mdio_wch, CONFIG_MDIO_LOG_LEVEL);

--- a/dts/bindings/ethernet/mdio/wch,mdio.yaml
+++ b/dts/bindings/ethernet/mdio/wch,mdio.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 James Bennion-Pedley <james@bojit.org>
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH MDIO Controller
+
+compatible: "wch,mdio"
+
+include: [mdio-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  "#address-cells":
+    required: true
+    const: 1
+
+  "#size-cells":
+    required: true
+    const: 0
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true

--- a/dts/bindings/ethernet/wch,ethernet.yaml
+++ b/dts/bindings/ethernet/wch,ethernet.yaml
@@ -6,7 +6,7 @@ title: Ethernet MAC Controller for WCH CH32 series MCUs
 compatible: "wch,ethernet"
 
 include:
-  - name: snps,dwmac.yaml
+  - name: ethernet-controller.yaml
   - name: pinctrl-device.yaml
 
 properties:

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -11,7 +11,7 @@
 	soc {
 		eth: mac: ethernet@40028000 {
 			reg = <0x40028000 0x2000>;
-			compatible = "wch,ethernet", "snps,dwmac";
+			compatible = "wch,ethernet";
 			clocks = <&rcc CH32V20X_V30X_CLOCK_ETHMAC>,
 				 <&rcc CH32V20X_V30X_CLOCK_ETHMACTX>,
 				 <&rcc CH32V20X_V30X_CLOCK_ETHMACRX>;
@@ -20,12 +20,10 @@
 			interrupts = <77>, <78>;
 			internal-phy-pllmul = "15";
 			internal-phy-prediv = "2";
-			snps,multicast-filter-bins = <64>;
-			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {
-				compatible = "snps,dwmac-mdio";
+				compatible = "wch,mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";

--- a/dts/riscv/wch/ch32v317/ch32v317.dtsi
+++ b/dts/riscv/wch/ch32v317/ch32v317.dtsi
@@ -11,7 +11,7 @@
 	soc {
 		eth: mac: ethernet@40028000 {
 			reg = <0x40028000 0x2000>;
-			compatible = "wch,ethernet", "snps,dwmac";
+			compatible = "wch,ethernet";
 			clocks = <&rcc CH32V20X_V30X_CLOCK_ETHMAC>,
 				 <&rcc CH32V20X_V30X_CLOCK_ETHMACTX>,
 				 <&rcc CH32V20X_V30X_CLOCK_ETHMACRX>;
@@ -20,12 +20,10 @@
 			interrupts = <77>, <78>;
 			internal-phy-pllmul = "15";
 			internal-phy-prediv = "2";
-			snps,multicast-filter-bins = <64>;
-			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {
-				compatible = "snps,dwmac-mdio";
+				compatible = "wch,mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";


### PR DESCRIPTION
Revert commit de54141bbf38 ("dts: ethernet: wch: add snps,dwmac") and commit 82fc84fca053 ("dts: bindings: ethernet: mdio: wch: use snps,dwmac-mdio"), which describe the WCH Ethernet MAC as `snps,dwmac` and its MDIO as `snps,dwmac-mdio`. Keep the flattened devicetree layout from commit 2b254cf94ca7 ("drivers: ethernet: wch: allign devicetree structure").

The two controllers share most of their register layout, but differ in detail. DWMAC encodes the line speed as 0b10 for 10 Mbps, 0b11 for 100 Mbps and 0b00 for 1000 Mbps; the CH32 Ethernet uses 0b00, 0b01 and 0b10 for the same three speeds, swapping 10 Mbps and 1000 Mbps. The CH32 also lacks features such as CRC pad stripping, and adds ones DWMAC does not have, such as the transmit clock delay in the MAC control register. Further differences are likely, and a shared driver would turn them into hard-to-diagnose errors. Treat the controller as a distinct part instead.

Restore the ethernet-controller.yaml include that snps,dwmac.yaml had replaced; it provides the types for reg, clocks and the PHY properties. Revert commit 39a9edc0b2f2 ("dts: ethernet: wch: describe multicast filter capabilities") as well: snps,multicast-filter-bins and snps,perfect-filter-entries are declared only by the DWMAC binding and unused by the WCH driver. Update the 4.5 migration guide accordingly.