### PR TITLE
fix: tracing: ctf: add sleep_ticks tracing

### DIFF
--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -3363,3 +3363,20 @@ event {
 		uint32_t id;
 	};
 };
+
+event {
+	name = thread_sleep_ticks_enter;
+	id = 0x184;
+	fields := struct {
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = thread_sleep_ticks_exit;
+	id = 0x185;
+	fields := struct {
+		uint32_t timeout;
+		int32_t ret;
+	};
+};


### PR DESCRIPTION
Commit a672a717cae added the sleep_ticks enter/exit trace enums 0x184 and 0x185 to factorize the sleep functions tracing, but the metadata was not updated with the matching event classes. Add them in the metadata.

Assisted-by: opencode:big-pickle