### PR TITLE
ec_host_cmd: Fix packet length validation against integer overflow

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_espi.c
@@ -58,7 +58,7 @@ static void espi_handler(const struct device *dev, struct espi_callback *cb,
 	/* tx stores the shared memory buf pointer and size, so use it */
 	const struct ec_host_cmd_request_header *rx_header = hc_espi->tx->buf;
 	const size_t shared_size = hc_espi->tx->len_max;
-	const uint16_t rx_valid_data_size = rx_header->data_len + RX_HEADER_SIZE;
+	const size_t rx_valid_data_size = (size_t)rx_header->data_len + RX_HEADER_SIZE;
 
 	if (event_type != ESPI_PERIPHERAL_EC_HOST_CMD) {
 		return;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_usb.c
@@ -116,7 +116,7 @@ struct ec_host_cmd_usb_ctx {
 	struct k_work_delayable reset_work;
 };
 
-static int expected_request_len(const struct ec_host_cmd_request_header *header)
+static size_t expected_request_len(const struct ec_host_cmd_request_header *header)
 {
 	/* Check host request version */
 	if (header->prtcl_ver != EC_HOST_REQUEST_VERSION) {
@@ -128,7 +128,7 @@ static int expected_request_len(const struct ec_host_cmd_request_header *header)
 		return 0;
 	}
 
-	return sizeof(*header) + header->data_len;
+	return sizeof(*header) + (size_t)header->data_len;
 }
 
 static inline uint8_t ec_host_cmd_get_out_ep(struct usbd_class_data *const c_data)

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -86,7 +86,7 @@ static int64_t suppressed_cmds_deadline = CONFIG_EC_HOST_CMD_LOG_SUPPRESSED_INTE
 static size_t suppressed_cmds_number;
 #endif /* CONFIG_EC_HOST_CMD_LOG_SUPPRESSED */
 
-static uint8_t cal_checksum(const uint8_t *const buffer, const uint16_t size)
+static uint8_t cal_checksum(const uint8_t *const buffer, const size_t size)
 {
 	uint8_t checksum = 0;
 
@@ -227,13 +227,13 @@ static enum ec_host_cmd_status verify_rx(struct ec_host_cmd_rx_ctx *rx)
 		return EC_HOST_CMD_INVALID_HEADER;
 	}
 
-	const uint16_t rx_valid_data_size = rx_header->data_len + RX_HEADER_SIZE;
+	const size_t rx_valid_data_size = (size_t)rx_header->data_len + RX_HEADER_SIZE;
 	/*
 	 * Ensure we received at least as much data as is expected.
 	 * It is okay to receive more since some hardware interfaces
 	 * add on extra padding bytes at the end.
 	 */
-	if (rx->len < rx_valid_data_size) {
+	if (rx_valid_data_size > rx->len_max || rx->len < rx_valid_data_size) {
 		return EC_HOST_CMD_REQUEST_TRUNCATED;
 	}
 
@@ -273,7 +273,7 @@ static enum ec_host_cmd_status prepare_response(struct ec_host_cmd_tx_buf *tx, u
 	tx_header->data_len = len;
 	tx_header->reserved = 0;
 
-	const uint16_t tx_valid_data_size = tx_header->data_len + TX_HEADER_SIZE;
+	const size_t tx_valid_data_size = (size_t)tx_header->data_len + TX_HEADER_SIZE;
 
 	if (tx_valid_data_size > tx->len_max) {
 		return EC_HOST_CMD_INVALID_RESPONSE;

--- a/tests/subsys/mgmt/ec_host_cmd/simulator/src/main.c
+++ b/tests/subsys/mgmt/ec_host_cmd/simulator/src/main.c
@@ -412,6 +412,22 @@ ZTEST(ec_host_cmd, test_unbounded_handler_response_too_big)
 	verify_tx_error(EC_HOST_CMD_INVALID_RESPONSE);
 }
 
+
+ZTEST(ec_host_cmd, test_unbounded_handler_response_wrap)
+{
+	host_to_dut->header.prtcl_ver = 3;
+	host_to_dut->header.cmd_id = EC_CMD_UNBOUNDED;
+	host_to_dut->header.cmd_ver = 1;
+	host_to_dut->header.reserved = 0;
+	host_to_dut->header.data_len = sizeof(host_to_dut->unbounded);
+
+	/* 0xFFF8 + 8 wraps to 0 in uint16_t */
+	host_to_dut->unbounded.bytes_to_write =
+		(uint16_t)(UINT16_MAX - sizeof(struct ec_host_cmd_response_header) + 1);
+	simulate_rx_data();
+	verify_tx_error(EC_HOST_CMD_INVALID_RESPONSE);
+}
+
 #define EC_CMD_TOO_BIG 0x0003
 static enum ec_host_cmd_status
 ec_host_cmd_too_big(struct ec_host_cmd_handler_args *args)
@@ -432,6 +448,76 @@ ZTEST(ec_host_cmd, test_response_always_too_big)
 	simulate_rx_data();
 
 	verify_tx_error(EC_HOST_CMD_INVALID_RESPONSE);
+}
+
+
+ZTEST(ec_host_cmd, test_rx_data_len_overflow)
+{
+	int rv;
+
+	host_to_dut->header.prtcl_ver = 3;
+	host_to_dut->header.cmd_id = EC_CMD_HELLO;
+	host_to_dut->header.cmd_ver = 0;
+	host_to_dut->header.reserved = 0;
+
+	/* 0xFFF8 + 8 wraps to 0 in uint16_t */
+	host_to_dut->header.data_len =
+		(uint16_t)(UINT16_MAX - sizeof(struct ec_host_cmd_request_header) + 1);
+	host_to_dut->header.checksum = 0;
+
+	/* Send 64 bytes (simulating a USB bulk packet) */
+	rv = ec_host_cmd_backend_sim_data_received(host_to_dut_buffer, 64);
+	zassert_equal(rv, 0, "Could not send data %d", rv);
+
+	/* Ensure Send was called so we can verify outputs */
+	rv = k_sem_take(&send_called, K_SECONDS(1));
+	zassert_equal(rv, 0, "Send was not called");
+	verify_tx_error(EC_HOST_CMD_REQUEST_TRUNCATED);
+}
+ZTEST(ec_host_cmd, test_rx_data_len_max)
+{
+	int rv;
+
+	host_to_dut->header.prtcl_ver = 3;
+	host_to_dut->header.cmd_id = EC_CMD_HELLO;
+	host_to_dut->header.cmd_ver = 0;
+	host_to_dut->header.reserved = 0;
+
+	/* UINT16_MAX (0xFFFF) */
+	host_to_dut->header.data_len = UINT16_MAX;
+	host_to_dut->header.checksum = 0;
+
+	/* Send 64 bytes */
+	rv = ec_host_cmd_backend_sim_data_received(host_to_dut_buffer, 64);
+	zassert_equal(rv, 0, "Could not send data %d", rv);
+
+	/* Ensure Send was called so we can verify outputs */
+	rv = k_sem_take(&send_called, K_SECONDS(1));
+	zassert_equal(rv, 0, "Send was not called");
+	verify_tx_error(EC_HOST_CMD_REQUEST_TRUNCATED);
+}
+
+ZTEST(ec_host_cmd, test_rx_data_len_greater_than_len_max)
+{
+	int rv;
+
+	host_to_dut->header.prtcl_ver = 3;
+	host_to_dut->header.cmd_id = EC_CMD_HELLO;
+	host_to_dut->header.cmd_ver = 0;
+	host_to_dut->header.reserved = 0;
+
+	/* Greater than CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE */
+	host_to_dut->header.data_len = CONFIG_EC_HOST_CMD_HANDLER_RX_BUFFER_SIZE + 1;
+	host_to_dut->header.checksum = 0;
+
+	/* Send fewer bytes than data_len */
+	rv = ec_host_cmd_backend_sim_data_received(host_to_dut_buffer, 64);
+	zassert_equal(rv, 0, "Could not send data %d", rv);
+
+	/* Ensure Send was called so we can verify outputs */
+	rv = k_sem_take(&send_called, K_SECONDS(1));
+	zassert_equal(rv, 0, "Send was not called");
+	verify_tx_error(EC_HOST_CMD_REQUEST_TRUNCATED);
 }
 
 static void *ec_host_cmd_tests_setup(void)


### PR DESCRIPTION
In verify_rx() and prepare_response(), the valid data size was computed using uint16_t, which could wrap around if data_len was close to UINT16_MAX. Additionally, incoming request size was not explicitly bounded against rx->len_max.
Compute valid data sizes using size_t and reject incoming packets whose expected size exceeds rx->len_max or available rx->len. Also update the eSPI backend and cal_checksum() size type to prevent potential truncation. Add unit tests covering large data lengths and response wrapping.