### PR TITLE
net: dsa: Add vlan_setup to the DSA API

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -466,6 +466,9 @@ New APIs and options
   * :c:macro:`DT_IRQN_BY_NAME`
   * :c:macro:`DT_INST_IRQN_BY_NAME`
 
+* DSA
+  * :c:member:`dsa_api.vlan_setup`
+
 * Haptics
 
   * :c:enumerator:`haptics_monitor`

--- a/doc/services/connectivity/networking/dsa.rst
+++ b/doc/services/connectivity/networking/dsa.rst
@@ -103,8 +103,8 @@ of i.MX NETC.
 Common pitfalls using DSA setups
 ********************************
 
-This is copied from Linux DSA documentation. It applies to zephyr too. Although conduit port and
-cpu port exposed as ethernet device in zephyr, they are not able to be used.
+This is partially copied from Linux DSA documentation. It applies to zephyr too. Although conduit
+port and cpu port exposed as ethernet device in zephyr, they are not able to be used.
 
 .. note::
 
@@ -113,6 +113,16 @@ cpu port exposed as ethernet device in zephyr, they are not able to be used.
   be used as a conduit interface. Sending packets directly through this interface (e.g.: opening
   a socket using this interface) will not make us go through the switch tagging protocol transmit
   function, so the Ethernet switch on the other end, expecting a tag will typically drop this frame.
+
+VLAN configuration
+==================
+
+When configuring a switch's VLAN tables by implementing the ``vlan_setup`` member of a
+``struct dsa_api``, drivers should typically enable VLAN entries for not only the user port
+identified by the device passed to ``net_eth_vlan_enable()`` but also on the switch's CPU port.
+Failing to do so would --- assuming the filtering is applied strictly to ingress frames --- result
+in the switch passing VLAN frames from the user port from the conduit but not in the opposite
+direction.
 
 TODO work
 *********

--- a/include/zephyr/net/dsa_core.h
+++ b/include/zephyr/net/dsa_core.h
@@ -136,6 +136,11 @@ struct dsa_api {
 	int (*get_config)(const struct device *dev,
 			  enum ethernet_config_type type,
 			  struct ethernet_config *config);
+#if defined(CONFIG_NET_VLAN)
+	/** Configure VLAN for port */
+	int (*vlan_setup)(const struct device *dev, struct net_if *iface, uint16_t tag,
+			  bool enable);
+#endif /* CONFIG_NET_VLAN */
 };
 
 /**

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -190,6 +190,24 @@ static int dsa_get_config(const struct device *dev,
 	return dsa_switch_ctx->dapi->get_config(dev, type, config);
 }
 
+#if defined(CONFIG_NET_VLAN)
+static int dsa_vlan_setup(const struct device *dev, struct net_if *iface, uint16_t tag, bool enable)
+{
+	struct dsa_switch_context *dsa_switch_ctx = dev->data;
+
+	if (dsa_switch_ctx->dapi->vlan_setup == NULL) {
+		/* Getting here means that the driver has set the ETHERNET_HW_VLAN capability.
+		 * Assume that the absence of a vlan_setup implementation implies that no setup is
+		 * required. Setting the aforementioned cap while not providing a vlan_setup
+		 * function for a chip that does require VLAN configuration is a programming error.
+		 */
+		return 0;
+	}
+
+	return dsa_switch_ctx->dapi->vlan_setup(dev, iface, tag, enable);
+}
+#endif /* CONFIG_NET_VLAN */
+
 const struct ethernet_api dsa_eth_api = {
 	.iface_api.init = dsa_port_iface_init,
 	.get_phy = dsa_port_get_phy,
@@ -200,4 +218,7 @@ const struct ethernet_api dsa_eth_api = {
 	.get_capabilities = dsa_port_get_capabilities,
 	.set_config = dsa_set_config,
 	.get_config = dsa_get_config,
+#if defined(CONFIG_NET_VLAN)
+	.vlan_setup = dsa_vlan_setup,
+#endif /* CONFIG_NET_VLAN */
 };


### PR DESCRIPTION
A switch providing hardware VLAN capabilities may need to configure various tables (VLAN, CAM, etc.) when VLAN is enabled on one of its ports. Add `vlan_setup` to `struct dsa_api` and the DSA Ethernet API instance.