### PR TITLE
dts: arm: infineon: psc3: fix CPU clock-frequency override path

### DIFF
--- a/dts/arm/infineon/cat1b/mpns/psc3m3edabq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edabq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edabq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edabq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edacq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edacq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edacq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edacq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edlgq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edlgq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edlgq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edlgq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edlhq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edlhq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3edlhq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3edlhq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2abq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2abq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2abq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2abq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2acq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2acq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2acq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2acq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2lgq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2lgq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2lgq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2lgq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2lhq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2lhq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3m3fds2lhq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3m3fds2lhq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edabq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edabq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edabq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edabq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edacq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edacq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edacq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edacq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edlgq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edlgq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edlgq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edlgq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edlhq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edlhq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2edlhq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2edlhq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2abq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2abq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2abq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2abq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2acq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2acq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2acq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2acq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.e-lqfp-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2lgq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2lgq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2lgq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2lgq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-48_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2lhq1.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2lhq1.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@42150000 {

--- a/dts/arm/infineon/cat1b/mpns/psc3p2fds2lhq1_s.dtsi
+++ b/dts/arm/infineon/cat1b/mpns/psc3p2fds2lhq1_s.dtsi
@@ -9,8 +9,10 @@
 #include "../psc3/psc3.vqfn-64_s.dtsi"
 
 / {
-	cpu@0 {
-		clock-frequency = <100000000>;
+	cpus {
+		cpu@0 {
+			clock-frequency = <100000000>;
+		};
 	};
 
 	flash-controller@52150000 {


### PR DESCRIPTION
PSC3M5 MPNs for 100MHz grade parts override clock frequency on a root-level cpu@0 node, but the CPU is declared at /cpus/cpu@0.  This creates a stray node that's never used and SYS_CLOCK_HW_CYCLES_PER_SEC is never corrected to 100MHz for these parts.

Nest the override inside cpus so it targets the intended node.
