### PR TITLE
os: clock: avoid redundant clock read after a completed nanosleep

### DIFF
--- a/lib/os/clock.c
+++ b/lib/os/clock.c
@@ -194,10 +194,16 @@ int z_impl_sys_clock_nanosleep(int clock_id, int flags, const struct timespec *r
 
 	timeout = timespec_to_timeout(&duration, NULL);
 	end = sys_timepoint_calc(timeout);
-	do {
-		(void)k_sleep(timeout);
+	/* Re-read the clock only when the sleep was cut short (k_wakeup());
+	 * a zero return means the full duration elapsed and no further
+	 * timepoint check is needed.
+	 */
+	while (k_sleep_ticks(timeout) != 0) {
 		timeout = sys_timepoint_timeout(end);
-	} while (!K_TIMEOUT_EQ(timeout, K_NO_WAIT));
+		if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+			break;
+		}
+	}
 
 	if (update_rmtp) {
 		*rmtp = (struct timespec){


### PR DESCRIPTION
sys_clock_nanosleep() re-read the system clock through sys_timepoint_timeout() after every k_sleep(), including the common case where the sleep ran to completion, only to conclude that no time remains.  That is one spinlocked 64-bit tick read (a syscall in userspace builds) per nanosleep()/clock_nanosleep() call whose result is discarded.

Use k_sleep_ticks() instead, which reports the remaining ticks directly: a zero return means the full duration elapsed and the loop can exit without touching the clock.  The timepoint is still consulted when the sleep is cut short by k_wakeup(), preserving the re-sleep behaviour, and a zero-length sleep still yields exactly as before.