### PR TITLE
net_buf: buf: avoid rewalking the chain in net_buf_append_bytes

### DIFF
--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -692,7 +692,8 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 			    const void *value, k_timeout_t timeout,
 			    net_buf_allocator_cb allocate_cb, void *user_data)
 {
-	struct net_buf *frag = net_buf_frag_last(buf);
+	struct net_buf *tail = net_buf_frag_last(buf);
+	struct net_buf *frag = tail;
 	size_t added_len = 0;
 	const uint8_t *value8 = value;
 	size_t max_size;
@@ -728,7 +729,15 @@ size_t net_buf_append_bytes(struct net_buf *buf, size_t len,
 			return added_len;
 		}
 
-		net_buf_frag_add(buf, frag);
+		/* The tail is already known, so link the new fragment behind
+		 * it instead of walking the chain from the head again: a
+		 * single append spanning n fragments would otherwise cost
+		 * O(n^2) traversal steps. Re-derive the tail from the
+		 * returned fragment, in case the allocator handed back a
+		 * chain rather than a single buffer.
+		 */
+		net_buf_frag_insert(tail, frag);
+		tail = net_buf_frag_last(frag);
 	} while (1);
 
 	/* Unreachable */

--- a/tests/lib/net_buf/buf/src/main.c
+++ b/tests/lib/net_buf/buf/src/main.c
@@ -1020,6 +1020,78 @@ ZTEST(net_buf_tests, test_net_buf_fixed_append)
 	net_buf_unref(buf);
 }
 
+/* Half of the fixed pool per append, so that a single call spans several
+ * fragments and the second call starts from a chain that already has some.
+ */
+#define APPEND_CHUNK (FIXED_BUFFER_SIZE * 5)
+
+/* Fragment allocator used to build a long chain, counting the allocations. */
+static struct net_buf *fixed_pool_allocator(k_timeout_t timeout, void *user_data)
+{
+	unsigned int *allocations = user_data;
+
+	(*allocations)++;
+
+	return net_buf_alloc(&fixed_pool, timeout);
+}
+
+ZTEST(net_buf_tests, test_net_buf_append_long_chain)
+{
+	static uint8_t data[APPEND_CHUNK];
+	unsigned int allocations = 0;
+	struct net_buf *buf, *frag;
+	size_t frags = 0;
+	size_t written;
+
+	destroy_called = 0;
+
+	/* Vary the pattern per fragment so that a reordered chain cannot
+	 * still match the source payload.
+	 */
+	for (size_t i = 0; i < sizeof(data); i++) {
+		data[i] = (uint8_t)(i + (i / FIXED_BUFFER_SIZE));
+	}
+
+	buf = net_buf_alloc(&fixed_pool, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get fixed buffer");
+
+	written = net_buf_append_bytes(buf, sizeof(data), data, K_NO_WAIT, fixed_pool_allocator,
+				       &allocations);
+	zassert_equal(written, sizeof(data), "Incomplete first append");
+	zassert_equal(allocations, 4, "Unexpected fragment allocation count");
+
+	written = net_buf_append_bytes(buf, sizeof(data), data, K_NO_WAIT, fixed_pool_allocator,
+				       &allocations);
+	zassert_equal(written, sizeof(data), "Incomplete second append");
+	zassert_equal(allocations, 9, "Unexpected fragment allocation count");
+
+	/* Every fragment must be filled and linked exactly once. */
+	for (frag = buf; frag != NULL; frag = frag->frags) {
+		zassert_equal(frag->len, FIXED_BUFFER_SIZE, "Fragment not filled");
+		frags++;
+	}
+	zassert_equal(frags, 10, "Unexpected fragment count");
+	zassert_equal(net_buf_frags_len(buf), APPEND_CHUNK * 2, "Unexpected chain length");
+
+	/* Both appends must be readable back in order, including across the
+	 * fragment that joins them.
+	 */
+	zassert_equal(net_buf_data_match(buf, 0, data, sizeof(data)), sizeof(data),
+		      "First append is out of order");
+	zassert_equal(net_buf_data_match(buf, sizeof(data), data, sizeof(data)), sizeof(data),
+		      "Second append is out of order");
+
+	/* The pool is now empty: a failed allocation must leave the chain as
+	 * it is.
+	 */
+	written = net_buf_append_bytes(buf, 1, data, K_NO_WAIT, fixed_pool_allocator, &allocations);
+	zassert_equal(written, 0, "Appended to an exhausted pool");
+	zassert_equal(net_buf_frags_len(buf), APPEND_CHUNK * 2, "Chain changed on failed append");
+
+	net_buf_unref(buf);
+	zassert_equal(destroy_called, 10, "Incorrect destroy callback count");
+}
+
 ZTEST(net_buf_tests, test_net_buf_linearize)
 {
 	struct net_buf *buf, *frag;


### PR DESCRIPTION
## Problem

`net_buf_append_bytes()` links each newly allocated fragment with `net_buf_frag_add()`, which calls `net_buf_frag_last()` and walks the whole chain from the head to find the tail. That tail is already known (it is the fragment the loop has just filled), so appending a payload that spans multiple fragments can incur O(n^2) fragment traversals.

The redundant search occurs each time a new fragment is linked. When a single call links many fragments, repeatedly searching the growing chain produces quadratic traversal work. A call linking only one fragment still repeats the search for the existing chain’s tail. The in-tree callers are the hl7800 and wncm14a2a modem receive paths, which append UART reads into a growing chain.

## Change

Keep the chain tail in a local variable and link the new fragment behind it with `net_buf_frag_insert()`. For a non-NULL head that is exactly what `net_buf_frag_add()` does, and the function already requires a non-NULL buffer, so the fragment reference is still consumed and the resulting chain order is unchanged. The tail is re-derived from the returned fragment, so an allocator callback that hands back a chain keeps its previous behaviour.

Allocation-failure behaviour is unchanged: the function returns the number of bytes appended so far, retaining any data and fragments already added during the call.

## Evidence

Deterministic count of ->frags traversal steps, taken with a temporary counter in net_buf_frag_last() on native_sim/native/64, with an identical build and configuration on both sides:

| Case | Before | After |
| --- | --- | --- |
| 4096 bytes appended in one call over 32 x 128-byte fragments | 465 | 0 |
| The same chain built with 32 single-fragment appends | 930 | 465 |

The first row is the case the O(n^2) bound describes. The second is the shape of the in-tree hl7800 and wncm14a2a modem receive paths, which read at most one fragment's worth per call: for them the chain is walked once per call instead of twice. The remaining 465 steps are from the net_buf_frag_last() calls at function entry, which the head-pointer argument requires and which this change does not address. (The claim is a reduction in executed pointer traversals, not a measured wall-clock figure.)

## Testing

Executed with Twister, host/gnu toolchain:

- `libraries.net_buf.buf` on `native_sim/native` and `native_sim/native/64`
- `libraries.net_buf.buf_simple` and `libraries.net_buf.buf_simple.hardening`
  on `unit_testing/unit_testing`
- `net.packet`, `net.packet.preempt`, `net.packet.large_buffer` and
  `net.packet.allocation_stats` on `native_sim/native` and
  `native_sim/native/64`

12 of 12 configurations passed, 329 of 329 executed test cases passed. I've added `net_buf_append_long_chain`, which builds a ten-fragment chain over two appends and checks the fragment count, that every fragment is filled, the payload order across the join between the two appends, and that an additional append to an already-full chain leaves it unchanged when the pool is exhausted.. The change is semantics-preserving so this test passes before and after, i.e. it guards the chain ordering that the tail tracking must maintain. 

`checkpatch.pl` reports no issues; ClangFormat, Identity, YAMLLint, TextEncoding and BinaryFiles compliance checks pass.

## Limitations

For callers that append a single fragment's worth per call, the chain is still walked once per call from the head, so this change removes the second walk, not the first. The two in-tree callers are vendor modem drivers that were not built locally because their target toolchains were unavailable. No physical-target timing or cross-compiled code-size measurements were taken.