### PR TITLE
arch: arm64: cache the current thread in TPIDR_EL1 on Cortex-A SMP

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -6,6 +6,9 @@
 config CPU_CORTEX_A
 	bool
 	select CPU_CORTEX
+	# With PM, CPU resume must restore TPIDR_EL1 from _current_cpu->current
+	# before the register-backed current-thread lookup can be used.
+	select ARCH_HAS_CUSTOM_CURRENT_IMPL if SMP && !PM
 	select HAS_FLASH_LOAD_OFFSET
 	select KERNEL_DIRECT_MAP if MMU
 	select SCHED_IPI_SUPPORTED if SMP

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -245,6 +245,10 @@ switch_el:
 
 1:
 	/* EL1 init */
+#ifdef CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL
+	/* No current thread exists until the kernel installs its dummy thread. */
+	msr	tpidr_el1, xzr
+#endif
 	bl	z_arm64_el1_init
 
 	/* We want to use SP_ELx from now on */

--- a/include/zephyr/arch/arm64/arch_inlines.h
+++ b/include/zephyr/arch/arm64/arch_inlines.h
@@ -14,6 +14,26 @@
 #include <zephyr/arch/arm64/tpidrro_el0.h>
 #include <zephyr/sys/__assert.h>
 
+#ifdef CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL
+/* A register read cannot race with migration between a CPU lookup and load. */
+static ALWAYS_INLINE struct k_thread *arch_current_thread(void)
+{
+	uintptr_t thread;
+
+	/* Volatile prevents reuse of a read after TPIDR_EL1 is updated.
+	 * MRS does not access memory, so no memory clobber is needed.
+	 */
+	__asm__ volatile ("mrs %0, tpidr_el1" : "=r" (thread));
+	return (struct k_thread *)thread;
+}
+
+static ALWAYS_INLINE void arch_current_thread_set(struct k_thread *thread)
+{
+	/* The scheduler updates this CPU-local register with preemption disabled. */
+	write_tpidr_el1((uintptr_t)thread);
+}
+#endif
+
 /* Note: keep in sync with `get_cpu` in arch/arm64/core/macro_priv.inc */
 static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 {

--- a/include/zephyr/arch/arm64/lib_helpers.h
+++ b/include/zephyr/arch/arm64/lib_helpers.h
@@ -84,6 +84,7 @@ MAKE_REG_HELPER(par_el1);
 MAKE_REG_HELPER(scr_el3);
 #endif /* CONFIG_ARMV8_R */
 MAKE_REG_HELPER(tpidrro_el0);
+MAKE_REG_HELPER(tpidr_el1);
 MAKE_REG_HELPER(vmpidr_el2);
 MAKE_REG_HELPER(sp_el0);
 


### PR DESCRIPTION
Use the existing custom-current architecture hooks to keep the running thread pointer in TPIDR_EL1. A register read avoids the call and IRQ masking needed to prevent migration between a CPU lookup and the current-thread load.

Keep the per-CPU current pointer for cross-CPU readers. The scheduler updates the register with preemption disabled, and reset initializes it before the kernel installs the dummy thread on each CPU. TPIDR_EL0 remains available for TLS and TPIDRRO_EL0 for CPU and exception state.

Enable this for Cortex-A SMP without system power management. Uniprocessor and PM builds keep the existing lookup; power-state restoration is not extended to save the register.

A53 quad core microbenchmarks show ~1.2% higher throughput and up to 4.7% lower latency.

Assisted-by: Codex:GPT-5