### PR TITLE
drivers: intc: sam0: add hardware debounce support

### DIFF
--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -9,3 +9,15 @@ config GPIO_SAM0
 	depends on DT_HAS_ATMEL_SAM0_GPIO_ENABLED
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.
+
+config GPIO_SAM0_HW_DEBOUNCE
+	bool "SAM0 EIC hardware debounce support (DPRESCALER + DEBOUNCEN)"
+	depends on GPIO_SAM0
+	help
+	  Enable hardware debounce on the External Interrupt Controller (EIC).
+	  This configures GCLK1 @ OSCULP32K as slow clock for the EIC and
+	  enables the DPRESCALER and DEBOUNCEN registers for per-line hardware
+	  filtering. Use the 'microchip,debounce-time-us' devicetree property
+	  on the EIC node to set the target debounce time.
+	  Only effective on SoC variants with DPRESCALER registers
+	  (SAMC2xN, SAMD5x/E5x series).

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -161,6 +161,12 @@ int sam0_eic_acquire(int port, int pin, enum sam0_eic_trigger trigger,
 
 	if (filter) {
 		config |= EIC_CONFIG_FILTEN0 << config_shift;
+#ifdef CONFIG_GPIO_SAM0_HW_DEBOUNCE
+		/* Enable per-line debouncer (DEBOUNCEN) for this EXTINT line */
+		if (DT_INST_PROP_OR(0, microchip_debounce_time_us, 0) > 0) {
+			EIC->DEBOUNCEN.reg |= mask;
+		}
+#endif
 	}
 
 	/* Apply the config to the EIC itself */
@@ -343,6 +349,61 @@ static int sam0_eic_init(const struct device *dev)
 	/* Enable the GCLK */
 	GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0 |
 					 GCLK_PCHCTRL_CHEN;
+
+#ifdef CONFIG_GPIO_SAM0_HW_DEBOUNCE
+	{
+		uint32_t target_us = DT_INST_PROP_OR(0, microchip_debounce_time_us,
+						      0);
+
+		if (target_us > 0) {
+			/* Switch EIC to GCLK1 @ OSCULP32K for slow debounce */
+			GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK1 |
+							 GCLK_PCHCTRL_CHEN;
+
+			uint32_t best_prescaler = 0;
+			uint32_t best_states = 0;
+			uint32_t best_diff = UINT32_MAX;
+
+			for (uint32_t prescaler = 0; prescaler <= 7; prescaler++) {
+				for (uint32_t states = 0; states <= 1; states++) {
+					uint32_t samples = (states == 0) ? 2 : 3;
+					uint32_t debounce_clock = 32768
+						/ (2 * (prescaler + 1));
+					uint32_t time_us = (samples * 1000000)
+						/ debounce_clock;
+					int32_t diff = (int32_t)(time_us)
+						- (int32_t)target_us;
+
+					if (diff < 0) {
+						diff = -diff;
+					}
+
+					if ((uint32_t)diff < best_diff) {
+						best_diff = (uint32_t)diff;
+						best_prescaler = prescaler;
+						best_states = states;
+					}
+				}
+			}
+
+			/* Disable EIC for DPRESCALER + CKSEL configuration */
+			set_eic_enable(0);
+
+			EIC->DPRESCALER.reg = EIC_DPRESCALER_PRESCALER0(best_prescaler);
+
+			if (best_states != 0) {
+				EIC->DPRESCALER.reg |= EIC_DPRESCALER_STATES0;
+			}
+
+			EIC->DPRESCALER.reg |= EIC_DPRESCALER_TICKON;
+
+			EIC->CTRLA.bit.CKSEL = 1;
+
+			set_eic_enable(1);
+			wait_synchronization();
+		}
+	}
+#endif /* CONFIG_GPIO_SAM0_HW_DEBOUNCE */
 #else
 	/* Enable the EIC clock in PM */
 	PM->APBAMASK.bit.EIC_ = 1;
@@ -350,7 +411,7 @@ static int sam0_eic_init(const struct device *dev)
 	/* Enable the GCLK */
 	GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID_EIC | GCLK_CLKCTRL_GEN_GCLK0 |
 			    GCLK_CLKCTRL_CLKEN;
-#endif
+#endif /* MCLK */
 
 #if DT_INST_IRQ_HAS_CELL(0, irq)
 	SAM0_EIC_IRQ_CONNECT(0);

--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -10,3 +10,14 @@ properties:
 
   interrupts:
     required: true
+
+  microchip,debounce-time-us:
+    type: int
+    description: |
+      Requested debounce time in microseconds for all EIC lines.
+      This enables the DPRESCALER + DEBOUNCEN hardware debouncer.
+      Requires a slow EIC clock (e.g., GCLK1 @ OSCULP32K) configured
+      via CONFIG_GPIO_SAM0_HW_DEBOUNCE. The driver calculates the
+      best PRESCALER/STATES combination from the actual GCLK frequency.
+      Only available on variants with DPRESCALER registers (N-variants,
+      SAMD5x/E5x series).

--- a/soc/atmel/sam0/common/soc_samc2x.c
+++ b/soc/atmel/sam0/common/soc_samc2x.c
@@ -11,6 +11,7 @@
  */
 
 /* GCLK Gen 0 -> GCLK_MAIN @ OSC48M
+ * GCLK Gen 1 -> EIC      @ OSCULP32K (for HW debounce, optional)
  * GCLK Gen 2 -> WDT       @ reserved
  * GCLK Gen 0 -> ADC       @ OSC48M
  * GCLK Gen 4 -> RTC       @ reserved
@@ -49,6 +50,13 @@ static void gclks_init(void)
 	GCLK->GENCTRL[0].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_OSC48M)
 			     | GCLK_GENCTRL_DIV(1)
 			     | GCLK_GENCTRL_GENEN;
+
+#ifdef CONFIG_GPIO_SAM0_HW_DEBOUNCE
+	/* GCLK1 @ OSCULP32K (32.768 kHz) for EIC hardware debouncer */
+	GCLK->GENCTRL[1].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_OSCULP32K)
+			     | GCLK_GENCTRL_DIV(1)
+			     | GCLK_GENCTRL_GENEN;
+#endif
 }
 
 void soc_reset_hook(void)


### PR DESCRIPTION
Add CONFIG_GPIO_SAM0_HW_DEBOUNCE and implement hardware debounce for
SAM0 variants with DPRESCALER and DEBOUNCEN registers (SAMC2xN and
SAMD5x/E5x series).

When enabled and the EIC node has 'microchip,debounce-time-us' set:

  - The EIC GCLK is switched to GCLK1 (~32 kHz OSCULP32K)
  - The optimal PRESCALER and STATES are calculated from the target
    debounce time and the 32768 Hz EIC clock
  - CTRLA.CKSEL is set to use the prescaled debounce clock
  - DPRESCALER register is configured with the calculated values
  - TICKON is set for stable sampling
  - Per-line DEBOUNCEN is set in sam0_eic_acquire() for each pin
    requesting SAM0_GPIO_DEBOUNCE

The existing FILTENx synchronous filter path is unaffected.

Example devicetree overlay:

  &eic {
      microchip,debounce-time-us = <10000>;
  };

  button {
      gpios = <&portb 19 (GPIO_PULL_UP | GPIO_ACTIVE_LOW
                           | SAM0_GPIO_DEBOUNCE)>;
  };