### PR TITLE
include: zephyr: sys: Adds a new priority aware lock free mpsc queue

### DIFF
--- a/include/zephyr/sys/mpsc_lockfree_priority.h
+++ b/include/zephyr/sys/mpsc_lockfree_priority.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_
+#define ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_
+
+/**
+ * @file
+ * @brief Priority-aware lock-free multiple-producer, single-consumer queue.
+ */
+
+#include <zephyr/sys/mpsc_lockfree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Priority MPSC queue
+ * @param queues Array containing one MPSC queue per priority
+ * @param num_priorities Number of elements in @p queues
+ */
+struct mpsc_priority {
+	/** @brief Array containing one MPSC queue per priority. */
+	struct mpsc *queues;
+
+	/** @brief Number of priorities. */
+	uint8_t num_priorities;
+};
+
+/**
+ * @brief Initialize a priority MPSC queue
+ *
+ * @param q Priority queue to initialize
+ * @param queues Array containing one MPSC queue per priority
+ * @param num_priorities Number of elements in @p queues
+ */
+static inline void mpsc_priority_init(struct mpsc_priority *q, struct mpsc *queues,
+				      uint8_t num_priorities)
+{
+	__ASSERT_NO_MSG(q != NULL);
+	__ASSERT_NO_MSG(queues != NULL);
+	__ASSERT_NO_MSG(num_priorities > 0U);
+
+	q->queues = queues;
+	q->num_priorities = num_priorities;
+
+	for (uint8_t priority = 0U; priority < num_priorities; priority++) {
+		mpsc_init(&queues[priority]);
+	}
+}
+
+/**
+ * @brief Push a node into a priority MPSC queue
+ *
+ * @param q Priority queue
+ * @param node Node to push
+ * @param priority Node priority, where 0 is the highest priority
+ */
+static ALWAYS_INLINE void mpsc_priority_push(struct mpsc_priority *q, struct mpsc_node *node,
+					     uint8_t priority)
+{
+	__ASSERT_NO_MSG(q != NULL);
+	__ASSERT_NO_MSG(node != NULL);
+	__ASSERT_NO_MSG(priority < q->num_priorities);
+
+	mpsc_push(&q->queues[priority], node);
+}
+
+/**
+ * @brief Pop the highest-priority available node
+ *
+ * This function must only be called from one execution context. If producers
+ * are active concurrently, the returned node is the highest-priority node
+ * observable while the queues are scanned.
+ *
+ * @param q Priority queue
+ *
+ * @retval NULL When no node is available
+ * @retval node Highest-priority available node
+ */
+static inline struct mpsc_node *mpsc_priority_pop(struct mpsc_priority *q)
+{
+	__ASSERT_NO_MSG(q != NULL);
+
+	for (uint8_t priority = 0U; priority < q->num_priorities; priority++) {
+		struct mpsc_node *node = mpsc_pop(&q->queues[priority]);
+
+		if (node != NULL) {
+			return node;
+		}
+	}
+
+	return NULL;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_ */

--- a/tests/lib/lockfree/src/test_mpsc.c
+++ b/tests/lib/lockfree/src/test_mpsc.c
@@ -11,6 +11,7 @@
 #include <zephyr/timing/timing.h>
 #include <zephyr/sys/spsc_lockfree.h>
 #include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/sys/mpsc_lockfree_priority.h>
 
 static struct mpsc push_pop_q;
 static struct mpsc_node push_pop_nodes[2];
@@ -66,6 +67,52 @@ ZTEST(mpsc, test_push_pop)
 
 	node = mpsc_pop(&push_pop_q);
 	zassert_is_null(node, "Pop on empty queue should return null");
+}
+
+
+/*
+ * @brief Test for MPSC priority ordering
+ *
+ * This test verifies that elements pushed into the MPSC priority queue
+ * are popped in the correct priority order.
+ */
+#define MPSC_PRIORITY_LEVELS 3
+
+struct test_mpsc_priority_node {
+	struct mpsc_node node;
+	uint32_t value;
+};
+
+ZTEST(mpsc, test_priority_ordering)
+{
+	struct mpsc queues[MPSC_PRIORITY_LEVELS];
+	struct mpsc_priority priority_q;
+	struct test_mpsc_priority_node nodes[] = {
+		{ .value = 0U },
+		{ .value = 1U },
+		{ .value = 2U },
+		{ .value = 3U },
+	};
+	const uint32_t expected[] = { 1U, 2U, 0U, 3U };
+
+	mpsc_priority_init(&priority_q, queues, ARRAY_SIZE(queues));
+	zassert_is_null(mpsc_priority_pop(&priority_q));
+
+	mpsc_priority_push(&priority_q, &nodes[0].node, 2U);
+	mpsc_priority_push(&priority_q, &nodes[1].node, 0U);
+	mpsc_priority_push(&priority_q, &nodes[2].node, 1U);
+	mpsc_priority_push(&priority_q, &nodes[3].node, 2U);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(expected); i++) {
+		struct mpsc_node *node = mpsc_priority_pop(&priority_q);
+		struct test_mpsc_priority_node *priority_node;
+
+		zassert_not_null(node);
+		priority_node = CONTAINER_OF(node, struct test_mpsc_priority_node, node);
+		zassert_equal(priority_node->value, expected[i]);
+	}
+
+	zassert_is_null(mpsc_priority_pop(&priority_q));
 }
 
 #define MPSC_FREEQ_SZ 8


### PR DESCRIPTION
This is a priority aware lock free mpsc queue which is built on top of the existing mpsc implementation