### PR TITLE
twister: only resolve a filter up front when that is the cheaper path

### DIFF
--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -97,7 +97,21 @@ t_ignore = " \t\n"
 def t_error(t):
     raise SyntaxError("Unexpected token '%s'" % t.value)
 
-lex.lex()
+lexer = lex.lex()
+
+
+def symbols(expr_text):
+    """Return the symbols an expression refers to, in order of appearance.
+
+    Operators, literals and the reserved words are not symbols and are left
+    out. Raises SyntaxError on text the lexer does not recognise.
+    """
+    # The lexer holds the position in the text it is scanning, so give each
+    # caller its own.
+    scanner = lexer.clone()
+    scanner.input(expr_text)
+    return [token.value for token in scanner if token.type == "SYMBOL"]
+
 
 precedence = (
     ('left', 'OR'),

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -2149,7 +2149,7 @@ class TwisterRunner:
                         processing_queue.append({"op": "report", "test": instance})
                 elif test_only and instance.run:
                     processing_queue.append({"op": "run", "test": instance})
-                elif instance.filter_stages and "full" not in instance.filter_stages:
+                elif self.filter_before_configuring(instance):
                     processing_queue.append({"op": "filter", "test": instance})
                 else:
                     cache_file = os.path.join(instance.build_dir, "CMakeCache.txt")
@@ -2234,6 +2234,23 @@ class TwisterRunner:
                 p.terminate()
             return True
         return False
+
+    @staticmethod
+    def filter_before_configuring(instance):
+        """Whether resolving a filter up front is worth what it costs.
+
+        It skips configuring the instances the filter excludes, and costs
+        the filter stages on every instance. Kconfig costs nearly as much
+        as a configuration, so it only wins on a filter that excludes four
+        instances in five. Real ones exclude far fewer. Sysbuild is the
+        exception: its filter stages cover one application, the
+        configuration they save covers every image.
+        """
+        stages = instance.filter_stages
+        if not stages or "full" in stages:
+            return False
+
+        return stages != ["kconfig"] or instance.sysbuild
 
     @staticmethod
     def get_cmake_filter_stages(filt):

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -2137,8 +2137,7 @@ class TwisterRunner:
                 instance.filter_stages = []
                 if instance.testsuite.filter:
                     instance.filter_stages = self.get_cmake_filter_stages(
-                        instance.testsuite.filter,
-                        expr_parser.reserved.keys()
+                        instance.testsuite.filter
                     )
 
                 if not instance.testsuite.build:
@@ -2237,39 +2236,27 @@ class TwisterRunner:
         return False
 
     @staticmethod
-    def get_cmake_filter_stages(filt, logic_keys):
-        """Analyze filter expressions from test yaml
-        and decide if dts and/or kconfig based filtering will be needed.
+    def get_cmake_filter_stages(filt):
+        """Decide which CMake stages a filter expression needs.
+
+        A 'dt_' function needs the 'dts' stage, a CONFIG symbol needs
+        'kconfig'. Anything else - a CMake cache entry, ARCH, PLATFORM, an
+        environment variable - is only known once a build is configured.
+        That is what "full" asks for.
         """
-        dts_required = False
-        kconfig_required = False
-        full_required = False
-        filter_stages = []
-
-        # Compress args in expressions like "function('x', 'y')"
-        # so they are not split when splitting by whitespaces
-        filt = filt.replace(", ", ",")
-        # Remove logic words
-        for k in logic_keys:
-            filt = filt.replace(f"{k} ", "")
-        # Remove brackets
-        filt = filt.replace("(", "")
-        filt = filt.replace(")", "")
-        # Splite by whitespaces
-        filt = filt.split()
-        for expression in filt:
-            if expression.startswith("dt_"):
-                dts_required = True
-            elif expression.startswith("CONFIG"):
-                kconfig_required = True
-            else:
-                full_required = True
-
-        if full_required:
+        try:
+            symbols = expr_parser.symbols(filt)
+        except SyntaxError:
+            # Let the filter evaluation itself report what is wrong with it.
             return ["full"]
-        if dts_required:
+
+        if any(not s.startswith(("dt_", "CONFIG")) for s in symbols):
+            return ["full"]
+
+        filter_stages = []
+        if any(s.startswith("dt_") for s in symbols):
             filter_stages.append("dts")
-        if kconfig_required:
+        if any(s.startswith("CONFIG") for s in symbols):
             filter_stages.append("kconfig")
 
         return filter_stages

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -3299,3 +3299,29 @@ def test_twisterrunner_get_cmake_filter_stages(filter, expected_result):
     result = TwisterRunner.get_cmake_filter_stages(filter)
 
     assert sorted(result) == sorted(expected_result)
+
+
+TESTDATA_21 = [
+    ([], False, False),
+    (['full'], False, False),
+    (['dts'], False, True),
+    (['kconfig'], False, False),
+    (['dts', 'kconfig'], False, True),
+    (['kconfig'], True, True),
+    (['full'], True, False),
+]
+
+@pytest.mark.parametrize(
+    'filter_stages, sysbuild, expected_result',
+    TESTDATA_21,
+    ids=['none', 'full', 'dts', 'kconfig', 'dts+kconfig',
+         'kconfig sysbuild', 'full sysbuild']
+)
+def test_twisterrunner_filter_before_configuring(
+    filter_stages,
+    sysbuild,
+    expected_result
+):
+    instance = mock.Mock(filter_stages=filter_stages, sysbuild=sysbuild)
+
+    assert TwisterRunner.filter_before_configuring(instance) == expected_result

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -3156,7 +3156,7 @@ def test_twisterrunner_add_tasks_to_queue(
     build,
     expected_pipeline_elements
 ):
-    def mock_get_cmake_filter_stages(filter, keys):
+    def mock_get_cmake_filter_stages(filter):
         return [filter]
 
     instances = {
@@ -3192,9 +3192,9 @@ def test_twisterrunner_add_tasks_to_queue(
         [build_only != instance.run for instance in instances.values()]
     )
 
-    tr.get_cmake_filter_stages.assert_any_call('full', mock.ANY)
+    tr.get_cmake_filter_stages.assert_any_call('full')
     if retry_build_errors:
-        tr.get_cmake_filter_stages.assert_any_call('some', mock.ANY)
+        tr.get_cmake_filter_stages.assert_any_call('some')
 
     print(processing_queue_mock.append.call_args_list)
     print([mock.call(el) for el in expected_pipeline_elements])
@@ -3285,7 +3285,7 @@ def test_twisterrunner_execute(caplog):
 TESTDATA_20 = [
     ('', []),
     ('not ARCH in ["x86", "arc"]', ['full']),
-    ('dt_dummy(x, y)', ['dts']),
+    ('dt_dummy("x", "y")', ['dts']),
     ('not CONFIG_FOO', ['kconfig']),
     ('dt_dummy and CONFIG_FOO', ['dts', 'kconfig']),
 ]
@@ -3296,6 +3296,6 @@ TESTDATA_20 = [
     ids=['none', 'full', 'dts', 'kconfig', 'dts+kconfig']
 )
 def test_twisterrunner_get_cmake_filter_stages(filter, expected_result):
-    result = TwisterRunner.get_cmake_filter_stages(filter, ['not', 'and'])
+    result = TwisterRunner.get_cmake_filter_stages(filter)
 
     assert sorted(result) == sorted(expected_result)

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -12,7 +12,6 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
-from expr_parser import reserved
 from twisterlib.error import BuildError
 from twisterlib.handlers import QEMUHandler
 from twisterlib.platform import Simulator
@@ -222,8 +221,7 @@ TESTDATA_PART_3 = [
 
 @pytest.mark.parametrize("filter_expr, expected_stages", TESTDATA_PART_3)
 def test_which_filter_stages(filter_expr, expected_stages):
-    logic_keys = reserved.keys()
-    stages = TwisterRunner.get_cmake_filter_stages(filter_expr, logic_keys)
+    stages = TwisterRunner.get_cmake_filter_stages(filter_expr)
     assert sorted(stages) == sorted(expected_stages)
 
 


### PR DESCRIPTION
Twister resolves a `filter:` expression before configuring an instance, by running just the devicetree and/or Kconfig stages through `package_helper.cmake`. That saves configuring the instances the filter excludes, but costs those stages on every instance. It only pays off on a selective enough filter.

Measured on x86_64 Linux for `nrf52840dk/nrf52840`, best of 5:

| run | cost | pays off from |
|---|---|---|
| `package_helper -DMODULES=dts` | 1.752 s | 46% excluded |
| `package_helper -DMODULES=kconfig` | 3.136 s | 82% excluded |
| full `cmake` configure | 3.829 s | |

Kconfig-only filters are nowhere near 82%: in [run 33814795682](https://github.com/zephyrproject-rtos/zephyr/actions/runs/33814795682) they excluded 31% of the 12392 instances they were asked about. Filters needing both stages excluded 74% and devicetree-only ones 46%, so those stay as they are and only the Kconfig-only case changes. Sysbuild instances also keep the up-front path: their filter stages cover one application, the configuration they save covers every image.

The first commit is a prerequisite. `get_cmake_filter_stages()` took an expression apart with string replacements and treated anything not starting with `dt_` or `CONFIG` as needing a full configuration, so `CONFIG_MP_MAX_NUM_CPUS > 1` asked for one on account of `>` and `1`. It now asks the filter language's own lexer. 41 of the 1398 expressions in the tree stop asking for a full configuration; none loses a stage it used to ask for.

`twister --cmake-only -j16` over `tests/kernel` and `tests/benchmarks` for native_sim, qemu_x86 and qemu_cortex_m3 (576 configurations), three paired runs: **10.3% less CPU and 9.2% less wall clock**. That is roughly 25000 s of CPU over run 33814795682, about 2.3% of its billed shard time.