### PR TITLE
tracing: ctf: per-CPU packet streams for SMP

### DIFF
--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -533,20 +533,31 @@ To get started, the simplest way is to use the CTF format with the
 
 .. zephyr-app-commands::
    :tool: all
-   :zephyr-app: samples/subsys/tracing
+   :zephyr-app: samples/subsys/tracing/basic
    :board: native_sim
-   :gen-args: -DCONF_FILE=prj_native_ctf.conf
+   :gen-args: -DEXTRA_CONF_FILE=prj_native_ctf.conf
    :goals: build
+
+The ``prj_*.conf`` files are overlays on top of the sample's ``prj.conf``, so
+they have to be applied with ``EXTRA_CONF_FILE``; passing them as ``CONF_FILE``
+replaces the baseline instead and produces an image with tracing disabled.
 
 You can then run the resulting binary with the option ``-trace-file`` to generate
 the tracing data::
 
-    mkdir data
+    ./build/zephyr/zephyr.exe -trace-file=channel0_0
+
+Split the capture into one file per CPU and add the metadata beside them::
+
+    $ZEPHYR_BASE/scripts/tracing/split_ctf_streams.py -i channel0_0 -o data/
     cp $ZEPHYR_BASE/subsys/tracing/ctf/tsdl/metadata data/
-    ./build/zephyr/zephyr.exe -trace-file=data/channel0_0
 
 The resulting CTF output can be visualized using babeltrace or TraceCompass
 by pointing the tool to the ``data`` directory with the metadata and trace files.
+
+Events are gathered into fixed-size CTF packets and each CPU produces its own
+stream, so on an SMP system the reader merges the per-CPU streams into a single
+timeline and every event carries the ``cpu_id`` of the CPU that emitted it.
 
 Using RAM backend
 =================

--- a/include/zephyr/tracing/tracing_format.h
+++ b/include/zephyr/tracing/tracing_format.h
@@ -89,28 +89,6 @@ void tracing_format_string(const char *str, ...);
 void tracing_format_raw_data(uint8_t *data, uint32_t length);
 
 /**
- * @brief Tracing a message in raw data format, timestamped at emission.
- *
- * Identical to tracing_format_raw_data(), except that the first
- * sizeof(uint64_t) bytes of @a data are overwritten with a tracing timestamp
- * sampled while the emitting CPU holds the tracing lock. Reading the clock at
- * that point rather than at the call site is what keeps the timestamps in the
- * stream monotonic: on SMP the caller may otherwise lose the race for the
- * tracing lock to a CPU that sampled the clock later, and insert an event with
- * an older timestamp behind it.
- *
- * Callers must reserve the leading timestamp slot themselves, so @a length must
- * be at least sizeof(uint64_t). Intended for tracing formats that carry a
- * timestamp in their event header; other callers want
- * tracing_format_raw_data().
- *
- * @param data   Raw data to be traced, with sizeof(uint64_t) leading bytes
- *               reserved for the timestamp.
- * @param length Raw data length, including the reserved timestamp.
- */
-void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length);
-
-/**
  * @brief Tracing a message in tracing data format.
  *
  * @param tracing_data_array Tracing_data format data array to be traced.

--- a/include/zephyr/tracing/tracing_format.h
+++ b/include/zephyr/tracing/tracing_format.h
@@ -89,6 +89,28 @@ void tracing_format_string(const char *str, ...);
 void tracing_format_raw_data(uint8_t *data, uint32_t length);
 
 /**
+ * @brief Tracing a message in raw data format, timestamped at emission.
+ *
+ * Identical to tracing_format_raw_data(), except that the first
+ * sizeof(uint64_t) bytes of @a data are overwritten with a tracing timestamp
+ * sampled while the emitting CPU holds the tracing lock. Reading the clock at
+ * that point rather than at the call site is what keeps the timestamps in the
+ * stream monotonic: on SMP the caller may otherwise lose the race for the
+ * tracing lock to a CPU that sampled the clock later, and insert an event with
+ * an older timestamp behind it.
+ *
+ * Callers must reserve the leading timestamp slot themselves, so @a length must
+ * be at least sizeof(uint64_t). Intended for tracing formats that carry a
+ * timestamp in their event header; other callers want
+ * tracing_format_raw_data().
+ *
+ * @param data   Raw data to be traced, with sizeof(uint64_t) leading bytes
+ *               reserved for the timestamp.
+ * @param length Raw data length, including the reserved timestamp.
+ */
+void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length);
+
+/**
  * @brief Tracing a message in tracing data format.
  *
  * @param tracing_data_array Tracing_data format data array to be traced.

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -133,18 +133,43 @@ static inline int z_vrfy_k_thread_priority_get(k_tid_t thread)
 #endif /* CONFIG_USERSPACE */
 
 #ifdef CONFIG_THREAD_NAME
+/*
+ * Serializes renaming a thread against taking a copy of its name.
+ *
+ * Renaming writes several bytes into a buffer another CPU may be reading at the
+ * same moment, so without this a reader can come away with a mixture of the old
+ * and the new name. Renaming a thread that is already running is what makes
+ * this reachable: tracing, for one, reads the name of every thread it sees
+ * switched in, and has been observed recording a name spliced out of both.
+ *
+ * This is a leaf lock. Nothing is acquired while it is held, so it stays safe
+ * to take from a context that already holds another lock - a thread switch
+ * tracing hook running under the scheduler lock, in particular.
+ */
+static struct k_spinlock thread_name_lock;
+
 static void set_thread_name(struct k_thread *thread, const char *str)
 {
+	k_spinlock_key_t key = k_spin_lock(&thread_name_lock);
+
 	if (str != NULL) {
 		strncpy(thread->name, str, CONFIG_THREAD_MAX_NAME_LEN - 1);
 		/* Ensure NULL termination, truncate if longer */
 		thread->name[CONFIG_THREAD_MAX_NAME_LEN - 1] = '\0';
-#ifdef CONFIG_ARCH_HAS_THREAD_NAME_HOOK
-		arch_thread_name_set(thread, str);
-#endif /* CONFIG_ARCH_HAS_THREAD_NAME_HOOK */
 	} else {
 		thread->name[0] = '\0';
 	}
+
+	k_spin_unlock(&thread_name_lock, key);
+
+#ifdef CONFIG_ARCH_HAS_THREAD_NAME_HOOK
+	if (str != NULL) {
+		/* Kept outside the lock: this is arch code that does more than
+		 * write the buffer above, and the lock has to remain a leaf.
+		 */
+		arch_thread_name_set(thread, str);
+	}
+#endif /* CONFIG_ARCH_HAS_THREAD_NAME_HOOK */
 }
 #endif /* CONFIG_THREAD_NAME */
 
@@ -211,7 +236,22 @@ const char *k_thread_name_get(k_tid_t thread)
 int z_impl_k_thread_name_copy(k_tid_t thread, char *buf, size_t size)
 {
 #ifdef CONFIG_THREAD_NAME
+	k_spinlock_key_t key;
+
+	if (size == 0U) {
+		return 0;
+	}
+
+	key = k_spin_lock(&thread_name_lock);
 	strncpy(buf, thread->name, size);
+	k_spin_unlock(&thread_name_lock, key);
+
+	/* strncpy() writes no terminator when the name is at least as long as
+	 * the destination, so supply one rather than hand back a string the
+	 * caller cannot safely read.
+	 */
+	buf[size - 1U] = '\0';
+
 	return 0;
 #else
 	ARG_UNUSED(thread);
@@ -293,6 +333,7 @@ static inline int z_vrfy_k_thread_name_copy(k_tid_t thread,
 					    char *buf, size_t size)
 {
 #ifdef CONFIG_THREAD_NAME
+	char name[CONFIG_THREAD_MAX_NAME_LEN];
 	size_t len;
 	struct k_object *ko = k_object_find(thread);
 
@@ -306,12 +347,20 @@ static inline int z_vrfy_k_thread_name_copy(k_tid_t thread,
 	if (K_SYSCALL_MEMORY_WRITE(buf, size) != 0) {
 		return -EFAULT;
 	}
-	len = strlen(thread->name);
+
+	/* Take one stable copy and work from that. Measuring the name and then
+	 * copying it straight out of the thread reads the buffer twice, so a
+	 * rename in between could change the length out from under the check,
+	 * quite apart from handing user mode a torn name.
+	 */
+	(void)z_impl_k_thread_name_copy(thread, name, sizeof(name));
+
+	len = strlen(name);
 	if ((len + 1) > size) {
 		return -ENOSPC;
 	}
 
-	return k_usermode_to_copy((void *)buf, thread->name, len + 1);
+	return k_usermode_to_copy((void *)buf, name, len + 1);
 #else
 	ARG_UNUSED(thread);
 	ARG_UNUSED(buf);

--- a/samples/subsys/tracing/basic/README.rst
+++ b/samples/subsys/tracing/basic/README.rst
@@ -312,9 +312,11 @@ the console, in the spirit of SEGGER SystemView or Trace Compass.
 It decodes the packed CTF records itself (reading the field layout from the same
 :zephyr_file:`subsys/tracing/ctf/tsdl/metadata`) so it has no dependencies
 beyond Python 3. It reads a raw capture directly, with no need to split the
-per-CPU streams out of it first; because the timeline draws a single
-running-thread lane it shows one CPU at a time, the first one seen unless
-``--cpu`` selects another.
+per-CPU streams out of it first. On an SMP capture the timeline is grouped by
+CPU: a row per CPU showing how busy it was, with the threads that ran on it
+nested underneath, so a migrating thread is seen moving between the groups. A
+second section below keeps one lane per thread across all CPUs, showing thread
+state. ``--cpu`` narrows the display to a single CPU.
 
 With the default semihosting backend the run produces a ``tracing.bin`` in the
 build directory:

--- a/samples/subsys/tracing/basic/README.rst
+++ b/samples/subsys/tracing/basic/README.rst
@@ -311,7 +311,10 @@ For a quick look without installing any external tooling,
 the console, in the spirit of SEGGER SystemView or Trace Compass.
 It decodes the packed CTF records itself (reading the field layout from the same
 :zephyr_file:`subsys/tracing/ctf/tsdl/metadata`) so it has no dependencies
-beyond Python 3.
+beyond Python 3. It reads a raw capture directly, with no need to split the
+per-CPU streams out of it first; because the timeline draws a single
+running-thread lane it shows one CPU at a time, the first one seen unless
+``--cpu`` selects another.
 
 With the default semihosting backend the run produces a ``tracing.bin`` in the
 build directory:

--- a/samples/subsys/tracing/basic/README.rst
+++ b/samples/subsys/tracing/basic/README.rst
@@ -268,19 +268,40 @@ Decoding a CTF trace
 ********************
 
 The CTF backends (UART, USB, POSIX and RAM) emit a binary stream that follows
-the metadata in :zephyr_file:`subsys/tracing/ctf/tsdl/metadata`. To view it,
-place the captured stream next to that metadata file and open it with a
+the metadata in :zephyr_file:`subsys/tracing/ctf/tsdl/metadata`. Events are
+gathered into fixed-size CTF packets, and each CPU produces its own sequence of
+them, tagged with the CPU number in the packet context.
+
+Because a backend such as UART, USB or RAM carries one link, the packets of
+every CPU arrive interleaved on it. Split them into the one-file-per-stream
+layout a CTF reader expects with
+:zephyr_file:`scripts/tracing/split_ctf_streams.py`, then open the result with a
 CTF-aware tool such as `babeltrace2 <https://babeltrace.org/>`_:
 
 .. code-block:: console
 
-	mkdir ctf
-	cp channel0_0 ctf/
+	$ZEPHYR_BASE/scripts/tracing/split_ctf_streams.py -i channel0_0 -o ctf/
 	cp $ZEPHYR_BASE/subsys/tracing/ctf/tsdl/metadata ctf/
 	babeltrace2 ctf/
 
+The splitter also reports how many events, if any, the target had to discard
+because no free packet was available. On a uniprocessor build there is only one
+CPU, so the step just produces a single ``channel0_0``; running it is harmless
+either way.
+
+The reader merges the per-CPU streams into one timeline ordered by the trace
+clock, so events from different CPUs appear interleaved in time, each carrying
+the ``cpu_id`` of the CPU that produced it.
+
 The same ``ctf`` directory can also be opened in `Trace Compass
 <https://eclipse.dev/tracecompass/>`_ for a graphical timeline.
+
+.. note::
+   Correlating streams across CPUs assumes the timing counter behind the trace
+   clock is shared by all of them. That holds for the counters Zephyr uses on
+   the SMP-capable targets - the x86 TSC and the Arm generic timer, for example
+   - but a per-core cycle counter would place each CPU on its own time base and
+   the merge would be meaningless.
 
 Viewing a CTF trace in the terminal
 ***********************************

--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -60,6 +60,15 @@ def main():
 
         ns_from_origin = msg.default_clock_snapshot.ns_from_origin
         event = msg.event
+
+        # Zephyr's sequential CPU id, carried as the event common context by
+        # every event. Guarded so that traces captured with an older metadata
+        # that has no common context still parse.
+        cpu = None
+        if event.common_context_field is not None:
+            cpu = event.common_context_field.get("cpu_id", None)
+        cpu_string = "" if cpu is None else f"(cpu: {cpu})"
+
         # Compute the time difference since the last event message.
         diff_s = 0
 
@@ -79,22 +88,16 @@ def main():
                 'thread_abort'
                 ]:
 
-            cpu = event.payload_field.get("cpu", None)
             thread_id = event.payload_field.get("thread_id", None)
             thread_name = event.payload_field.get("name", None)
 
             th = {}
-            if event.name in ['thread_switched_out', 'thread_switched_in'] and cpu is not None:
-                cpu_string = f"(cpu: {cpu})"
-            else:
-                cpu_string = ""
-
             if thread_name:
                 print(f"{dt} (+{diff_s:.6f} s): {event.name}: {thread_name} {cpu_string}")
             elif thread_id:
                 print(f"{dt} (+{diff_s:.6f} s): {event.name}: {thread_id} {cpu_string}")
             else:
-                print(f"{dt} (+{diff_s:.6f} s): {event.name}")
+                print(f"{dt} (+{diff_s:.6f} s): {event.name} {cpu_string}")
 
             if event.name in ['thread_switched_out', 'thread_switched_in']:
                 if thread_name:
@@ -142,7 +145,7 @@ def main():
             arg1 = event.payload_field['arg1']
             print(f"{dt} (+{diff_s:.6f} s): {event.name} (name: {name}, arg0: {arg0} arg1: {arg1})")
         else:
-            print(f"{dt} (+{diff_s:.6f} s): {event.name}")
+            print(f"{dt} (+{diff_s:.6f} s): {event.name} {cpu_string}")
 
         last_event_ns_from_origin = ns_from_origin
 

--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -61,12 +61,12 @@ def main():
         ns_from_origin = msg.default_clock_snapshot.ns_from_origin
         event = msg.event
 
-        # Zephyr's sequential CPU id, carried as the event common context by
-        # every event. Guarded so that traces captured with an older metadata
-        # that has no common context still parse.
+        # Zephyr's sequential CPU id, carried by the context of the packet the
+        # event came in. Guarded so a trace captured with an older metadata
+        # that has no packet context still parses.
         cpu = None
-        if event.common_context_field is not None:
-            cpu = event.common_context_field.get("cpu_id", None)
+        if event.packet is not None and event.packet.context_field is not None:
+            cpu = event.packet.context_field.get("cpu_id", None)
         cpu_string = "" if cpu is None else f"(cpu: {cpu})"
 
         # Compute the time difference since the last event message.

--- a/scripts/tracing/split_ctf_streams.py
+++ b/scripts/tracing/split_ctf_streams.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Split a Zephyr CTF capture into one stream file per CPU.
+
+A backend that drives a single link - a UART, USB, or a RAM buffer read out
+with a debugger - carries the packets of every CPU interleaved on that one
+link. babeltrace2 wants one file per stream, so the packets have to be sorted
+by the cpu_id in their packet context before the trace can be read.
+
+Each packet is self describing: the header carries a magic number and the
+context carries the packet size, so this needs no knowledge of the events
+themselves and does not have to be kept in step with the event metadata.
+
+Usage:
+
+    ./scripts/tracing/split_ctf_streams.py -i channel0_0 -o ctf/
+    cp subsys/tracing/ctf/tsdl/metadata ctf/
+    babeltrace2 ctf/
+"""
+
+import argparse
+import pathlib
+import struct
+import sys
+
+CTF_MAGIC = 0xC1FC1FC1
+
+# struct packet_header { uint32_t magic; uint32_t stream_id; }
+HEADER = struct.Struct("<II")
+# struct packet_context { uint64 timestamp_begin; uint64 timestamp_end;
+#                         uint32 content_size; uint32 packet_size;
+#                         uint32 events_discarded; uint8 cpu_id; }
+CONTEXT = struct.Struct("<QQIIIB")
+PREFIX_SIZE = HEADER.size + CONTEXT.size
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument("-i", "--input", required=True,
+                        help="raw CTF capture holding interleaved packets")
+    parser.add_argument("-o", "--output", required=True,
+                        help="directory to write the per-CPU stream files into")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="report every packet as it is split out")
+    return parser.parse_args()
+
+
+def resync(data, pos):
+    """Find the next packet magic at or after pos, or None."""
+    want = struct.pack("<I", CTF_MAGIC)
+    found = data.find(want, pos)
+    return None if found < 0 else found
+
+
+def main():
+    args = parse_args()
+
+    data = pathlib.Path(args.input).read_bytes()
+    outdir = pathlib.Path(args.output)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    streams = {}
+    pos = 0
+    packets = 0
+    resyncs = 0
+    truncated = 0
+    discarded_seen = {}
+
+    while pos + PREFIX_SIZE <= len(data):
+        magic, _stream_id = HEADER.unpack_from(data, pos)
+        if magic != CTF_MAGIC:
+            # A lossy transport can drop bytes; scan forward for the next
+            # packet rather than giving up on the whole capture.
+            nxt = resync(data, pos + 1)
+            if nxt is None:
+                break
+            resyncs += 1
+            pos = nxt
+            continue
+
+        (_ts_begin, _ts_end, _content_bits,
+         packet_bits, discarded, cpu_id) = CONTEXT.unpack_from(data, pos + HEADER.size)
+
+        packet_size = packet_bits // 8
+        if packet_size < PREFIX_SIZE:
+            # Not a packet we can trust; treat the magic as a coincidence.
+            nxt = resync(data, pos + 1)
+            if nxt is None:
+                break
+            resyncs += 1
+            pos = nxt
+            continue
+
+        if pos + packet_size > len(data):
+            # Capture stopped mid-packet.
+            truncated = len(data) - pos
+            break
+
+        if cpu_id not in streams:
+            streams[cpu_id] = (outdir / f"channel0_{cpu_id}").open("wb")
+        streams[cpu_id].write(data[pos:pos + packet_size])
+
+        discarded_seen[cpu_id] = discarded
+        packets += 1
+        if args.verbose:
+            print(f"packet {packets}: cpu {cpu_id}, {packet_size} bytes, "
+                  f"{_content_bits // 8} bytes of events")
+
+        pos += packet_size
+
+    for f in streams.values():
+        f.close()
+
+    if not streams:
+        sys.exit(f"No CTF packets found in {args.input}. Was the capture made "
+                 "with a CTF-format tracing build?")
+
+    print(f"{packets} packets -> {len(streams)} stream(s) in {outdir}")
+    for cpu_id in sorted(streams):
+        print(f"  channel0_{cpu_id}: cpu {cpu_id}, "
+              f"{discarded_seen[cpu_id]} event(s) discarded on target")
+    if resyncs:
+        print(f"WARNING: resynchronized {resyncs} time(s); the capture lost bytes")
+    if truncated:
+        print(f"WARNING: dropped a trailing partial packet of {truncated} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -1065,7 +1065,7 @@ def window_stats(tr, view0, view1):
 
 def run_text(tr, width):
     lanes = cpu_lane_order(tr)
-    order = all_lanes(tr)
+    threads = lane_order(tr)
     header = "CPU / THREAD"
     label_w = max([len(header)] + [len(lane_label(tr, ln)) for ln in lanes]) + 1
     label_w = min(label_w, 22)
@@ -1080,7 +1080,7 @@ def run_text(tr, width):
     print()
 
     occ = render_cpu_occupancy(tr, lanes, tr.t0, tr.t1, tl_w)
-    state_rows = render_state_rows(tr, order, tr.t0, tr.t1, tl_w)
+    state_rows = render_state_rows(tr, threads, tr.t0, tr.t1, tl_w)
 
     def lbl(s):
         s = s[: label_w - 1]
@@ -1112,7 +1112,7 @@ def run_text(tr, width):
     print()
     print(ruler)
     print(lbl("THREAD") + axis)
-    for tid in order:
+    for tid in threads:
         cells = state_rows[tid]
         if all(c is None for c in cells):
             continue
@@ -1139,7 +1139,7 @@ def run_text(tr, width):
         f"  {'handle':<12}{'name':<18}{'prio':>5}  {'stack_base':<12}"
         f"{'stack_sz':>9}  {'cpus':<16}"
     )
-    for tid in order:
+    for tid in threads:
         t = tr.threads[tid]
         prio = "" if t["prio"] is None else str(t["prio"])
         sb = "" if t["stack_base"] is None else f"0x{t['stack_base']:08x}"

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -1268,19 +1268,34 @@ def run_curses(stdscr, reader, fh=None):
                 chunk = fh.read()
             except OSError:
                 chunk = b""
+            prev_span = max(0, tr.t1 - tr.t0)
             if reader.feed(chunk):
                 # Rebuilt rather than extended: the trace is reassembled in
                 # timestamp order on every update, so a late packet from
                 # another CPU can land events before the end of the list.
                 ts_list[:] = [ev.ts for ev in tr.events]
+                was_empty = full_span <= 1
                 full_span = max(1, tr.t1 - tr.t0)
+                if was_empty:
+                    # Following a trace that had not started yet: the autoplay
+                    # rate was derived from an empty span and would be useless.
+                    speed = max(1.0, full_span / 20.0)
                 if (len(tr.threads), len(tr.cpus)) != lane_sig:
                     lane_sig = (len(tr.threads), len(tr.cpus))
                     order = all_lanes(tr)
             if live_follow and tr.t1 > tr.t0:
-                span = max(100, view1 - view0)
-                view1 = tr.t1
-                view0 = max(tr.t0, view1 - span)
+                # A window that was showing the whole trace keeps showing the
+                # whole trace as it grows; one the user has zoomed into keeps
+                # its width and rides the live edge. Without this a viewer
+                # started before the application produced anything is stuck
+                # with the width of an empty trace, which reads as being zoomed
+                # in to nothing.
+                if (view1 - view0) >= prev_span:
+                    view0, view1 = tr.t0, tr.t1
+                else:
+                    keep = max(100, view1 - view0)
+                    view1 = tr.t1
+                    view0 = max(tr.t0, view1 - keep)
                 cursor_ns = float(tr.t1)
                 log_scroll = len(tr.events)  # keep log view at the newest row
 

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -375,7 +375,10 @@ class TraceReader:
         # CPU whose stream is being followed, and everything seen in the trace.
         self.cpu = cpu
         self.cpus_seen = set()
-        self.discarded = 0
+        # cpu -> events the target dropped on that CPU. The packet context
+        # carries a running total per stream, so the last value seen for a
+        # CPU is that CPU's total.
+        self.discarded = {}
         # Some platforms back the CTF timestamp with a free-running cycle
         # counter that wraps, giving a sawtooth instead of a monotonic clock.
         # Unwrap it: every time the raw value jumps backwards, add the previous
@@ -602,7 +605,7 @@ class TraceReader:
                 break  # incomplete trailing packet; wait for more
 
             self.cpus_seen.add(cpu)
-            self.discarded = max(self.discarded, discarded)
+            self.discarded[cpu] = discarded
 
             # Every CPU is decoded; self.cpu, when set, narrows the display to
             # one of them rather than the decode.
@@ -669,10 +672,13 @@ def _report_cpus(reader):
                 f"note: restricted to CPU {reader.cpu}; this trace also has "
                 f"{', '.join(str(c) for c in others)} (drop --cpu to see them all)\n"
             )
-    if reader.discarded:
+    dropped = {c: n for c, n in reader.discarded.items() if n}
+    if dropped:
+        per_cpu = ", ".join(f"{n} on CPU {c}" for c, n in sorted(dropped.items()))
         sys.stderr.write(
-            f"warning: the target discarded {reader.discarded} event(s) on CPU "
-            f"{reader.cpu} for want of a free packet\n"
+            f"warning: the target discarded {sum(dropped.values())} event(s) "
+            f"({per_cpu}) for want of a free packet; this trace is incomplete. "
+            "Raise CONFIG_TRACING_CTF_PACKETS_PER_CPU to capture them.\n"
         )
 
 

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -35,6 +35,13 @@ from the TSDL ``metadata`` file that ships next to the tracing subsystem
 events added there; a built-in fallback table covers the core scheduling events
 so the time graph still works even when the metadata file cannot be found.
 
+A capture taken on an SMP system holds one stream per CPU, and on a backend
+carrying a single link those streams arrive interleaved. The raw capture can be
+opened directly - there is no need to split it first - but since the time graph
+draws a single running-thread lane it shows one CPU at a time, the first one
+seen unless ``--cpu`` says otherwise. Captures predating the packet framing are
+still read as-is.
+
 Usage::
 
     # interactive viewer (a terminal/TTY is required)
@@ -48,6 +55,9 @@ Usage::
 
     # point at a specific metadata file
     ./trace_viewer.py build/tracing.bin --metadata path/to/metadata
+
+    # pick which CPU to show from an SMP capture
+    ./trace_viewer.py build/tracing.bin --cpu 1
 """
 
 import argparse
@@ -79,6 +89,23 @@ def safe_open(path, mode, **kwargs):
 #   <packed, byte-aligned event specific fields>
 HDR = struct.Struct("<QH")
 HDR_NO_TS = struct.Struct("<H")
+
+# Events are gathered into fixed-size CTF packets, one sequence of them per CPU.
+# A packet opens with these two structures, is filled with records up to
+# content_size, and is padded out to packet_size.
+#
+#   struct packet_header  { uint32_t magic; uint32_t stream_id; }
+#   struct packet_context { uint64_t timestamp_begin, timestamp_end;
+#                           uint32_t content_size, packet_size, events_discarded;
+#                           uint8_t  cpu_id; }
+#
+# Older traces have no framing at all and are just records back to back; both
+# layouts are accepted, decided by whether the stream opens with the magic.
+PACKET_MAGIC = 0xC1FC1FC1
+PACKET_MAGIC_BYTES = struct.pack("<I", PACKET_MAGIC)
+PKT_HEADER = struct.Struct("<II")
+PKT_CONTEXT = struct.Struct("<QQIIIB")
+PKT_PREFIX = PKT_HEADER.size + PKT_CONTEXT.size
 
 # Map a TSDL integer typedef to a struct format character and byte size.
 TYPES = {
@@ -303,7 +330,7 @@ class TraceReader:
     next feed.
     """
 
-    def __init__(self, defs, has_ts=True):
+    def __init__(self, defs, has_ts=True, cpu=None):
         self.defs = defs
         self.has_ts = has_ts
         self.hdr = HDR if has_ts else HDR_NO_TS
@@ -311,6 +338,12 @@ class TraceReader:
         self._buf = b""  # undecoded bytes (possibly a partial record)
         self._fake_ts = 0
         self._desync = False
+        # None until the first bytes say whether this trace is packetized.
+        self._packetized = None
+        # CPU whose stream is being followed, and everything seen in the trace.
+        self.cpu = cpu
+        self.cpus_seen = set()
+        self.discarded = 0
         # Some platforms back the CTF timestamp with a free-running cycle
         # counter that wraps, giving a sawtooth instead of a monotonic clock.
         # Unwrap it: every time the raw value jumps backwards, add the previous
@@ -442,13 +475,11 @@ class TraceReader:
 
         self._state_machine(ts, name, fields, tid)
 
-    def _decode_buf(self):
-        data = self._buf
-        off = 0
-        n = len(data)
+    def _decode_records(self, data, off, end):
+        """Decode records in data[off:end]. Returns (events, offset reached)."""
         hsz = self.hdr.size
         new = 0
-        while off + hsz <= n:
+        while off + hsz <= end:
             if self.has_ts:
                 ts, eid = self.hdr.unpack_from(data, off)
             else:
@@ -461,7 +492,7 @@ class TraceReader:
                 self._desync = True
                 break
             rec = hsz + edef.size
-            if off + rec > n:
+            if off + rec > end:
                 break  # incomplete trailing record; wait for more
             if ts is None:
                 ts = self._fake_ts
@@ -475,7 +506,74 @@ class TraceReader:
             off += rec
             self._consume(ts, eid, edef.name, fields)
             new += 1
+        return new, off
+
+    def _decode_packets(self):
+        data = self._buf
+        off = 0
+        n = len(data)
+        new = 0
+
+        while off + PKT_PREFIX <= n:
+            magic, _stream_id = PKT_HEADER.unpack_from(data, off)
+            if magic != PACKET_MAGIC:
+                nxt = data.find(PACKET_MAGIC_BYTES, off + 1)
+                self._desync = True
+                if nxt < 0:
+                    off = n
+                    break
+                off = nxt
+                continue
+
+            (_ts_begin, _ts_end, content_bits, packet_bits, discarded,
+             cpu) = PKT_CONTEXT.unpack_from(data, off + PKT_HEADER.size)
+            psize = packet_bits // 8
+            csize = content_bits // 8
+
+            if psize < PKT_PREFIX or csize < PKT_PREFIX or csize > psize:
+                # The magic was a coincidence in the middle of event data.
+                nxt = data.find(PACKET_MAGIC_BYTES, off + 1)
+                self._desync = True
+                if nxt < 0:
+                    off = n
+                    break
+                off = nxt
+                continue
+
+            if off + psize > n:
+                break  # incomplete trailing packet; wait for more
+
+            self.cpus_seen.add(cpu)
+            self.discarded = max(self.discarded, discarded)
+            if self.cpu is None:
+                self.cpu = cpu
+
+            # Only one CPU's stream is followed. This viewer draws a single
+            # running-thread lane, which cannot represent several CPUs at once,
+            # and taking every CPU's packets would also interleave two
+            # independent time sequences into one and confuse the wrap
+            # detection above.
+            if cpu == self.cpu:
+                got, _ = self._decode_records(data, off + PKT_PREFIX, off + csize)
+                new += got
+
+            off += psize
+
         self._buf = data[off:]
+        return new
+
+    def _decode_buf(self):
+        if self._packetized is None:
+            if len(self._buf) < PKT_HEADER.size:
+                return 0
+            (magic,) = struct.unpack_from("<I", self._buf, 0)
+            self._packetized = magic == PACKET_MAGIC
+
+        if self._packetized:
+            return self._decode_packets()
+
+        new, off = self._decode_records(self._buf, 0, len(self._buf))
+        self._buf = self._buf[off:]
         return new
 
     def feed(self, data):
@@ -492,9 +590,24 @@ class TraceReader:
         return new
 
 
-def parse_trace(path, defs, has_ts=True):
+def _report_cpus(reader):
+    """Tell the user when a trace holds more CPUs than can be shown at once."""
+    others = sorted(c for c in reader.cpus_seen if c != reader.cpu)
+    if others:
+        sys.stderr.write(
+            f"note: showing CPU {reader.cpu}; this trace also has "
+            f"{', '.join(str(c) for c in others)} (use --cpu N to switch)\n"
+        )
+    if reader.discarded:
+        sys.stderr.write(
+            f"warning: the target discarded {reader.discarded} event(s) on CPU "
+            f"{reader.cpu} for want of a free packet\n"
+        )
+
+
+def parse_trace(path, defs, has_ts=True, cpu=None):
     """Read a complete trace file in one shot (non-live path)."""
-    reader = TraceReader(defs, has_ts)
+    reader = TraceReader(defs, has_ts, cpu)
     with safe_open(path, "rb") as fh:
         reader.feed(fh.read())
     return reader.tr
@@ -1441,6 +1554,14 @@ def main():
         help="trace was built without CONFIG_TRACING_CTF_TIMESTAMP",
     )
     ap.add_argument(
+        "--cpu",
+        type=int,
+        default=None,
+        help="CPU whose stream to display (default: the first one seen). "
+        "Only meaningful for a trace captured on an SMP system, where each "
+        "CPU produces its own stream",
+    )
+    ap.add_argument(
         "-f",
         "--follow",
         action="store_true",
@@ -1463,9 +1584,13 @@ def main():
         if args.text or not sys.stdout.isatty():
             sys.stderr.write("--follow requires an interactive terminal\n")
             return 1
-        return _run_follow(args.binary, defs, has_ts)
+        return _run_follow(args.binary, defs, has_ts, args.cpu)
 
-    tr = parse_trace(args.binary, defs, has_ts=has_ts)
+    reader = TraceReader(defs, has_ts, args.cpu)
+    with safe_open(args.binary, "rb") as fh:
+        reader.feed(fh.read())
+    tr = reader.tr
+    _report_cpus(reader)
     if not tr.events:
         sys.stderr.write("no events decoded; is this a CTF trace? try --no-timestamp\n")
         return 1
@@ -1475,17 +1600,13 @@ def main():
         run_text(tr, width)
         return 0
 
-    reader = TraceReader(defs, has_ts)
-    with safe_open(args.binary, "rb") as fh:
-        reader.feed(fh.read())
-
     import curses
 
     curses.wrapper(run_curses, reader)
     return 0
 
 
-def _run_follow(path, defs, has_ts):
+def _run_follow(path, defs, has_ts, cpu=None):
     """Open the trace, catch up on existing bytes, then follow it live."""
     import curses
     import time
@@ -1497,7 +1618,7 @@ def _run_follow(path, defs, has_ts):
             deadline = True
         time.sleep(0.3)
 
-    reader = TraceReader(defs, has_ts)
+    reader = TraceReader(defs, has_ts, cpu)
     fh = safe_open(path, "rb")
     try:
         reader.feed(fh.read())  # catch up on whatever already exists

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -319,6 +319,15 @@ class Trace:
     """Parsed trace: ordered events plus reconstructed running timeline."""
 
     def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Empty the trace in place.
+
+        Deliberately not a fresh object: the front-ends hold on to the Trace for
+        the lifetime of the display, and rebuilding it on every live update
+        would leave them rendering an orphan.
+        """
         self.events = []
         self.threads = {}  # tid -> {name, prio, stack_base, stack_size}
         self.segments = []  # (start_ts, end_ts, tid, cpu) running thread spans
@@ -386,7 +395,10 @@ class TraceReader:
 
     def _reset_derived(self):
         """Clear everything replayed from the decoded events."""
-        self.tr = Trace()
+        if getattr(self, "tr", None) is None:
+            self.tr = Trace()
+        else:
+            self.tr.reset()
         # running-thread / ISR state, per CPU
         self._cur_tid = {}  # cpu -> tid
         self._seg_start = {}  # cpu -> ts
@@ -1215,7 +1227,10 @@ def run_curses(stdscr, reader, fh=None):
     # Live follow: when reading a file that is still being written, keep the
     # view pinned to the latest events. Panning/zooming detaches; 'f' re-pins.
     live_follow = live
-    nthreads = len(tr.threads)
+    # Lanes are rebuilt when either count changes: a secondary CPU comes
+    # online partway through boot, so the CPU set grows during a live trace
+    # just as the thread set does.
+    lane_sig = (len(tr.threads), len(tr.cpus))
 
     def clampview():
         nonlocal view0, view1
@@ -1254,10 +1269,13 @@ def run_curses(stdscr, reader, fh=None):
             except OSError:
                 chunk = b""
             if reader.feed(chunk):
-                ts_list.extend(ev.ts for ev in tr.events[len(ts_list) :])
+                # Rebuilt rather than extended: the trace is reassembled in
+                # timestamp order on every update, so a late packet from
+                # another CPU can land events before the end of the list.
+                ts_list[:] = [ev.ts for ev in tr.events]
                 full_span = max(1, tr.t1 - tr.t0)
-                if len(tr.threads) != nthreads:
-                    nthreads = len(tr.threads)
+                if (len(tr.threads), len(tr.cpus)) != lane_sig:
+                    lane_sig = (len(tr.threads), len(tr.cpus))
                     order = all_lanes(tr)
             if live_follow and tr.t1 > tr.t0:
                 span = max(100, view1 - view0)

--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -14,9 +14,13 @@ backend) and renders it graphically on the console - a lightweight,
 terminal-only take on tools such as SEGGER SystemView or Eclipse Trace Compass.
 
 The viewer focuses on visualization. Most of the screen is a Gantt-style time
-graph with one lane per thread (plus lanes for the idle thread and for ISRs);
-coloured bars show which thread is running over time and the transitions
-between them are the context switches. A movable time cursor (the playhead)
+graph in two sections. The upper one is grouped by CPU: a row per CPU showing
+how busy it was, with the threads that executed on it nested underneath, each
+shaded by how much of the interval it held that CPU. A thread that migrates
+appears under every CPU it ran on, so its work is seen moving between the
+groups. The lower section has one lane per thread covering all CPUs, where
+coloured bars show the thread's state over time and the transitions between
+running and ready are the context switches. A movable time cursor (the playhead)
 selects a point in the trace, with a small info strip beneath the chart that
 can be toggled off to give the graph the whole screen. A metrics panel fills
 the area below the lanes with a CPU-busy gauge, context-switch / event rates
@@ -37,10 +41,9 @@ so the time graph still works even when the metadata file cannot be found.
 
 A capture taken on an SMP system holds one stream per CPU, and on a backend
 carrying a single link those streams arrive interleaved. The raw capture can be
-opened directly - there is no need to split it first - but since the time graph
-draws a single running-thread lane it shows one CPU at a time, the first one
-seen unless ``--cpu`` says otherwise. Captures predating the packet framing are
-still read as-is.
+opened directly - there is no need to split it first - and every CPU is shown.
+``--cpu`` narrows the display to one of them. Captures predating the packet
+framing are still read as-is.
 
 Usage::
 
@@ -56,11 +59,12 @@ Usage::
     # point at a specific metadata file
     ./trace_viewer.py build/tracing.bin --metadata path/to/metadata
 
-    # pick which CPU to show from an SMP capture
+    # narrow an SMP capture to a single CPU
     ./trace_viewer.py build/tracing.bin --cpu 1
 """
 
 import argparse
+import collections
 import os
 import re
 import struct
@@ -287,13 +291,28 @@ def find_metadata(binary_path, override):
 
 
 class Event:
-    __slots__ = ("ts", "eid", "name", "fields")
+    __slots__ = ("ts", "eid", "name", "fields", "cpu")
 
-    def __init__(self, ts, eid, name, fields):
+    def __init__(self, ts, eid, name, fields, cpu=0):
         self.ts = ts
         self.eid = eid
         self.name = name
         self.fields = fields
+        self.cpu = cpu
+
+
+# A lane is one row of the time graph. The chart has two sections: the CPU
+# section, whose rows are occupancy (how much of each column the row held that
+# CPU), and the thread section, whose rows are the familiar per-thread state
+# timeline covering every CPU.
+#
+#   Lane("cpu",   cpu, None) - the CPU itself: its utilization
+#   Lane("occ",   cpu, tid)  - a thread, over the time it ran on that CPU
+#   Lane("isr",   cpu, None) - ISR activity on that CPU
+#   Lane("state", None, tid) - a thread's state across all CPUs
+Lane = collections.namedtuple("Lane", "kind cpu tid")
+
+LANE_OCCUPANCY = ("cpu", "occ", "isr")
 
 
 class Trace:
@@ -302,10 +321,11 @@ class Trace:
     def __init__(self):
         self.events = []
         self.threads = {}  # tid -> {name, prio, stack_base, stack_size}
-        self.segments = []  # (start_ts, end_ts, tid) running thread spans
-        self.isr_spans = []  # (start_ts, end_ts) ISR active spans
+        self.segments = []  # (start_ts, end_ts, tid, cpu) running thread spans
+        self.isr_spans = []  # (start_ts, end_ts, cpu) ISR active spans
         self.states = {}  # tid -> [(start, end, state, reason), ...]
         self.state_starts = {}  # tid -> [start, ...] (for bisect)
+        self.cpus = set()  # every CPU seen in the trace
         self.t0 = 0
         self.t1 = 0
 
@@ -313,6 +333,9 @@ class Trace:
         return self.threads.setdefault(
             tid, {"name": "", "prio": None, "stack_base": None, "stack_size": None}
         )
+
+    def cpu_list(self):
+        return sorted(self.cpus) if self.cpus else [0]
 
 
 class TraceReader:
@@ -349,14 +372,29 @@ class TraceReader:
         # Unwrap it: every time the raw value jumps backwards, add the previous
         # raw value as an offset so the timeline stays monotonic. For a trace
         # whose timestamps are already monotonic this is a no-op.
-        self._prev_raw = None
-        self._ts_off = 0
-        # running-thread / ISR incremental state
-        self._cur_tid = None
-        self._seg_start = None
-        self._isr_depth = 0
-        self._isr_start = None
-        # per-thread state-machine incremental state
+        # Unwrapping is per CPU: each CPU's stream is monotonic on its own, but
+        # the streams are independent, so a shared "went backwards" test would
+        # read the interleaving of two CPUs as a wrap on every other event.
+        self._prev_raw = {}  # cpu -> last raw timestamp
+        self._ts_off = {}  # cpu -> accumulated unwrap offset
+        # Every decoded event, (ts, eid, name, fields, cpu). Kept so the trace
+        # can be rebuilt in timestamp order: CPUs are decoded from separate
+        # streams and so arrive interleaved, while the per-thread state machine
+        # only makes sense fed in time order.
+        self._raw = []
+        self._reset_derived()
+
+    def _reset_derived(self):
+        """Clear everything replayed from the decoded events."""
+        self.tr = Trace()
+        # running-thread / ISR state, per CPU
+        self._cur_tid = {}  # cpu -> tid
+        self._seg_start = {}  # cpu -> ts
+        self._isr_depth = {}  # cpu -> nesting depth
+        self._isr_start = {}  # cpu -> ts
+        # per-thread state-machine state (a thread is ready/blocked/asleep
+        # regardless of CPU, and runs on only one at a time, so this stays
+        # global rather than per CPU)
         self._st_cur = {}  # tid -> [state, since, reason]
         self._st_hint = {}  # tid -> (state, reason)
         self._running = None
@@ -430,9 +468,10 @@ class TraceReader:
             if tid is not None and tid not in self._st_cur:
                 self._st_set(tid, ts, ST_RDY)
 
-    def _consume(self, ts, eid, name, fields):
+    def _consume(self, ts, eid, name, fields, cpu=0):
         tr = self.tr
-        tr.events.append(Event(ts, eid, name, fields))
+        tr.events.append(Event(ts, eid, name, fields, cpu))
+        tr.cpus.add(cpu)
         if len(tr.events) == 1:
             tr.t0 = ts
         tr.t1 = ts
@@ -449,33 +488,39 @@ class TraceReader:
                 t["stack_base"] = fields.get("stack_base")
                 t["stack_size"] = fields.get("stack_size")
 
-        # Running-thread timeline from context switches.
+        # Running-thread timeline from context switches, tracked per CPU: each
+        # CPU has its own current thread, and a thread migrating between them
+        # simply closes a segment on one and opens one on the other.
         if eid == THREAD_SWITCHED_IN:
-            if self._cur_tid is not None and self._seg_start is not None:
-                tr.segments.append((self._seg_start, ts, self._cur_tid))
-            self._cur_tid = tid
-            self._seg_start = ts
+            cur = self._cur_tid.get(cpu)
+            start = self._seg_start.get(cpu)
+            if cur is not None and start is not None:
+                tr.segments.append((start, ts, cur, cpu))
+            self._cur_tid[cpu] = tid
+            self._seg_start[cpu] = ts
         elif eid == THREAD_SWITCHED_OUT:
-            if self._cur_tid is not None and self._seg_start is not None:
-                tr.segments.append((self._seg_start, ts, self._cur_tid))
-            self._cur_tid = None
-            self._seg_start = None
+            cur = self._cur_tid.get(cpu)
+            start = self._seg_start.get(cpu)
+            if cur is not None and start is not None:
+                tr.segments.append((start, ts, cur, cpu))
+            self._cur_tid[cpu] = None
+            self._seg_start[cpu] = None
 
         # ISR overlay spans (nested enters collapse to one active span).
         if eid == ISR_ENTER:
-            if self._isr_depth == 0:
-                self._isr_start = ts
-            self._isr_depth += 1
+            if self._isr_depth.get(cpu, 0) == 0:
+                self._isr_start[cpu] = ts
+            self._isr_depth[cpu] = self._isr_depth.get(cpu, 0) + 1
         elif eid in (ISR_EXIT, ISR_EXIT_TO_SCHEDULER):
-            if self._isr_depth > 0:
-                self._isr_depth -= 1
-                if self._isr_depth == 0 and self._isr_start is not None:
-                    tr.isr_spans.append((self._isr_start, ts))
-                    self._isr_start = None
+            if self._isr_depth.get(cpu, 0) > 0:
+                self._isr_depth[cpu] -= 1
+                if self._isr_depth[cpu] == 0 and self._isr_start.get(cpu) is not None:
+                    tr.isr_spans.append((self._isr_start[cpu], ts, cpu))
+                    self._isr_start[cpu] = None
 
         self._state_machine(ts, name, fields, tid)
 
-    def _decode_records(self, data, off, end):
+    def _decode_records(self, data, off, end, cpu=0):
         """Decode records in data[off:end]. Returns (events, offset reached)."""
         hsz = self.hdr.size
         new = 0
@@ -498,13 +543,14 @@ class TraceReader:
                 ts = self._fake_ts
                 self._fake_ts += 1
             else:
-                if self._prev_raw is not None and ts < self._prev_raw:
-                    self._ts_off += self._prev_raw  # counter wrapped
-                self._prev_raw = ts
-                ts += self._ts_off
+                prev = self._prev_raw.get(cpu)
+                if prev is not None and ts < prev:
+                    self._ts_off[cpu] = self._ts_off.get(cpu, 0) + prev  # wrapped
+                self._prev_raw[cpu] = ts
+                ts += self._ts_off.get(cpu, 0)
             fields, _ = edef.decode(data, off + hsz)
             off += rec
-            self._consume(ts, eid, edef.name, fields)
+            self._raw.append((ts, eid, edef.name, fields, cpu))
             new += 1
         return new, off
 
@@ -545,16 +591,11 @@ class TraceReader:
 
             self.cpus_seen.add(cpu)
             self.discarded = max(self.discarded, discarded)
-            if self.cpu is None:
-                self.cpu = cpu
 
-            # Only one CPU's stream is followed. This viewer draws a single
-            # running-thread lane, which cannot represent several CPUs at once,
-            # and taking every CPU's packets would also interleave two
-            # independent time sequences into one and confuse the wrap
-            # detection above.
-            if cpu == self.cpu:
-                got, _ = self._decode_records(data, off + PKT_PREFIX, off + csize)
+            # Every CPU is decoded; self.cpu, when set, narrows the display to
+            # one of them rather than the decode.
+            if self.cpu is None or cpu == self.cpu:
+                got, _ = self._decode_records(data, off + PKT_PREFIX, off + csize, cpu)
                 new += got
 
             off += psize
@@ -576,6 +617,22 @@ class TraceReader:
         self._buf = self._buf[off:]
         return new
 
+    def _replay(self):
+        """Rebuild the trace from every decoded event, in timestamp order.
+
+        CPUs are decoded from separate streams and so reach the reader
+        interleaved, while a thread's state timeline only makes sense assembled
+        in time order - a thread can be woken by one CPU and switched in by
+        another. Sorting and replaying keeps that correct no matter how the
+        packets happened to arrive. The sort is over an almost-ordered list, so
+        it is cheap, and a single-CPU trace is already in order and replays
+        unchanged.
+        """
+        self._raw.sort(key=lambda r: r[0])
+        self._reset_derived()
+        for ts, eid, name, fields, cpu in self._raw:
+            self._consume(ts, eid, name, fields, cpu)
+
     def feed(self, data):
         """Decode as many complete records as `data` (appended) allows.
 
@@ -584,20 +641,22 @@ class TraceReader:
         if not data:
             return 0
         self._buf += data
-        self._drop_provisional()
         new = self._decode_buf()
-        self._add_provisional()
+        if new:
+            self._replay()
+            self._add_provisional()
         return new
 
 
 def _report_cpus(reader):
-    """Tell the user when a trace holds more CPUs than can be shown at once."""
-    others = sorted(c for c in reader.cpus_seen if c != reader.cpu)
-    if others:
-        sys.stderr.write(
-            f"note: showing CPU {reader.cpu}; this trace also has "
-            f"{', '.join(str(c) for c in others)} (use --cpu N to switch)\n"
-        )
+    """Warn about anything the display leaves out."""
+    if reader.cpu is not None:
+        others = sorted(c for c in reader.cpus_seen if c != reader.cpu)
+        if others:
+            sys.stderr.write(
+                f"note: restricted to CPU {reader.cpu}; this trace also has "
+                f"{', '.join(str(c) for c in others)} (drop --cpu to see them all)\n"
+            )
     if reader.discarded:
         sys.stderr.write(
             f"warning: the target discarded {reader.discarded} event(s) on CPU "
@@ -710,12 +769,47 @@ def thread_running_at(tr, ts):
 def lane_order(tr):
     """Return thread ids ordered for display (most-active first)."""
     busy = {}
-    for s, e, tid in tr.segments:
+    for s, e, tid, _cpu in tr.segments:
         busy[tid] = busy.get(tid, 0) + max(0, e - s)
     # Threads that ran, busiest first; then any known-but-idle threads.
     ran = sorted(busy, key=lambda t: -busy[t])
     others = [t for t in tr.threads if t not in busy]
     return ran + others
+
+
+def cpu_lane_order(tr):
+    """Return the display lanes: each CPU followed by the threads that ran on it.
+
+    A thread that migrates appears under every CPU it ran on, showing only the
+    intervals it spent there, so a row always answers "what was this CPU doing"
+    without having to read the other rows.
+    """
+    busy = {}  # cpu -> {tid: ns}
+    for s, e, tid, cpu in tr.segments:
+        busy.setdefault(cpu, {})[tid] = busy.get(cpu, {}).get(tid, 0) + max(0, e - s)
+    isr_cpus = {cpu for _s, _e, cpu in tr.isr_spans}
+
+    lanes = []
+    for cpu in tr.cpu_list():
+        lanes.append(Lane("cpu", cpu, None))
+        # Real work first, busiest first; the idle thread sinks to the bottom of
+        # the group, where it reads as the leftovers rather than dominating.
+        for tid in sorted(
+            busy.get(cpu, {}), key=lambda t: (is_idle_thread(tr, t), -busy[cpu][t])
+        ):
+            lanes.append(Lane("occ", cpu, tid))
+        if cpu in isr_cpus:
+            lanes.append(Lane("isr", cpu, None))
+    return lanes
+
+
+def all_lanes(tr):
+    """CPU-grouped occupancy lanes, a divider, then a state lane per thread."""
+    return (
+        cpu_lane_order(tr)
+        + [Lane("sep", None, None)]
+        + [Lane("state", None, tid) for tid in lane_order(tr)]
+    )
 
 
 def thread_label(tr, tid):
@@ -725,6 +819,17 @@ def thread_label(tr, tid):
         # by name only, otherwise show the handle.
         name = "(unnamed)"
     return name
+
+
+def lane_label(tr, lane):
+    """Label for a lane, indented so threads read as nested under their CPU."""
+    if lane.kind == "cpu":
+        return f"CPU {lane.cpu}"
+    if lane.kind == "isr":
+        return "  [ISR]"
+    if lane.kind == "sep":
+        return "THREADS"
+    return f"  {thread_label(tr, lane.tid)}"
 
 
 def fmt_time(ns):
@@ -767,10 +872,10 @@ def render_rows(tr, order, view0, view1, width):
             if cov > 0:
                 acc[c] = min(1.0, acc[c] + cov)
 
-    for s, e, tid in tr.segments:
+    for s, e, tid, _cpu in tr.segments:
         if tid in rows:
             paint(rows[tid], s, e)
-    for s, e in tr.isr_spans:
+    for s, e, _cpu in tr.isr_spans:
         paint(isr_row, s, e)
 
     def to_chars(acc):
@@ -785,6 +890,80 @@ def render_rows(tr, order, view0, view1, width):
 
     char_rows = {tid: to_chars(acc) for tid, acc in rows.items()}
     return char_rows, to_chars(isr_row)
+
+
+def is_idle_thread(tr, tid):
+    """Whether a thread is one of the per-CPU idle threads."""
+    return thread_label(tr, tid).startswith("idle")
+
+
+# Shading for the CPU section: how much of a column's time bucket the row
+# occupied that CPU for. Reading occupancy as a fraction rather than a yes/no
+# keeps the rows meaningful at any zoom - a brief slice stays visible as a light
+# cell instead of either vanishing or painting the whole column solid.
+OCC_SHADES = " ░▒▓█"
+
+
+def occ_glyph(frac):
+    if frac <= 0.0:
+        return " "
+    return OCC_SHADES[min(4, 1 + int(frac * 3.999))]
+
+
+def render_cpu_occupancy(tr, lanes, view0, view1, width):
+    """Return {lane: [fraction per column]} for the CPU-grouped lanes.
+
+    A CPU row is that CPU's utilization: the share of each column it spent
+    running something other than its idle thread. A thread row beneath it is
+    the share of the column that thread held *that* CPU, so a migrating thread
+    reads as work moving from one group to the other. Only occupancy appears
+    here; what a thread does while off-CPU is a property of the thread, not of
+    a CPU, and is shown in the per-thread section instead.
+    """
+    span = max(1, view1 - view0)
+    col_ns = span / width
+
+    def cover(acc, s, e):
+        if e < view0 or s > view1:
+            return
+        s = max(s, view0)
+        e = min(e, view1)
+        c0 = (s - view0) / col_ns
+        c1 = (e - view0) / col_ns
+        lo = max(0, min(width - 1, int(c0)))
+        hi = max(lo, min(width - 1, int(c1)))
+        for c in range(lo, hi + 1):
+            ov = min(c + 1, c1) - max(c, c0)
+            if ov > 0:
+                acc[c] = min(1.0, acc[c] + ov)
+            elif c == lo:
+                # The thread did hold the CPU here, but for less than the clock
+                # could resolve - on some platforms consecutive events share a
+                # timestamp entirely. Keep it visible as the faintest shade
+                # rather than dropping the row to blank.
+                acc[c] = max(acc[c], 0.01)
+
+    out = {lane: [0.0] * width for lane in lanes if lane.kind in LANE_OCCUPANCY}
+    thread_lane = {(ln.cpu, ln.tid): ln for ln in out if ln.kind == "occ"}
+    cpu_lane = {ln.cpu: ln for ln in out if ln.kind == "cpu"}
+    isr_lane = {ln.cpu: ln for ln in out if ln.kind == "isr"}
+
+    for s, e, tid, cpu in tr.segments:
+        lane = thread_lane.get((cpu, tid))
+        if lane is not None:
+            cover(out[lane], s, e)
+        # The CPU's own row counts real work only, so it reads as utilization
+        # rather than simply "powered on".
+        lane = cpu_lane.get(cpu)
+        if lane is not None and not is_idle_thread(tr, tid):
+            cover(out[lane], s, e)
+
+    for s, e, cpu in tr.isr_spans:
+        lane = isr_lane.get(cpu)
+        if lane is not None:
+            cover(out[lane], s, e)
+
+    return out
 
 
 def render_state_rows(tr, lanes, view0, view1, width):
@@ -873,57 +1052,90 @@ def window_stats(tr, view0, view1):
 
 
 def run_text(tr, width):
-    order = lane_order(tr)
-    label_w = max([len("THREAD")] + [len(thread_label(tr, t)) for t in order]) + 1
-    label_w = min(label_w, 18)
+    lanes = cpu_lane_order(tr)
+    order = all_lanes(tr)
+    header = "CPU / THREAD"
+    label_w = max([len(header)] + [len(lane_label(tr, ln)) for ln in lanes]) + 1
+    label_w = min(label_w, 22)
     tl_w = max(20, width - label_w - 12)
 
     print(
         f"Zephyr CTF trace  ({len(tr.events)} events, "
-        f"{len(tr.threads)} threads, "
+        f"{len(tr.threads)} threads, {len(tr.cpus)} CPU(s), "
         f"{fmt_time(tr.t1 - tr.t0)} span)"
     )
     print(f"t0 = {fmt_time(tr.t0)}   t1 = {fmt_time(tr.t1)}")
     print()
 
+    occ = render_cpu_occupancy(tr, lanes, tr.t0, tr.t1, tl_w)
     state_rows = render_state_rows(tr, order, tr.t0, tr.t1, tl_w)
-    _, isr_row = render_rows(tr, [], tr.t0, tr.t1, tl_w)
 
     def lbl(s):
         s = s[: label_w - 1]
         return s.ljust(label_w)
 
+    axis = "".join("|" if i % 10 == 0 else "." for i in range(tl_w))
+    span_lbl = fmt_time(tr.t1 - tr.t0)
+    ruler = " " * label_w + "0" + " " * (tl_w - len(span_lbl) - 1) + span_lbl
+
+    print("CPU occupancy   shade = share of the interval spent on that CPU:")
+    print("  " + "  ".join(f"{occ_glyph(f)} {int(f * 100)}%" for f in (0.2, 0.4, 0.7, 1.0)))
+    print("A thread appears under every CPU it ran on, so migration reads as work")
+    print("moving between the groups.")
+    print()
+    print(ruler)
+    print(lbl(header) + axis)
+    first = True
+    for lane in lanes:
+        if lane.kind == "cpu" and not first:
+            print()
+        first = False
+        print(lbl(lane_label(tr, lane)) + "".join(occ_glyph(f) for f in occ[lane]))
+
+    print()
     legend = "  ".join(
         f"{STATE_GLYPH[s]}={STATE_NAME[s]}" for s in (ST_RUN, ST_RDY, ST_BLK, ST_SLP, ST_SUS)
     )
-    print("states: " + legend)
+    print("Thread states (across all CPUs)   " + legend)
     print()
-    axis = "".join("|" if i % 10 == 0 else "." for i in range(tl_w))
-    print(
-        " " * label_w
-        + "0"
-        + " " * (tl_w - len(fmt_time(tr.t1 - tr.t0)) - 1)
-        + fmt_time(tr.t1 - tr.t0)
-    )
+    print(ruler)
     print(lbl("THREAD") + axis)
     for tid in order:
         cells = state_rows[tid]
         if all(c is None for c in cells):
             continue
         line = "".join(STATE_GLYPH.get(c, " ") if c else " " for c in cells)
-        print(lbl(thread_label(tr, tid)) + line)
-    if any(c != " " for c in isr_row):
-        print(lbl("[ISR]") + "".join(isr_row))
+        print(lbl("  " + thread_label(tr, tid)) + line)
+
+    # Where each thread actually ran, so migration is visible as a number
+    # rather than only as bars appearing under two CPUs.
+    ran_on = {}
+    for s, e, tid, cpu in tr.segments:
+        ran_on.setdefault(tid, {})
+        ran_on[tid][cpu] = ran_on[tid].get(cpu, 0) + max(0, e - s)
+
+    def cpu_summary(tid):
+        per = ran_on.get(tid)
+        if not per:
+            return "-"
+        total = sum(per.values()) or 1
+        return " ".join(f"{c}:{100 * v // total}%" for c, v in sorted(per.items()))
 
     print()
     print("Threads")
-    print(f"  {'handle':<12}{'name':<18}{'prio':>5}  {'stack_base':<12}{'stack_sz':>9}")
+    print(
+        f"  {'handle':<12}{'name':<18}{'prio':>5}  {'stack_base':<12}"
+        f"{'stack_sz':>9}  {'cpus':<16}"
+    )
     for tid in order:
         t = tr.threads[tid]
         prio = "" if t["prio"] is None else str(t["prio"])
         sb = "" if t["stack_base"] is None else f"0x{t['stack_base']:08x}"
         ss = "" if t["stack_size"] is None else str(t["stack_size"])
-        print(f"  0x{tid:08x}  {thread_label(tr, tid):<18}{prio:>5}  {sb:<12}{ss:>9}")
+        print(
+            f"  0x{tid:08x}  {thread_label(tr, tid):<18}{prio:>5}  {sb:<12}{ss:>9}"
+            f"  {cpu_summary(tid):<16}"
+        )
 
     # Event histogram by type.
     print()
@@ -980,7 +1192,7 @@ def run_curses(stdscr, reader, fh=None):
         curses.init_pair(22, curses.COLOR_WHITE, curses.COLOR_BLUE)  # selected
         curses.init_pair(23, curses.COLOR_BLACK, curses.COLOR_GREEN)  # play
 
-    order = lane_order(tr)
+    order = all_lanes(tr)
     ts_list = [ev.ts for ev in tr.events]
 
     full_span = max(1, tr.t1 - tr.t0)
@@ -1046,7 +1258,7 @@ def run_curses(stdscr, reader, fh=None):
                 full_span = max(1, tr.t1 - tr.t0)
                 if len(tr.threads) != nthreads:
                     nthreads = len(tr.threads)
-                    order = lane_order(tr)
+                    order = all_lanes(tr)
             if live_follow and tr.t1 > tr.t0:
                 span = max(100, view1 - view0)
                 view1 = tr.t1
@@ -1317,55 +1529,77 @@ def _draw_gantt(
     panel_h = 5 if show_info else 0
     lanes_top = 3
     overhead = lanes_top + panel_h + 1  # +1 footer
-    visible = [
-        t for t in order if any(tt == t and s <= view1 and e >= view0 for s, e, tt in tr.segments)
-    ] or order
+    def lane_in_view(ln):
+        if ln.kind in ("cpu", "isr", "sep"):
+            return True
+        for s, e, tid, cpu in tr.segments:
+            if tid != ln.tid or s > view1 or e < view0:
+                continue
+            if ln.kind == "occ" and cpu != ln.cpu:
+                continue
+            return True
+        return False
+
+    visible = [ln for ln in order if lane_in_view(ln)] or order
     max_lanes = max(1, h - overhead - 1)  # -1 for the events row
     view_lanes = visible[:max_lanes]
     sel_row = max(0, min(sel_row, len(view_lanes) - 1)) if view_lanes else 0
 
-    state_rows = render_state_rows(tr, view_lanes, view0, view1, tl_w)
-    _, isr_row = render_rows(tr, [], view0, view1, tl_w)
+    occ_rows = render_cpu_occupancy(
+        tr, [ln for ln in view_lanes if ln.kind in LANE_OCCUPANCY], view0, view1, tl_w
+    )
+    state_rows = render_state_rows(
+        tr, [ln.tid for ln in view_lanes if ln.kind == "state"], view0, view1, tl_w
+    )
     cursor_col = int((cursor_ns - view0) / max(1, span) * tl_w)
     cursor_col = max(0, min(tl_w - 1, cursor_col))
 
     row_y = lanes_top
-    for idx, tid in enumerate(view_lanes):
+    for idx, lane in enumerate(view_lanes):
         sel = idx == sel_row
-        lbl = thread_label(tr, tid)[: label_w - 1].ljust(label_w)
+        lbl = lane_label(tr, lane)[: label_w - 1].ljust(label_w)
         lblattr = (
             curses.color_pair(22)
             if (sel and use_color)
-            else (curses.A_BOLD if sel else curses.A_NORMAL)
+            else (curses.A_BOLD if sel or lane.kind == "cpu" else curses.A_NORMAL)
         )
         stdscr.addstr(row_y, 0, lbl, lblattr)
-        # Draw each lane as runs of same-state glyphs, coloured per state.
-        cells = state_rows[tid]
+
+        # A divider between the CPU section and the per-thread section; it
+        # carries no bars of its own.
+        if lane.kind == "sep":
+            stdscr.addstr(row_y, label_w, "-" * tl_w, curses.A_DIM)
+            row_y += 1
+            continue
+
+        # Occupancy lanes are shaded by how much of the column they held the
+        # CPU for; state lanes keep the per-state glyph and colour.
+        if lane.kind in LANE_OCCUPANCY:
+            cells = [occ_glyph(f) for f in occ_rows[lane]]
+            attrs = [st_attr(ST_RUN)] * tl_w
+        else:
+            states = state_rows[lane.tid]
+            cells = [STATE_GLYPH.get(s, " ") if s else " " for s in states]
+            attrs = [st_attr(s) for s in states]
+
         c = 0
         while c < tl_w:
-            st = cells[c]
             run = c + 1
-            while run < tl_w and cells[run] == st:
+            while run < tl_w and cells[run] == cells[c] and attrs[run] == attrs[c]:
                 run += 1
-            glyph = STATE_GLYPH.get(st, " ") if st else " "
-            if glyph != " ":
-                stdscr.addstr(row_y, label_w + c, glyph * (run - c), st_attr(st))
+            if cells[c] != " ":
+                stdscr.addstr(row_y, label_w + c, cells[c] * (run - c), attrs[c])
             c = run
         # Playhead marker.
-        st = cells[cursor_col] if cursor_col < len(cells) else None
-        mark = STATE_GLYPH.get(st, "|") if st else "|"
+        mark = cells[cursor_col] if cursor_col < len(cells) else "|"
+        if mark == " ":
+            mark = "|"
         stdscr.addstr(
             row_y,
             label_w + cursor_col,
             mark,
             curses.color_pair(21) if use_color else curses.A_REVERSE,
         )
-        row_y += 1
-
-    if any(c != " " for c in isr_row) and row_y < h - panel_h - 1:
-        stdscr.addstr(row_y, 0, "[ISR]".ljust(label_w), curses.A_BOLD)
-        iattr = curses.color_pair(20) if use_color else curses.A_REVERSE
-        stdscr.addstr(row_y, label_w, "".join(isr_row)[:tl_w], iattr)
         row_y += 1
 
     if show_events and row_y < h - panel_h - 1:
@@ -1404,7 +1638,7 @@ def _draw_gantt(
                 w,
                 view0,
                 view1,
-                view_lanes,
+                [ln.tid for ln in view_lanes if ln.kind == "state"] or lane_order(tr),
                 ev_lo,
                 ev_hi,
                 curses,
@@ -1436,7 +1670,8 @@ def _draw_gantt(
         )
         py += 1
         # Selected lane: its state and, when blocked, why.
-        sel_tid = view_lanes[sel_row] if view_lanes else None
+        sel_lane = view_lanes[sel_row] if view_lanes else None
+        sel_tid = sel_lane.tid if sel_lane is not None else None
         if sel_tid is not None:
             t = tr.threads[sel_tid]
             prio = "-" if t["prio"] is None else str(t["prio"])
@@ -1461,10 +1696,16 @@ def _draw_metrics(stdscr, tr, y0, y1, w, view0, view1, lanes, ev_lo, ev_hi, curs
     lanes: a CPU-busy gauge, context-switch / event rates, and per-thread
     stacked utilization bars (run/ready/blocked/sleep)."""
     per, span = window_stats(tr, view0, view1)
-    idle_ids = {t for t in tr.threads if tr.threads[t].get("name") == "idle"}
-    run_total = sum(a.get(ST_RUN, 0) for a in per.values())
-    idle_run = sum(per.get(t, {}).get(ST_RUN, 0) for t in idle_ids)
-    busy = max(0.0, min(1.0, (run_total - idle_run) / span))
+    # Utilization is computed per CPU straight from the running segments: the
+    # per-thread state totals cover every CPU at once, so on SMP they would add
+    # up to more than one CPU's worth of time.
+    busy_per_cpu = {}
+    for s, e, tid, cpu in tr.segments:
+        if e <= view0 or s >= view1 or is_idle_thread(tr, tid):
+            continue
+        busy_per_cpu[cpu] = busy_per_cpu.get(cpu, 0) + (min(e, view1) - max(s, view0))
+    cpus = tr.cpu_list()
+    busy = max(0.0, min(1.0, sum(busy_per_cpu.values()) / (span * max(1, len(cpus)))))
     switches = sum(1 for ev in tr.events[ev_lo:ev_hi] if ev.eid == THREAD_SWITCHED_IN)
     nev = ev_hi - ev_lo
     secs = span / 1e9
@@ -1487,12 +1728,23 @@ def _draw_metrics(stdscr, tr, y0, y1, w, view0, view1, lanes, ev_lo, ev_hi, curs
     if y >= y1:
         return
     gw = 14
-    head = f" CPU {busy * 100:3.0f}% "
+    label = " CPU" if len(cpus) == 1 else " ALL"
+    head = f"{label} {busy * 100:3.0f}% "
     stdscr.addstr(y, 0, head, curses.A_BOLD)
     bar(y, len(head), gw, [(ST_RUN, busy)])
+    # With more than one CPU, break the gauge down so an unbalanced load is
+    # visible rather than averaged away.
+    per_cpu = ""
+    if len(cpus) > 1:
+        per_cpu = "  " + " ".join(
+            f"cpu{c} {100 * busy_per_cpu.get(c, 0) / span:3.0f}%" for c in cpus
+        )
     sw_rate = f"{switches / secs:.0f}/s" if secs > 0 else "-"
     ev_rate = f"{nev / secs:.0f}/s" if secs > 0 else "-"
-    tail = f"  ctxsw {switches} ({sw_rate})  events {nev} ({ev_rate})  window {fmt_time(span)}"
+    tail = (
+        f"{per_cpu}  ctxsw {switches} ({sw_rate})  events {nev} ({ev_rate})"
+        f"  window {fmt_time(span)}"
+    )
     stdscr.addstr(y, len(head) + gw, tail[: max(0, w - len(head) - gw - 1)])
     y += 1
 

--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -51,6 +51,11 @@ if(CONFIG_TRACING_CORE)
     CONFIG_TRACING_SHELL
     tracing_shell.c
     )
+
+  zephyr_sources_ifdef(
+    CONFIG_TRACING_CTF
+    tracing_stream.c
+    )
 endif()
 
 zephyr_sources(

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -144,6 +144,33 @@ config TRACING_CTF_TIMESTAMP
 	  Timestamp prefix will be added to the beginning of CTF
 	  event internally.
 
+if TRACING_CTF
+
+config TRACING_CTF_PACKET_SIZE
+	int "Size of one CTF packet"
+	default 512
+	range 128 8192
+	help
+	  Size in bytes of a single CTF packet. Events are gathered into
+	  packets of this fixed size, which is what lets the amount of data a
+	  packet holds be recorded in the packet itself. A packet is padded to
+	  full size when it is closed, so a very large size wastes bandwidth
+	  on a mostly idle system while a very small one spends more of the
+	  stream on packet headers.
+
+config TRACING_CTF_PACKETS_PER_CPU
+	int "Number of CTF packets per CPU"
+	default 4 if TRACING_ASYNC
+	default 2
+	range 2 32
+	help
+	  Number of packets in each CPU's private ring. One is being filled
+	  while the others wait to be shipped, so at least two are needed to
+	  avoid dropping events while a packet is in flight. Total memory is
+	  this times TRACING_CTF_PACKET_SIZE times the number of CPUs.
+
+endif # TRACING_CTF
+
 choice TRACING_METHOD_CHOICE
 	prompt "Tracing Method"
 	default TRACING_ASYNC

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -331,6 +331,17 @@ void sys_trace_idle(void)
 #ifdef CONFIG_TRACING_IDLE
 	ctf_top_idle();
 #endif
+	/*
+	 * This CPU has run out of work, so whatever it has gathered would sit
+	 * in an unfinished packet until enough further events arrived to fill
+	 * it - on a CPU that has just gone quiet, possibly never. Close it here
+	 * instead, which bounds how long an event can be held to the point the
+	 * CPU next goes idle. Packets are sized to their contents, so closing
+	 * one early costs only what is in it.
+	 */
+	tracing_stream_flush_cpu();
+	tracing_stream_drain();
+
 	if (IS_ENABLED(CONFIG_CPU_LOAD_BACKEND_IDLE_HOOK)) {
 		cpu_load_on_enter_idle();
 	}

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -22,12 +22,20 @@ struct rtio_iodev_sqe;
 
 static void _get_thread_name(struct k_thread *thread, ctf_bounded_string_t *name)
 {
-	const char *tname = k_thread_name_get(thread);
+	ctf_bounded_string_t tname;
 
-	if (tname != NULL && tname[0] != '\0') {
-		strncpy(name->buf, tname, sizeof(name->buf));
-		/* strncpy may not always null-terminate */
-		name->buf[sizeof(name->buf) - 1] = 0;
+	/* Copy rather than read thread->name through k_thread_name_get(): a
+	 * thread renamed while it is running is rewritten in place, and reading
+	 * it directly from another CPU can splice the old and new names
+	 * together. k_thread_name_copy() takes a stable snapshot instead, and
+	 * always terminates it.
+	 */
+	if (k_thread_name_copy(thread, tname.buf, sizeof(tname.buf)) != 0) {
+		return;
+	}
+
+	if (tname.buf[0] != '\0') {
+		*name = tname;
 	}
 }
 

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -10,9 +10,20 @@
 #include <stddef.h>
 #include <string.h>
 #include <tracing_core.h>
+#include <tracing_stream.h>
 #include <ctf_map.h>
 #include <zephyr/tracing/tracing_format.h>
 #include <zephyr/net/net_ip.h>
+
+/* The tracing thread must not trace itself: shipping a packet would generate
+ * more events, which would never drain. Only the asynchronous mode has such a
+ * thread.
+ */
+#ifdef CONFIG_TRACING_ASYNC
+#define IS_TRACING_THREAD() is_tracing_thread()
+#else
+#define IS_TRACING_THREAD() false
+#endif
 
 /* Limit strings to 20 bytes to optimize bandwidth */
 #define CTF_MAX_STRING_LEN 20
@@ -52,54 +63,27 @@
 	}
 
 /*
- * Zephyr CPU number the event was emitted on, emitted as the CTF event common
- * context so that a trace from an SMP system can be demultiplexed per CPU. This
- * is Zephyr's own sequential CPU id (the one k_thread_cpu_pin() and the
- * scheduler use), not the platform-defined hardware id from arch_proc_id().
+ * The leading timestamp field is only reserved here; tracing_ctf_emit() fills
+ * it while this CPU still has interrupts locked, so that the order in which the
+ * clock is read matches the order events are appended to this CPU's stream.
  *
- * The read races with migration, so callers must keep it and the emission of
- * the packet within one interrupt-locked region.
- */
-static inline uint8_t ctf_top_cpu_id_get(void)
-{
-#ifdef CONFIG_SMP
-	return (uint8_t)arch_curr_cpu()->id;
-#else
-	return 0U;
-#endif
-}
-
-#ifdef CONFIG_TRACING_CTF_TIMESTAMP
-/*
- * The leading timestamp field is only reserved here; it is filled in by
- * tracing_format_raw_data_stamped() once the emitting CPU owns the tracing
- * lock. Sampling the clock at the call site instead would let two CPUs insert
- * their events in the opposite order to the one they read the clock in, which
- * puts a backwards timestamp in the stream and makes the trace unreadable.
+ * The interrupt lock also pins the event to one CPU, so it cannot be appended
+ * to a stream other than the one belonging to the core that produced it.
  */
 #define CTF_EVENT(_id, ...)                                                                        \
 	{                                                                                          \
-		if (!is_tracing_enabled()) {                                                       \
+		if (!is_tracing_enabled() || IS_TRACING_THREAD()) {                                \
 			return;                                                                    \
 		}                                                                                  \
-		unsigned int ctf_key = irq_lock();                                                 \
-		const uint64_t ctf_tstamp = 0U;                                                    \
-		const uint8_t ctf_cpu_id = ctf_top_cpu_id_get();                                   \
+		{                                                                                  \
+			unsigned int ctf_key = irq_lock();                                         \
+			const uint64_t ctf_tstamp = 0U;                                            \
                                                                                                    \
-		CTF_GATHER_FIELDS(tracing_format_raw_data_stamped, ctf_tstamp, _id, ctf_cpu_id,    \
-				  ##__VA_ARGS__)                                                   \
-		irq_unlock(ctf_key);                                                               \
+			CTF_GATHER_FIELDS(tracing_ctf_emit, ctf_tstamp, _id, ##__VA_ARGS__)        \
+			irq_unlock(ctf_key);                                                       \
+		}                                                                                  \
+		tracing_ctf_emit_post();                                                           \
 	}
-#else
-#define CTF_EVENT(_id, ...)                                                                        \
-	{                                                                                          \
-		unsigned int ctf_key = irq_lock();                                                 \
-		const uint8_t ctf_cpu_id = ctf_top_cpu_id_get();                                   \
-                                                                                                   \
-		CTF_GATHER_FIELDS(tracing_format_raw_data, _id, ctf_cpu_id, ##__VA_ARGS__)         \
-		irq_unlock(ctf_key);                                                               \
-	}
-#endif
 
 /* Anonymous compound literal with 1 member. Legal since C99.
  * This permits us to take the address of literals, like so:

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -39,38 +39,66 @@
 	}
 
 /*
- * Gather fields to a contiguous event-packet, then atomically emit.
+ * Gather fields to a contiguous event-packet, then atomically emit it through
+ * the given tracing_format_raw_data*() emitter.
  */
-#define CTF_GATHER_FIELDS(...)                                                                     \
+#define CTF_GATHER_FIELDS(_emit, ...)                                                              \
 	{                                                                                          \
 		uint8_t epacket[0 MAP(CTF_INTERNAL_FIELD_SIZE, ##__VA_ARGS__)];                    \
 		uint8_t *epacket_cursor = &epacket[0];                                             \
                                                                                                    \
 		MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                                      \
-		tracing_format_raw_data(epacket, sizeof(epacket));                                 \
+		_emit(epacket, sizeof(epacket));                                                   \
 	}
 
-#ifdef CONFIG_TRACING_CTF_TIMESTAMP
-#include <zephyr/timing/timing.h>
-
-static inline uint64_t ctf_top_timestamp_get(void)
+/*
+ * Zephyr CPU number the event was emitted on, emitted as the CTF event common
+ * context so that a trace from an SMP system can be demultiplexed per CPU. This
+ * is Zephyr's own sequential CPU id (the one k_thread_cpu_pin() and the
+ * scheduler use), not the platform-defined hardware id from arch_proc_id().
+ *
+ * The read races with migration, so callers must keep it and the emission of
+ * the packet within one interrupt-locked region.
+ */
+static inline uint8_t ctf_top_cpu_id_get(void)
 {
-	return timing_ns_get();
+#ifdef CONFIG_SMP
+	return (uint8_t)arch_curr_cpu()->id;
+#else
+	return 0U;
+#endif
 }
 
-#define CTF_EVENT(...)                                                                             \
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+/*
+ * The leading timestamp field is only reserved here; it is filled in by
+ * tracing_format_raw_data_stamped() once the emitting CPU owns the tracing
+ * lock. Sampling the clock at the call site instead would let two CPUs insert
+ * their events in the opposite order to the one they read the clock in, which
+ * puts a backwards timestamp in the stream and makes the trace unreadable.
+ */
+#define CTF_EVENT(_id, ...)                                                                        \
 	{                                                                                          \
 		if (!is_tracing_enabled()) {                                                       \
 			return;                                                                    \
 		}                                                                                  \
-		int key = irq_lock();                                                              \
-		const uint64_t tstamp = ctf_top_timestamp_get();                                   \
+		unsigned int ctf_key = irq_lock();                                                 \
+		const uint64_t ctf_tstamp = 0U;                                                    \
+		const uint8_t ctf_cpu_id = ctf_top_cpu_id_get();                                   \
                                                                                                    \
-		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
-		irq_unlock(key);                                                                   \
+		CTF_GATHER_FIELDS(tracing_format_raw_data_stamped, ctf_tstamp, _id, ctf_cpu_id,    \
+				  ##__VA_ARGS__)                                                   \
+		irq_unlock(ctf_key);                                                               \
 	}
 #else
-#define CTF_EVENT(...) {CTF_GATHER_FIELDS(__VA_ARGS__)}
+#define CTF_EVENT(_id, ...)                                                                        \
+	{                                                                                          \
+		unsigned int ctf_key = irq_lock();                                                 \
+		const uint8_t ctf_cpu_id = ctf_top_cpu_id_get();                                   \
+                                                                                                   \
+		CTF_GATHER_FIELDS(tracing_format_raw_data, _id, ctf_cpu_id, ##__VA_ARGS__)         \
+		irq_unlock(ctf_key);                                                               \
+	}
 #endif
 
 /* Anonymous compound literal with 1 member. Legal since C99.

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -12,6 +12,16 @@ struct event_header {
 	uint16_t id;
 };
 
+/* Common context carried by every event. cpu_id is Zephyr's sequential CPU
+ * number, so an SMP trace can be demultiplexed per CPU. It lives in the event
+ * common context rather than the event header because babeltrace2 consumes the
+ * CTF 1.8 event header itself and does not expose its extra fields to readers,
+ * while the common context is surfaced as event.common_context_field.
+ */
+struct event_context {
+	uint8_t cpu_id;
+};
+
 trace {
 	major = 1;
 	minor = 8;
@@ -20,6 +30,7 @@ trace {
 
 stream {
 	event.header := struct event_header;
+	event.context := struct event_context;
 };
 
 event {

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -32,13 +32,26 @@ struct event_header {
 	uint16_t id;
 };
 
-/* Common context carried by every event. cpu_id is Zephyr's sequential CPU
- * number, so an SMP trace can be demultiplexed per CPU. It lives in the event
- * common context rather than the event header because babeltrace2 consumes the
- * CTF 1.8 event header itself and does not expose its extra fields to readers,
- * while the common context is surfaced as event.common_context_field.
+/* Events are gathered into fixed-size packets, one sequence of them per CPU.
+ * content_size is what makes that possible: it is written when a packet is
+ * closed and tells the reader where the events stop and the tail padding
+ * begins, so the size never has to be known in advance.
+ *
+ * cpu_id names the CPU that produced the packet. For a backend that carries
+ * one link, every CPU's packets travel interleaved on it and cpu_id is what
+ * lets the host split them back into one file per CPU.
  */
-struct event_context {
+struct packet_header {
+	uint32_t magic;
+	uint32_t stream_id;
+};
+
+struct packet_context {
+	uint64_clock_t timestamp_begin;
+	uint64_clock_t timestamp_end;
+	uint32_t content_size;
+	uint32_t packet_size;
+	uint32_t events_discarded;
 	uint8_t cpu_id;
 };
 
@@ -46,11 +59,13 @@ trace {
 	major = 1;
 	minor = 8;
 	byte_order = le;
+	packet.header := struct packet_header;
 };
 
 stream {
+	id = 0;
+	packet.context := struct packet_context;
 	event.header := struct event_header;
-	event.context := struct event_context;
 };
 
 event {

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -7,8 +7,28 @@ typealias integer { size = 32; align = 8; signed = true; } := int32_t;
 typealias integer { size = 64; align = 8; signed = false; } := uint64_t;
 typealias integer { size = 8; align = 8; signed = false; encoding = ASCII; } := ctf_bounded_string_t;
 
+/* The tracing clock. Declaring it is what lets a reader order and merge events
+ * by time; without a clock block the timestamp is just an integer field and
+ * streams cannot be correlated at all. Zephyr emits the timestamp already
+ * converted to nanoseconds, so the clock runs at 1 GHz by definition. It is not
+ * absolute: it counts from an arbitrary origin near boot, not from the epoch.
+ */
+clock {
+	name = zephyr;
+	description = "Zephyr tracing clock, in nanoseconds since an arbitrary origin";
+	freq = 1000000000;
+	precision = 1;
+	offset_s = 0;
+	absolute = false;
+};
+
+typealias integer {
+	size = 64; align = 8; signed = false;
+	map = clock.zephyr.value;
+} := uint64_clock_t;
+
 struct event_header {
-	uint64_t timestamp;
+	uint64_clock_t timestamp;
 	uint16_t id;
 };
 

--- a/subsys/tracing/include/tracing_backend.h
+++ b/subsys/tracing/include/tracing_backend.h
@@ -29,7 +29,14 @@ struct tracing_backend;
  */
 struct tracing_backend_api {
 	void (*init)(void);
-	void (*output)(const struct tracing_backend *backend,
+	/* @a stream_id identifies which trace stream the data belongs to. A
+	 * backend that can express several channels (a file per stream, say)
+	 * should keep the streams separate; one carrying a single link may
+	 * ignore it, as the framing in the stream itself lets the host
+	 * demultiplex. The core emits a single stream, id 0, until per-CPU
+	 * streams are wired up.
+	 */
+	void (*output)(const struct tracing_backend *backend, uint8_t stream_id,
 		       uint8_t *data, uint32_t length);
 	/* Optional: push any buffered data out of the backend. May be NULL. */
 	int (*flush)(const struct tracing_backend *backend);
@@ -71,16 +78,17 @@ static inline void tracing_backend_init(
 /**
  * @brief Output tracing packet with tracing backend.
  *
- * @param backend Pointer to tracing_backend instance.
- * @param data    Address of outputting buffer.
- * @param length  Length of outputting buffer.
+ * @param backend   Pointer to tracing_backend instance.
+ * @param stream_id Trace stream the data belongs to.
+ * @param data      Address of outputting buffer.
+ * @param length    Length of outputting buffer.
  */
 static inline void tracing_backend_output(
-		const struct tracing_backend *backend,
+		const struct tracing_backend *backend, uint8_t stream_id,
 		uint8_t *data, uint32_t length)
 {
 	if (backend && backend->api && backend->api->output) {
-		backend->api->output(backend, data, length);
+		backend->api->output(backend, stream_id, data, length);
 	}
 }
 

--- a/subsys/tracing/include/tracing_core.h
+++ b/subsys/tracing/include/tracing_core.h
@@ -73,10 +73,12 @@ int tracing_backends_flush(void);
 /**
  * @brief Give tracing buffer to backend.
  *
+ * @param stream_id Trace stream the data belongs to. The core emits a single
+ *                  stream, id 0, until per-CPU streams are wired up.
  * @param data Tracing buffer address.
  * @param length Tracing buffer length.
  */
-void tracing_buffer_handle(uint8_t *data, uint32_t length);
+void tracing_buffer_handle(uint8_t stream_id, uint8_t *data, uint32_t length);
 
 /**
  * @brief Handle tracing packet drop.

--- a/subsys/tracing/include/tracing_core.h
+++ b/subsys/tracing/include/tracing_core.h
@@ -33,6 +33,19 @@ extern struct k_spinlock tracing_lock;
  */
 bool is_tracing_enabled(void);
 
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+/**
+ * @brief Sample the tracing clock.
+ *
+ * Meant to be called from the emission path with the tracing lock held, so that
+ * the order in which CPUs sample the clock matches the order in which their
+ * events reach the tracing buffer.
+ *
+ * @return Current tracing timestamp in nanoseconds.
+ */
+uint64_t tracing_timestamp_get(void);
+#endif
+
 /**
  * @brief Enable or disable emission of tracing data at runtime.
  *

--- a/subsys/tracing/include/tracing_stream.h
+++ b/subsys/tracing/include/tracing_stream.h
@@ -86,6 +86,15 @@ uint8_t *tracing_stream_reserve(uint32_t length, uint64_t tstamp);
 void tracing_stream_drain(void);
 
 /**
+ * @brief Close the calling CPU's packet so its events can be shipped.
+ *
+ * Meant for the moment a CPU goes idle: what it has gathered so far would
+ * otherwise sit in an unfinished packet until enough further events arrived to
+ * fill it, which on a CPU that has just gone quiet may be a long time or never.
+ */
+void tracing_stream_flush_cpu(void);
+
+/**
  * @brief Close every partially filled packet and ship everything.
  *
  * Used to get a complete trace out at a point where the application knows it

--- a/subsys/tracing/include/tracing_stream.h
+++ b/subsys/tracing/include/tracing_stream.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _TRACE_STREAM_H
+#define _TRACE_STREAM_H
+
+#include <zephyr/types.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Per-CPU CTF packet streams.
+ *
+ * Each CPU owns a private ring of fixed-size CTF packets and one CTF stream.
+ * Only the owning CPU appends to its packets, so an event can be reserved with
+ * nothing but a local interrupt lock: producers on different CPUs never
+ * contend, and every stream is monotonic in time because a single CPU samples
+ * the clock and appends in that order. A reader merges the streams by the
+ * declared trace clock.
+ *
+ * Packets are fixed size because CTF records the amount of data a packet holds
+ * in its own header. Filling a packet to a boundary and padding the tail lets
+ * that count be written when the packet is closed, with no need to go back and
+ * patch data already handed to a backend.
+ */
+
+/** CTF packet header, on the wire. Must match trace.packet.header in the TSDL. */
+struct tracing_packet_header {
+	uint32_t magic;
+	uint32_t stream_id;
+} __packed;
+
+/** CTF packet context, on the wire. Must match stream.packet.context in the TSDL. */
+struct tracing_packet_context {
+	uint64_t timestamp_begin;
+	uint64_t timestamp_end;
+	/* CTF counts both of these in bits, not bytes. */
+	uint32_t content_size;
+	uint32_t packet_size;
+	uint32_t events_discarded;
+	uint8_t cpu_id;
+} __packed;
+
+#define TRACING_CTF_MAGIC 0xC1FC1FC1U
+
+#define TRACING_PACKET_PREFIX_SIZE                                                                 \
+	(sizeof(struct tracing_packet_header) + sizeof(struct tracing_packet_context))
+
+/**
+ * @brief Initialize the per-CPU packet streams.
+ */
+void tracing_stream_init(void);
+
+/**
+ * @brief Reserve room for one event in the current CPU's packet.
+ *
+ * Must be called with interrupts locked on the calling CPU, and the returned
+ * pointer used before they are unlocked: the reservation belongs to whichever
+ * CPU is executing, so migrating mid-event would append to another CPU's
+ * stream.
+ *
+ * Closes the current packet and opens the next one when @a length no longer
+ * fits. If no free packet is left the event is accounted as discarded (and
+ * reported in the next packet's context) and NULL is returned.
+ *
+ * @param length Number of bytes needed for the event.
+ * @param tstamp Timestamp of the event, on the declared trace clock.
+ *
+ * @return Address to write @a length bytes of event to, or NULL if the event
+ *         has to be dropped.
+ */
+uint8_t *tracing_stream_reserve(uint32_t length, uint64_t tstamp);
+
+/**
+ * @brief Ship every packet that is ready to leave, to all backends.
+ *
+ * Safe to call from any context; serializes internally, since backends
+ * generally drive one shared link.
+ */
+void tracing_stream_drain(void);
+
+/**
+ * @brief Close every partially filled packet and ship everything.
+ *
+ * Used to get a complete trace out at a point where the application knows it
+ * wants one, at the cost of a short packet per CPU.
+ */
+void tracing_stream_flush(void);
+
+/**
+ * @brief Whether any packet is ready to be shipped.
+ *
+ * @return true if a call to tracing_stream_drain() would do anything.
+ */
+bool tracing_stream_has_data(void);
+
+/**
+ * @brief Append one gathered CTF event to the current CPU's stream.
+ *
+ * Must be called with interrupts locked; @a data must begin with the
+ * sizeof(uint64_t) timestamp slot the caller reserved, which this fills in
+ * with the clock reading that also orders the event within the stream.
+ *
+ * @param data   Gathered event, timestamp slot first.
+ * @param length Event length in bytes.
+ */
+void tracing_ctf_emit(uint8_t *data, uint32_t length);
+
+/**
+ * @brief Follow-up work for an emitted event, run with interrupts unlocked.
+ *
+ * Kept out of the interrupt-locked region so that neither shipping a packet to
+ * a backend nor poking the tracing thread happens with interrupts off.
+ */
+void tracing_ctf_emit_post(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TRACE_STREAM_H */

--- a/subsys/tracing/tracing_backend_adsp_memory_window.c
+++ b/subsys/tracing/tracing_backend_adsp_memory_window.c
@@ -26,9 +26,11 @@ struct tracing_backend_adsp_memory_window {
 static volatile struct tracing_backend_adsp_memory_window *mem_window;
 
 static void tracing_backend_adsp_memory_window_output(
-		const struct tracing_backend *backend,
+		const struct tracing_backend *backend, uint8_t stream_id,
 		uint8_t *data, uint32_t length)
 {
+	ARG_UNUSED(stream_id);
+
 #ifdef CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
 	if (!mem_window) {
 		return;

--- a/subsys/tracing/tracing_backend_posix.c
+++ b/subsys/tracing/tracing_backend_posix.c
@@ -22,10 +22,11 @@ static void tracing_backend_posix_init(void)
 }
 
 static void tracing_backend_posix_output(
-		const struct tracing_backend *backend,
+		const struct tracing_backend *backend, uint8_t stream_id,
 		uint8_t *data, uint32_t length)
 {
 	ARG_UNUSED(backend);
+	ARG_UNUSED(stream_id);
 
 	tracing_backend_posix_output_bottom(data, length, out_stream);
 }

--- a/subsys/tracing/tracing_backend_ram.c
+++ b/subsys/tracing/tracing_backend_ram.c
@@ -16,9 +16,11 @@ static uint32_t pos;
 static bool buffer_full;
 
 static void tracing_backend_ram_output(
-		const struct tracing_backend *backend,
+		const struct tracing_backend *backend, uint8_t stream_id,
 		uint8_t *data, uint32_t length)
 {
+	ARG_UNUSED(stream_id);
+
 	if (buffer_full) {
 		return;
 	}

--- a/subsys/tracing/tracing_backend_semihosting.c
+++ b/subsys/tracing/tracing_backend_semihosting.c
@@ -12,9 +12,12 @@
 
 static int tracing_fd = -1;
 
-static void tracing_backend_semihost_output(const struct tracing_backend *backend, uint8_t *data,
+static void tracing_backend_semihost_output(const struct tracing_backend *backend,
+					    uint8_t stream_id, uint8_t *data,
 					    uint32_t length)
 {
+	ARG_UNUSED(stream_id);
+
 	semihost_write(tracing_fd, data, length);
 }
 

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -68,9 +68,11 @@ static void uart_isr(const struct device *dev, void *user_data)
 #endif
 
 static void tracing_backend_uart_output(
-	const struct tracing_backend *backend,
+	const struct tracing_backend *backend, uint8_t stream_id,
 	uint8_t *data, uint32_t length)
 {
+	ARG_UNUSED(stream_id);
+
 	for (uint32_t i = 0; i < length; i++) {
 		uart_poll_out(tracing_uart_dev, data[i]);
 	}

--- a/subsys/tracing/tracing_backend_usb.c
+++ b/subsys/tracing/tracing_backend_usb.c
@@ -258,8 +258,9 @@ struct net_buf *tracing_func_buf_alloc(struct usbd_class_data *const c_data)
 }
 
 static void tracing_backend_usb_output(const struct tracing_backend *backend,
-				       uint8_t *data, uint32_t length)
+				       uint8_t stream_id, uint8_t *data, uint32_t length)
 {
+	ARG_UNUSED(stream_id);
 	int ret = 0;
 	uint32_t bytes;
 	struct net_buf *buf;

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -181,6 +181,13 @@ bool is_tracing_enabled(void)
 	return atomic_get(&tracing_state) == TRACING_ENABLE;
 }
 
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+uint64_t tracing_timestamp_get(void)
+{
+	return timing_ns_get();
+}
+#endif
+
 void tracing_cmd_handle(uint8_t *buf, uint32_t length)
 {
 	if (strncmp(buf, TRACING_CMD_ENABLE, length) == 0) {

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -18,6 +18,16 @@
 #include <tracing_core.h>
 #include <tracing_buffer.h>
 #include <tracing_backend.h>
+#ifdef CONFIG_TRACING_CTF
+#include <tracing_stream.h>
+#define TRACING_STREAM_HAS_DATA() tracing_stream_has_data()
+#define TRACING_STREAM_DRAIN()    tracing_stream_drain()
+#else
+#define TRACING_STREAM_HAS_DATA() false
+#define TRACING_STREAM_DRAIN()                                                                     \
+	do {                                                                                       \
+	} while (false)
+#endif
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
 #include <zephyr/timing/timing.h>
 #endif
@@ -61,6 +71,15 @@ static void tracing_thread_func(void *dummy1, void *dummy2, void *dummy3)
 	tracing_thread_tid = k_current_get();
 
 	while (true) {
+		/*
+		 * CTF produces into the per-CPU packet streams; every other
+		 * format produces into the shared buffer. Drain whichever has
+		 * something, so both can be built.
+		 */
+		if (TRACING_STREAM_HAS_DATA()) {
+			TRACING_STREAM_DRAIN();
+		}
+
 		while (true) {
 			len = ring_buf_get_ptr(rb, &buf, 0);
 			if (len == 0) {
@@ -92,6 +111,9 @@ void tracing_set_enabled(bool enable)
 static int tracing_init(void)
 {
 	tracing_buffer_init();
+#ifdef CONFIG_TRACING_CTF
+	tracing_stream_init();
+#endif
 
 	/*
 	 * Output goes to the configured backend (CONFIG_TRACING_BACKEND_NAME) plus
@@ -224,7 +246,17 @@ uint32_t tracing_packet_drop_count_get(void)
 
 int tracing_backends_flush(void)
 {
-	int ret = tracing_backend_flush(primary_backend);
+	int ret;
+
+#ifdef CONFIG_TRACING_CTF
+	/* Close any partly filled packet first, so a flush actually
+	 * yields every event produced so far and not just the packets
+	 * that happened to fill up.
+	 */
+	tracing_stream_flush();
+#endif
+
+	ret = tracing_backend_flush(primary_backend);
 
 	if (multiple_backends) {
 		STRUCT_SECTION_FOREACH(tracing_backend, backend) {

--- a/subsys/tracing/tracing_core.c
+++ b/subsys/tracing/tracing_core.c
@@ -66,7 +66,7 @@ static void tracing_thread_func(void *dummy1, void *dummy2, void *dummy3)
 			if (len == 0) {
 				break;
 			}
-			tracing_buffer_handle(buf, len);
+			tracing_buffer_handle(0U, buf, len);
 			ring_buf_consume(rb, len);
 		}
 		k_sem_take(&tracing_thread_sem, K_FOREVER);
@@ -197,9 +197,9 @@ void tracing_cmd_handle(uint8_t *buf, uint32_t length)
 	}
 }
 
-void tracing_buffer_handle(uint8_t *data, uint32_t length)
+void tracing_buffer_handle(uint8_t stream_id, uint8_t *data, uint32_t length)
 {
-	tracing_backend_output(primary_backend, data, length);
+	tracing_backend_output(primary_backend, stream_id, data, length);
 
 	if (!multiple_backends) {
 		return;
@@ -207,7 +207,7 @@ void tracing_buffer_handle(uint8_t *data, uint32_t length)
 
 	STRUCT_SECTION_FOREACH(tracing_backend, backend) {
 		if (strcmp(backend->name, CONFIG_TRACING_BACKEND_NAME) != 0) {
-			tracing_backend_output(backend, data, length);
+			tracing_backend_output(backend, stream_id, data, length);
 		}
 	}
 }

--- a/subsys/tracing/tracing_format_async.c
+++ b/subsys/tracing/tracing_format_async.c
@@ -6,7 +6,6 @@
 
 #define DISABLE_SYSCALL_TRACING
 
-#include <string.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
@@ -56,37 +55,6 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 		tracing_packet_drop_handle();
 	}
 }
-
-#ifdef CONFIG_TRACING_CTF_TIMESTAMP
-void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length)
-{
-	bool put_success, before_put_is_empty;
-	uint64_t tstamp;
-
-	if (!is_tracing_enabled() || is_tracing_thread()) {
-		return;
-	}
-
-	TRACING_LOCK();
-	tstamp = tracing_timestamp_get();
-	(void)memcpy(data, &tstamp, sizeof(tstamp));
-	before_put_is_empty = tracing_buffer_is_empty();
-	put_success = tracing_format_raw_data_put(data, length);
-	TRACING_UNLOCK();
-
-	/*
-	 * Kept outside the tracing lock: the trigger starts a k_timer, which
-	 * takes the timeout lock. Nesting that under the tracing lock would
-	 * create a tracing -> timeout lock order that inverts against any
-	 * tracepoint reached with the timeout lock already held.
-	 */
-	if (put_success) {
-		tracing_trigger_output(before_put_is_empty);
-	} else {
-		tracing_packet_drop_handle();
-	}
-}
-#endif
 
 void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 {

--- a/subsys/tracing/tracing_format_async.c
+++ b/subsys/tracing/tracing_format_async.c
@@ -6,6 +6,7 @@
 
 #define DISABLE_SYSCALL_TRACING
 
+#include <string.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
@@ -55,6 +56,37 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 		tracing_packet_drop_handle();
 	}
 }
+
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length)
+{
+	bool put_success, before_put_is_empty;
+	uint64_t tstamp;
+
+	if (!is_tracing_enabled() || is_tracing_thread()) {
+		return;
+	}
+
+	TRACING_LOCK();
+	tstamp = tracing_timestamp_get();
+	(void)memcpy(data, &tstamp, sizeof(tstamp));
+	before_put_is_empty = tracing_buffer_is_empty();
+	put_success = tracing_format_raw_data_put(data, length);
+	TRACING_UNLOCK();
+
+	/*
+	 * Kept outside the tracing lock: the trigger starts a k_timer, which
+	 * takes the timeout lock. Nesting that under the tracing lock would
+	 * create a tracing -> timeout lock order that inverts against any
+	 * tracepoint reached with the timeout lock already held.
+	 */
+	if (put_success) {
+		tracing_trigger_output(before_put_is_empty);
+	} else {
+		tracing_packet_drop_handle();
+	}
+}
+#endif
 
 void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 {

--- a/subsys/tracing/tracing_format_sync.c
+++ b/subsys/tracing/tracing_format_sync.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <string.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
@@ -47,6 +48,23 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 	tracing_buffer_handle(data, length);
 	TRACING_UNLOCK();
 }
+
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length)
+{
+	uint64_t tstamp;
+
+	if (!is_tracing_enabled()) {
+		return;
+	}
+
+	TRACING_LOCK();
+	tstamp = tracing_timestamp_get();
+	(void)memcpy(data, &tstamp, sizeof(tstamp));
+	tracing_buffer_handle(data, length);
+	TRACING_UNLOCK();
+}
+#endif
 
 void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 {

--- a/subsys/tracing/tracing_format_sync.c
+++ b/subsys/tracing/tracing_format_sync.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <tracing_core.h>
 #include <tracing_buffer.h>
@@ -48,23 +47,6 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 	tracing_buffer_handle(0U, data, length);
 	TRACING_UNLOCK();
 }
-
-#ifdef CONFIG_TRACING_CTF_TIMESTAMP
-void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length)
-{
-	uint64_t tstamp;
-
-	if (!is_tracing_enabled()) {
-		return;
-	}
-
-	TRACING_LOCK();
-	tstamp = tracing_timestamp_get();
-	(void)memcpy(data, &tstamp, sizeof(tstamp));
-	tracing_buffer_handle(0U, data, length);
-	TRACING_UNLOCK();
-}
-#endif
 
 void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 {

--- a/subsys/tracing/tracing_format_sync.c
+++ b/subsys/tracing/tracing_format_sync.c
@@ -28,7 +28,7 @@ void tracing_format_string(const char *str, ...)
 
 	if (put_success) {
 		length = ring_buf_get_ptr(tracing_buffer_get_ring_buf(), &data, 0);
-		tracing_buffer_handle(data, length);
+		tracing_buffer_handle(0U, data, length);
 		ring_buf_consume(tracing_buffer_get_ring_buf(), length);
 	} else {
 		tracing_packet_drop_handle();
@@ -45,7 +45,7 @@ void tracing_format_raw_data(uint8_t *data, uint32_t length)
 	}
 
 	TRACING_LOCK();
-	tracing_buffer_handle(data, length);
+	tracing_buffer_handle(0U, data, length);
 	TRACING_UNLOCK();
 }
 
@@ -61,7 +61,7 @@ void tracing_format_raw_data_stamped(uint8_t *data, uint32_t length)
 	TRACING_LOCK();
 	tstamp = tracing_timestamp_get();
 	(void)memcpy(data, &tstamp, sizeof(tstamp));
-	tracing_buffer_handle(data, length);
+	tracing_buffer_handle(0U, data, length);
 	TRACING_UNLOCK();
 }
 #endif
@@ -81,7 +81,7 @@ void tracing_format_data(tracing_data_t *tracing_data_array, uint32_t count)
 
 	if (put_success) {
 		length = ring_buf_get_ptr(tracing_buffer_get_ring_buf(), &data, 0);
-		tracing_buffer_handle(data, length);
+		tracing_buffer_handle(0U, data, length);
 		ring_buf_consume(tracing_buffer_get_ring_buf(), length);
 	} else {
 		tracing_packet_drop_handle();

--- a/subsys/tracing/tracing_stream.c
+++ b/subsys/tracing/tracing_stream.c
@@ -91,17 +91,16 @@ static void packet_close(struct tracing_cpu_stream *s, uint32_t cpu)
 	ctx->timestamp_begin = s->ts_begin;
 	ctx->timestamp_end = s->ts_end;
 	ctx->content_size = s->used[slot] * 8U;
-	ctx->packet_size = PACKET_SIZE * 8U;
+	/*
+	 * Sized to what it holds rather than padded out to a fixed length. CTF
+	 * takes the length of each packet from the packet itself, so a short
+	 * one is perfectly legal, and a packet closed early - because the CPU
+	 * is going idle rather than because it filled up - then costs only what
+	 * is in it instead of a full packet's worth of padding.
+	 */
+	ctx->packet_size = s->used[slot] * 8U;
 	ctx->events_discarded = s->discarded;
 	ctx->cpu_id = (uint8_t)cpu;
-
-	/*
-	 * Every packet goes out at full size so the stream stays a sequence of
-	 * equally sized packets; the reader stops at content_size and ignores
-	 * the padding.
-	 */
-	(void)memset(&s->packet[slot][s->used[slot]], 0, PACKET_SIZE - s->used[slot]);
-	s->used[slot] = PACKET_SIZE;
 
 	s->open = false;
 	(void)atomic_inc(&s->head);
@@ -187,7 +186,7 @@ void tracing_stream_drain(void)
 		while (atomic_get(&s->tail) != atomic_get(&s->head)) {
 			uint32_t slot = (uint32_t)atomic_get(&s->tail) % NUM_PACKETS;
 
-			tracing_buffer_handle((uint8_t)cpu, &s->packet[slot][0], PACKET_SIZE);
+			tracing_buffer_handle((uint8_t)cpu, &s->packet[slot][0], s->used[slot]);
 			(void)atomic_inc(&s->tail);
 		}
 	}
@@ -248,6 +247,27 @@ void tracing_ctf_emit_post(void)
 	 */
 	tracing_stream_drain();
 #endif
+}
+
+void tracing_stream_flush_cpu(void)
+{
+	uint32_t cpu;
+	unsigned int key;
+
+	/*
+	 * Only ever closes the calling CPU's own packet, so unlike
+	 * tracing_stream_flush() it races with nobody: the owning CPU is the
+	 * only writer of this state, and the local interrupt lock shuts out its
+	 * own interrupt-context producers.
+	 */
+	key = irq_lock();
+	cpu = stream_cpu_id();
+	if (streams[cpu].open &&
+	    streams[cpu].used[(uint32_t)atomic_get(&streams[cpu].head) % NUM_PACKETS] >
+		    TRACING_PACKET_PREFIX_SIZE) {
+		packet_close(&streams[cpu], cpu);
+	}
+	irq_unlock(key);
 }
 
 void tracing_stream_flush(void)

--- a/subsys/tracing/tracing_stream.c
+++ b/subsys/tracing/tracing_stream.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Disable syscall tracing for all calls from this compilation unit to avoid
+ * recursing back into the tracing core from the packet path.
+ */
+#define DISABLE_SYSCALL_TRACING
+
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+#include <tracing_core.h>
+#include <tracing_stream.h>
+
+#define PACKET_SIZE  CONFIG_TRACING_CTF_PACKET_SIZE
+#define NUM_PACKETS  CONFIG_TRACING_CTF_PACKETS_PER_CPU
+#define NUM_CPUS     CONFIG_MP_MAX_NUM_CPUS
+#define PACKET_ROOM  (PACKET_SIZE - TRACING_PACKET_PREFIX_SIZE)
+
+struct tracing_cpu_stream {
+	uint8_t packet[NUM_PACKETS][PACKET_SIZE];
+	/* Bytes used in each packet, prefix included. */
+	uint32_t used[NUM_PACKETS];
+	/*
+	 * Free-running counters; the slot in use is the counter modulo
+	 * NUM_PACKETS. head is written only by the CPU that owns this stream
+	 * and tail only by whoever drains, which is what makes this a
+	 * single-producer single-consumer ring needing no lock between them.
+	 */
+	atomic_t head;
+	atomic_t tail;
+	/* Whether the packet at head has had its prefix written. */
+	bool open;
+	/* Cumulative since boot: CTF expects a running total, and a reader
+	 * takes the difference between consecutive packets.
+	 */
+	uint32_t discarded;
+	uint64_t ts_begin;
+	uint64_t ts_end;
+};
+
+static struct tracing_cpu_stream streams[NUM_CPUS];
+
+/*
+ * Backends generally drive one shared link, so shipping has to be serialized
+ * even though producing does not.
+ */
+static struct k_spinlock stream_out_lock;
+
+#ifdef CONFIG_TRACING_ASYNC
+/* Set once a wake-up has been requested, cleared when a drain starts. */
+static atomic_t drain_pending;
+#endif
+
+static inline uint32_t stream_cpu_id(void)
+{
+#ifdef CONFIG_SMP
+	return (uint32_t)arch_curr_cpu()->id;
+#else
+	return 0U;
+#endif
+}
+
+static void packet_open(struct tracing_cpu_stream *s, uint64_t tstamp)
+{
+	uint32_t slot = (uint32_t)atomic_get(&s->head) % NUM_PACKETS;
+	struct tracing_packet_header *hdr = (struct tracing_packet_header *)&s->packet[slot][0];
+
+	hdr->magic = TRACING_CTF_MAGIC;
+	/* One stream class; the per-CPU instances are told apart by the cpu_id
+	 * in the packet context.
+	 */
+	hdr->stream_id = 0U;
+
+	s->used[slot] = TRACING_PACKET_PREFIX_SIZE;
+	s->ts_begin = tstamp;
+	s->ts_end = tstamp;
+	s->open = true;
+}
+
+static void packet_close(struct tracing_cpu_stream *s, uint32_t cpu)
+{
+	uint32_t slot = (uint32_t)atomic_get(&s->head) % NUM_PACKETS;
+	struct tracing_packet_context *ctx =
+		(struct tracing_packet_context *)&s->packet[slot]
+						  [sizeof(struct tracing_packet_header)];
+
+	ctx->timestamp_begin = s->ts_begin;
+	ctx->timestamp_end = s->ts_end;
+	ctx->content_size = s->used[slot] * 8U;
+	ctx->packet_size = PACKET_SIZE * 8U;
+	ctx->events_discarded = s->discarded;
+	ctx->cpu_id = (uint8_t)cpu;
+
+	/*
+	 * Every packet goes out at full size so the stream stays a sequence of
+	 * equally sized packets; the reader stops at content_size and ignores
+	 * the padding.
+	 */
+	(void)memset(&s->packet[slot][s->used[slot]], 0, PACKET_SIZE - s->used[slot]);
+	s->used[slot] = PACKET_SIZE;
+
+	s->open = false;
+	(void)atomic_inc(&s->head);
+}
+
+void tracing_stream_init(void)
+{
+	(void)memset(streams, 0, sizeof(streams));
+}
+
+uint8_t *tracing_stream_reserve(uint32_t length, uint64_t tstamp)
+{
+	uint32_t cpu = stream_cpu_id();
+	struct tracing_cpu_stream *s = &streams[cpu];
+	uint32_t slot;
+	uint8_t *ptr;
+
+	if (length > PACKET_ROOM) {
+		/* Cannot ever fit, whatever the packet does next. */
+		s->discarded++;
+		return NULL;
+	}
+
+	slot = (uint32_t)atomic_get(&s->head) % NUM_PACKETS;
+
+	if (s->open && ((s->used[slot] + length) > PACKET_SIZE)) {
+		packet_close(s, cpu);
+	}
+
+	if (!s->open) {
+		if ((uint32_t)(atomic_get(&s->head) - atomic_get(&s->tail)) >= NUM_PACKETS) {
+			/* Every packet is waiting to be shipped. */
+			s->discarded++;
+			return NULL;
+		}
+		packet_open(s, tstamp);
+	}
+
+	slot = (uint32_t)atomic_get(&s->head) % NUM_PACKETS;
+	ptr = &s->packet[slot][s->used[slot]];
+	s->used[slot] += length;
+	s->ts_end = tstamp;
+
+	return ptr;
+}
+
+bool tracing_stream_has_data(void)
+{
+	for (uint32_t cpu = 0U; cpu < NUM_CPUS; cpu++) {
+		if (atomic_get(&streams[cpu].head) != atomic_get(&streams[cpu].tail)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void tracing_stream_drain(void)
+{
+	k_spinlock_key_t key;
+
+	/*
+	 * Deliberately a trylock. A backend can trace on its own account - a
+	 * UART backend driving a traced driver, say - which re-enters here on
+	 * the same CPU, and a spinlock is not recursive. Backing off instead
+	 * leaves the packets ready, for the next drain or the tracing thread
+	 * to ship.
+	 */
+	if (k_spin_trylock(&stream_out_lock, &key) != 0) {
+		return;
+	}
+
+#ifdef CONFIG_TRACING_ASYNC
+	/* Cleared before shipping, so an event produced during the drain arms
+	 * another wake-up rather than being left to sit until the next one.
+	 */
+	(void)atomic_clear(&drain_pending);
+#endif
+
+	for (uint32_t cpu = 0U; cpu < NUM_CPUS; cpu++) {
+		struct tracing_cpu_stream *s = &streams[cpu];
+
+		while (atomic_get(&s->tail) != atomic_get(&s->head)) {
+			uint32_t slot = (uint32_t)atomic_get(&s->tail) % NUM_PACKETS;
+
+			tracing_buffer_handle((uint8_t)cpu, &s->packet[slot][0], PACKET_SIZE);
+			(void)atomic_inc(&s->tail);
+		}
+	}
+
+	k_spin_unlock(&stream_out_lock, key);
+}
+
+void tracing_ctf_emit(uint8_t *data, uint32_t length)
+{
+	uint64_t tstamp;
+	uint8_t *dst;
+
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP
+	/*
+	 * Sampled here, inside the caller's interrupt lock, so that the order
+	 * in which this CPU reads the clock is the order in which it appends
+	 * to its own stream. Streams from different CPUs are independent and a
+	 * reader merges them on the declared trace clock, so no cross-CPU
+	 * serialization is needed to keep timestamps sane.
+	 */
+	tstamp = tracing_timestamp_get();
+	(void)memcpy(data, &tstamp, sizeof(tstamp));
+#else
+	tstamp = 0U;
+#endif
+
+	dst = tracing_stream_reserve(length, tstamp);
+	if (dst == NULL) {
+		tracing_packet_drop_handle();
+		return;
+	}
+
+	(void)memcpy(dst, data, length);
+}
+
+void tracing_ctf_emit_post(void)
+{
+	if (!tracing_stream_has_data()) {
+		return;
+	}
+
+#ifdef CONFIG_TRACING_ASYNC
+	/*
+	 * Edge triggered, not level triggered. Waking the tracing thread means
+	 * starting a timer, and starting a timer is itself traced, so a wake on
+	 * every event with a packet pending would recurse until the stack ran
+	 * out. Arming once and letting the drain clear it bounds the recursion
+	 * at one level: the nested event finds the flag already set and stops.
+	 */
+	if (atomic_cas(&drain_pending, 0, 1)) {
+		tracing_trigger_output(true);
+	}
+#else
+	/*
+	 * Shipping calls into a backend, which may itself be traced - a UART
+	 * backend driving a traced driver, say. That recursion terminates in
+	 * tracing_stream_drain(), whose trylock fails on the nested call.
+	 */
+	tracing_stream_drain();
+#endif
+}
+
+void tracing_stream_flush(void)
+{
+	for (uint32_t cpu = 0U; cpu < NUM_CPUS; cpu++) {
+		struct tracing_cpu_stream *s = &streams[cpu];
+		unsigned int key;
+
+		/*
+		 * Closing touches state owned by the CPU that produces into
+		 * this stream. Locking interrupts only shuts out that CPU's own
+		 * interrupt-context producers; a flush racing a remote CPU
+		 * still in the middle of an event is not made safe by this, so
+		 * only close a packet that has something in it and accept that
+		 * a concurrently produced event lands in the next packet.
+		 */
+		key = irq_lock();
+		if (s->open && (s->used[(uint32_t)atomic_get(&s->head) % NUM_PACKETS] >
+				TRACING_PACKET_PREFIX_SIZE)) {
+			packet_close(s, cpu);
+		}
+		irq_unlock(key);
+	}
+
+	tracing_stream_drain();
+}

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -202,6 +202,112 @@ ZTEST(threads_lifecycle, test_thread_name_get_set)
 	k_thread_abort(tid);
 }
 
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Test that a truncated thread name copy is still terminated
+ *
+ * @details k_thread_name_copy() is built on strncpy(), which writes no
+ * terminator when the name is at least as long as the destination. A caller
+ * handed such a buffer would read off the end of it looking for one.
+ *
+ * @see k_thread_name_copy(), k_thread_name_set()
+ */
+ZTEST(threads_lifecycle, test_thread_name_copy_truncated)
+{
+	char buf[4];
+	k_tid_t self = k_current_get();
+	int ret;
+
+	ret = k_thread_name_set(self, "abcdefgh");
+	zassert_equal(ret, 0, "k_thread_name_set() failed");
+
+	(void)memset(buf, 'X', sizeof(buf));
+	ret = k_thread_name_copy(self, buf, sizeof(buf));
+	zassert_equal(ret, 0, "couldn't copy thread name");
+
+	zassert_equal(buf[sizeof(buf) - 1], '\0',
+		      "truncated name was not terminated");
+	zassert_equal(strlen(buf), sizeof(buf) - 1,
+		      "truncated name has the wrong length");
+
+	/* Other tests in this suite expect to control this thread's name. */
+	(void)k_thread_name_set(self, "parent_thread");
+}
+
+/* Two names of different lengths, so that a copy which mixes them together is
+ * recognisably neither.
+ */
+#define NAME_RACE_SHORT "race_a"
+#define NAME_RACE_LONG  "race_bbbbb"
+#define NAME_RACE_ITERATIONS 20000
+
+static volatile bool name_race_stop;
+
+static void thread_name_race_entry(void *p1, void *p2, void *p3)
+{
+	k_tid_t target = (k_tid_t)p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	for (int i = 0; (i < NAME_RACE_ITERATIONS) && !name_race_stop; i++) {
+		(void)k_thread_name_set(target, NAME_RACE_SHORT);
+		(void)k_thread_name_set(target, NAME_RACE_LONG);
+	}
+}
+
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Test that renaming a running thread never yields a torn name
+ *
+ * @details Renaming rewrites the name buffer in place. Copying the name of a
+ * thread being renamed concurrently must still return one whole name or the
+ * other, never a splice of the two. On SMP the two run on different CPUs and
+ * genuinely overlap.
+ *
+ * @see k_thread_name_copy(), k_thread_name_set()
+ */
+ZTEST(threads_lifecycle, test_thread_name_race)
+{
+	char buf[CONFIG_THREAD_MAX_NAME_LEN];
+	k_tid_t self = k_current_get();
+	k_tid_t tid;
+	int ret;
+
+	name_race_stop = false;
+
+	/* ztest names the current thread after the test being run, so put one
+	 * of the two expected names in place before the reader starts looking.
+	 */
+	ret = k_thread_name_set(self, NAME_RACE_SHORT);
+	zassert_equal(ret, 0, "k_thread_name_set() failed");
+
+	/* Same priority as the reader and deliberately never yielding, so that
+	 * on an SMP build the two hammer the name from two CPUs at once, which
+	 * is the only way the window between the writes is actually hit. Both
+	 * loops are bounded, so on a single CPU the renamer simply runs to
+	 * completion in its turn rather than starving anyone.
+	 */
+	tid = k_thread_create(&tdata_name, tstack_name, STACK_SIZE,
+			      thread_name_race_entry, self, NULL, NULL,
+			      k_thread_priority_get(self), 0, K_NO_WAIT);
+
+	for (int i = 0; i < NAME_RACE_ITERATIONS; i++) {
+		ret = k_thread_name_copy(self, buf, sizeof(buf));
+		zassert_equal(ret, 0, "couldn't copy thread name");
+
+		zassert_true((strcmp(buf, NAME_RACE_SHORT) == 0) ||
+			     (strcmp(buf, NAME_RACE_LONG) == 0),
+			     "torn thread name observed: '%s'", buf);
+	}
+
+	name_race_stop = true;
+	zassert_equal(k_thread_join(tid, K_SECONDS(5)), 0, "renamer did not exit");
+
+	/* Other tests in this suite expect to control this thread's name. */
+	(void)k_thread_name_set(self, "parent_thread");
+}
+
 #ifdef CONFIG_USERSPACE
 static char unreadable_string[64];
 static char not_my_buffer[CONFIG_THREAD_MAX_NAME_LEN];

--- a/tests/subsys/tracing/ctf_trace/pytest/test_ctf_trace.py
+++ b/tests/subsys/tracing/ctf_trace/pytest/test_ctf_trace.py
@@ -7,7 +7,9 @@ expected events are present with sane fields.
 
 """
 
+import contextlib
 import glob
+import io
 import logging
 import os
 import sys
@@ -87,3 +89,26 @@ def test_ctf_trace(dut):
     assert idx["queue_init"] < idx["queue_get_exit"], "queue_init must precede queue_get_exit"
 
     logger.info("CTF trace validated: all %d expected event types present", len(EXPECTED_EVENTS))
+
+    # Render the text view as well. Decoding a trace and drawing it are separate
+    # code paths, and a section that comes out empty is easy to miss by eye, so
+    # assert that both the CPU section and the per-thread section produced rows
+    # and that the thread table lists the threads the trace mentions.
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        tv.run_text(tr, 100)
+    rendered = out.getvalue()
+
+    assert "CPU 0" in rendered, f"no CPU section rendered:\n{rendered}"
+    table = rendered.split("Threads\n", 1)
+    assert len(table) == 2, f"no thread table rendered:\n{rendered}"
+    listed = [ln for ln in table[1].splitlines() if ln.startswith("  0x")]
+    assert listed, f"thread table is empty:\n{rendered}"
+
+    bars = set("\u2588\u2593\u2592\u2591")
+    states = rendered.split("Thread states", 1)
+    assert len(states) == 2, f"no thread state section rendered:\n{rendered}"
+    assert any(bars & set(ln) for ln in states[1].splitlines()), (
+        f"thread state section drew no bars:\n{rendered}"
+    )
+    logger.info("text view rendered: %d threads listed", len(listed))

--- a/tests/subsys/tracing/tracing_api/src/main.c
+++ b/tests/subsys/tracing/tracing_api/src/main.c
@@ -62,9 +62,11 @@ static uint8_t *string_tracked[] = {
 
 #if defined(CONFIG_TRACING_BACKEND_UART)
 static void tracing_backends_output(
-		const struct tracing_backend *backend,
+		const struct tracing_backend *backend, uint8_t stream_id,
 		uint8_t *data, uint32_t length)
 {
+	ARG_UNUSED(stream_id);
+
 	/* Check the output data. */
 #ifdef CONFIG_TRACING_ASYNC
 	if (async_tracing_api) {

--- a/tests/subsys/tracing/tracing_backend_fanout/src/main.c
+++ b/tests/subsys/tracing/tracing_backend_fanout/src/main.c
@@ -18,9 +18,10 @@
 static atomic_t fanout_bytes;
 
 static void test_backend_output(const struct tracing_backend *backend,
-				uint8_t *data, uint32_t length)
+				uint8_t stream_id, uint8_t *data, uint32_t length)
 {
 	ARG_UNUSED(backend);
+	ARG_UNUSED(stream_id);
 	ARG_UNUSED(data);
 	atomic_add(&fanout_bytes, (atomic_val_t)length);
 }


### PR DESCRIPTION
CTF traces from an SMP system could not be read: nothing in the stream said which
CPU an event came from, and the timestamp was sampled under `irq_lock()` — local
interrupt masking, not mutual exclusion — while the order events reached the buffer
was decided by a spinlock further down. A CPU could therefore sample the clock
first, lose the race for that lock, and land its event behind one with a later
timestamp, which CTF forbids within a stream. The metadata also had no `clock`
block, without which a reader cannot correlate streams at all.

Give each CPU its own ring of CTF packets and its own stream. Reserving room for an
event then needs only a local interrupt lock, so producers on different CPUs no
longer contend, and each stream is monotonic because one CPU samples the clock and
appends in that order; a reader merges them on the declared clock. The packet
context carries the CPU number, how much the packet holds, and a running count of
events the target dropped, so a lossy capture says so rather than just looking short.

Packets are self describing, so a backend driving a single link carries every CPU's
packets interleaved on it. `scripts/tracing/split_ctf_streams.py` sorts them into one
file per CPU for babeltrace2 or Trace Compass, and `trace_viewer.py` reads a raw
capture directly, grouping its timeline by CPU with the threads that ran on each
nested underneath, so a migrating thread is seen moving between the groups.

Two independent fixes are included because the series cannot be exercised without
them: the TSDL metadata was missing the `k_sleep_ticks` event descriptions added by
commit a672a717caee ("tracing: give k_sleep_ticks() its own trace point"), which
desynchronizes decoding of any trace containing a `k_sleep()`; and
`k_thread_name_set()` rewrote `thread->name` with no lock while tracing read it from
another CPU, producing names spliced from the old and the new.

Uniprocessor behaviour is unchanged apart from the packet framing, which the host
tools handle transparently; captures in the older unframed layout still decode.
