### PR TITLE
drivers: modem: quectel_eg915u: hold PWRKEY long enough to power off

### DIFF
--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
@@ -64,7 +64,7 @@ static const struct modem_cellular_vendor_config quectel_eg915u_vendor = {
 	/* clang-format on */
 	.chat_delimiter = "\r",
 	.chat_filter = "\n",
-	.power_pulse_duration_ms = 2000,
+	.power_pulse_duration_ms = 3100,
 	.reset_pulse_duration_ms = 500,
 	.startup_time_ms = 15000,
 	.shutdown_time_ms = 3000,


### PR DESCRIPTION
The EG915U hardware design (V1.1, section 3.6 and section 3.7.1) requires PWRKEY to be driven low for at least 2 s to turn the module on and for at least 3 s to turn it off.

modem_cellular applies a single power_pulse_duration_ms to both the power-on pulse and the power-off pulse, so the current 2000 ms only satisfies the turn-on requirement. On a power-off request, the driver releases PWRKEY after 2 s; the module ignores the pulse and stays running, while the state machine advances to AWAIT_POWER_OFF, then IDLE, and reports the device as suspended.

This raises the pulse to 3100 ms, which meets both minimums with a small margin. The driver already takes the larger of the two timings for the Fibocom LE250 (3200 ms) and the Telit xEx10x families (5050 ms).