### PR TITLE
drivers: sensor: adxl372: support op mode/WUR via sensor API

### DIFF
--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Analog Devices Inc.
+ * Copyright (c) 2026 Daniel Kampert
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -581,6 +582,87 @@ static int adxl372_attr_set_odr(const struct device *dev,
 	return ret;
 }
 
+/**
+ * Set the Wake-Up Mode rate from a SENSOR_ATTR_SAMPLING_FREQUENCY value.
+ * Only meaningful while the device is in ADXL372_WAKE_UP mode.
+ * @param dev - The device structure.
+ * @param val - Requested frequency, in Hz.
+ *		Rounded to the slowest supported wake-up rate that is still at
+ *		least this fast: ADXL372_WUR_52ms, ADXL372_WUR_104ms,
+ *		ADXL372_WUR_208ms, ADXL372_WUR_512ms, ADXL372_WUR_2048ms,
+ *		ADXL372_WUR_4096ms, ADXL372_WUR_8192ms, ADXL372_WUR_24576ms.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int adxl372_attr_set_wur(const struct device *dev, const struct sensor_value *val)
+{
+	static const uint16_t wur_period_ms[] = {
+		[ADXL372_WUR_52ms] = 52,     [ADXL372_WUR_104ms] = 104,
+		[ADXL372_WUR_208ms] = 208,   [ADXL372_WUR_512ms] = 512,
+		[ADXL372_WUR_2048ms] = 2048, [ADXL372_WUR_4096ms] = 4096,
+		[ADXL372_WUR_8192ms] = 8192, [ADXL372_WUR_24576ms] = 24576,
+	};
+	struct adxl372_data *data = dev->data;
+	int64_t micro_hz = (int64_t)val->val1 * 1000000LL + val->val2;
+	int64_t period_ms;
+	enum adxl372_wakeup_rate wur = ADXL372_WUR_52ms;
+	int ret;
+
+	if (micro_hz <= 0) {
+		return -EINVAL;
+	}
+
+	/* period_ms = ceil(1000 / freq_hz), with freq_hz = micro_hz / 1e6 */
+	period_ms = (1000000000LL + micro_hz - 1) / micro_hz;
+
+	for (size_t i = ARRAY_SIZE(wur_period_ms) - 1; i >= 0; i--) {
+		if (wur_period_ms[i] <= period_ms) {
+			wur = (enum adxl372_wakeup_rate)i;
+			break;
+		}
+	}
+
+	ret = adxl372_set_wakeup_rate(dev, wur);
+	if (ret == 0) {
+		data->wur = wur;
+	}
+
+	return ret;
+}
+
+/**
+ * Set the mode of operation from a SENSOR_ATTR_CONFIGURATION value.
+ * @param dev - The device structure.
+ * @param val - Mode of operation, in val->val1.
+ *		Accepted values: ADXL372_STANDBY
+ *				 ADXL372_WAKE_UP
+ *				 ADXL372_INSTANT_ON
+ *				 ADXL372_FULL_BW_MEASUREMENT
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int adxl372_attr_set_op_mode(const struct device *dev, const struct sensor_value *val)
+{
+	struct adxl372_data *data = dev->data;
+	enum adxl372_op_mode op_mode = (enum adxl372_op_mode)val->val1;
+	int ret;
+
+	switch (op_mode) {
+	case ADXL372_STANDBY:
+	case ADXL372_WAKE_UP:
+	case ADXL372_INSTANT_ON:
+	case ADXL372_FULL_BW_MEASUREMENT:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = adxl372_set_op_mode(dev, op_mode);
+	if (ret == 0) {
+		data->op_mode = op_mode;
+	}
+
+	return ret;
+}
+
 static int adxl372_attr_set_thresh(const struct device *dev,
 				   enum sensor_channel chan,
 				   enum sensor_attribute attr,
@@ -631,12 +713,19 @@ static int adxl372_attr_set(const struct device *dev,
 			    enum sensor_attribute attr,
 			    const struct sensor_value *val)
 {
+	struct adxl372_data *data = dev->data;
+
 	switch (attr) {
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+		if (data->op_mode == ADXL372_WAKE_UP) {
+			return adxl372_attr_set_wur(dev, val);
+		}
 		return adxl372_attr_set_odr(dev, chan, attr, val);
 	case SENSOR_ATTR_UPPER_THRESH:
 	case SENSOR_ATTR_LOWER_THRESH:
 		return adxl372_attr_set_thresh(dev, chan, attr, val);
+	case SENSOR_ATTR_CONFIGURATION:
+		return adxl372_attr_set_op_mode(dev, val);
 	default:
 		return -ENOTSUP;
 	}
@@ -763,6 +852,7 @@ static int adxl372_probe(const struct device *dev)
 	if (ret) {
 		return ret;
 	}
+	data->wur = cfg->wur;
 
 	ret = adxl372_set_autosleep(dev, cfg->autosleep);
 	if (ret) {
@@ -824,6 +914,7 @@ static int adxl372_probe(const struct device *dev)
 	if (ret) {
 		return ret;
 	}
+	data->op_mode = cfg->op_mode;
 
 	return adxl372_set_act_proc_mode(dev, data->act_proc_mode);
 }
@@ -881,31 +972,22 @@ static int adxl372_init(const struct device *dev)
 #define ADXL372_CFG_IRQ(inst)
 #endif /* CONFIG_ADXL372_TRIGGER */
 
-#define ADXL372_CONFIG(inst)								\
-		.bw = DT_INST_PROP(inst, bw),						\
-		.hpf = DT_INST_PROP(inst, hpf),						\
-		.odr = DT_INST_PROP(inst, odr),						\
-		.max_peak_detect_mode = IS_ENABLED(CONFIG_ADXL372_PEAK_DETECT_MODE),	\
-		.th_mode = ADXL372_INSTANT_ON_LOW_TH,					\
-		.autosleep = false,							\
-		.wur = ADXL372_WUR_52ms,						\
-		.activity_th.thresh = CONFIG_ADXL372_ACTIVITY_THRESHOLD / 100,		\
-		.activity_th.referenced =						\
-			IS_ENABLED(CONFIG_ADXL372_REFERENCED_ACTIVITY_DETECTION_MODE),	\
-		.activity_th.enable = 1,						\
-		.activity_time = CONFIG_ADXL372_ACTIVITY_TIME,				\
-		.inactivity_th.thresh = CONFIG_ADXL372_INACTIVITY_THRESHOLD / 100,	\
-		.inactivity_th.referenced =						\
-			IS_ENABLED(CONFIG_ADXL372_REFERENCED_ACTIVITY_DETECTION_MODE),	\
-		.inactivity_th.enable = 1,						\
-		.inactivity_time = CONFIG_ADXL372_INACTIVITY_TIME,			\
-		.filter_settle = ADXL372_FILTER_SETTLE_370,				\
-		.fifo_config.fifo_mode =						\
-			DT_INST_PROP_OR(inst, fifo_mode, ADXL372_FIFO_BYPASSED),	\
-		.fifo_config.fifo_format = ADXL372_XYZ_FIFO,				\
-		.fifo_config.fifo_samples =						\
-			DT_INST_PROP_OR(inst, fifo_watermark, 0x80),			\
-		.op_mode = ADXL372_FULL_BW_MEASUREMENT,					\
+#define ADXL372_CONFIG(inst)                                                                       \
+	.bw = DT_INST_PROP(inst, bw), .hpf = DT_INST_PROP(inst, hpf),                              \
+	.odr = DT_INST_PROP(inst, odr),                                                            \
+	.max_peak_detect_mode = IS_ENABLED(CONFIG_ADXL372_PEAK_DETECT_MODE),                       \
+	.th_mode = ADXL372_INSTANT_ON_LOW_TH, .autosleep = false, .wur = ADXL372_WUR_52ms,         \
+	.activity_th.thresh = CONFIG_ADXL372_ACTIVITY_THRESHOLD / 100,                             \
+	.activity_th.referenced = IS_ENABLED(CONFIG_ADXL372_REFERENCED_ACTIVITY_DETECTION_MODE),   \
+	.activity_th.enable = 1, .activity_time = CONFIG_ADXL372_ACTIVITY_TIME,                    \
+	.inactivity_th.thresh = CONFIG_ADXL372_INACTIVITY_THRESHOLD / 100,                         \
+	.inactivity_th.referenced = IS_ENABLED(CONFIG_ADXL372_REFERENCED_ACTIVITY_DETECTION_MODE), \
+	.inactivity_th.enable = 1, .inactivity_time = CONFIG_ADXL372_INACTIVITY_TIME,              \
+	.filter_settle = ADXL372_FILTER_SETTLE_370,                                                \
+	.fifo_config.fifo_mode = DT_INST_PROP_OR(inst, fifo_mode, ADXL372_FIFO_BYPASSED),          \
+	.fifo_config.fifo_format = ADXL372_XYZ_FIFO,                                               \
+	.fifo_config.fifo_samples = DT_INST_PROP_OR(inst, fifo_watermark, 0x80),                   \
+	.op_mode = (enum adxl372_op_mode)DT_INST_PROP(inst, op_mode),
 
 #define ADXL372_CONFIG_SPI(inst)					\
 	{								\

--- a/drivers/sensor/adi/adxl372/adxl372.h
+++ b/drivers/sensor/adi/adxl372/adxl372.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Analog Devices Inc.
+ * Copyright (c) 2026 Daniel Kampert
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +9,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_ADXL372_ADXL372_H_
 
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/adxl372.h>
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
@@ -198,13 +200,6 @@ enum adxl372_axis {
 	ADXL372_Z_AXIS
 };
 
-enum adxl372_op_mode {
-	ADXL372_STANDBY,
-	ADXL372_WAKE_UP,
-	ADXL372_INSTANT_ON,
-	ADXL372_FULL_BW_MEASUREMENT
-};
-
 enum adxl372_bandwidth {
 	ADXL372_BW_200HZ,
 	ADXL372_BW_400HZ,
@@ -314,6 +309,8 @@ struct adxl372_data {
 	struct adxl372_fifo_config fifo_config;
 	enum adxl372_act_proc_mode act_proc_mode;
 	enum adxl372_odr odr;
+	enum adxl372_op_mode op_mode;
+	enum adxl372_wakeup_rate wur;
 #ifdef CONFIG_ADXL372_TRIGGER
 	struct gpio_callback gpio_cb;
 
@@ -412,6 +409,8 @@ int adxl372_trigger_set(const struct device *dev,
 int adxl372_init_interrupt(const struct device *dev);
 #endif /* CONFIG_ADXL372_TRIGGER */
 
+int adxl372_set_op_mode(const struct device *dev, enum adxl372_op_mode op_mode);
+
 #ifdef CONFIG_SENSOR_ASYNC_API
 int adxl372_get_accel_data(const struct device *dev, bool maxpeak,
 			   struct adxl372_xyz_accel_data *accel_data);
@@ -424,7 +423,6 @@ void adxl372_accel_convert(struct sensor_value *val, int16_t sample);
 int adxl372_configure_fifo(const struct device *dev, enum adxl372_fifo_mode mode,
 			   enum adxl372_fifo_format format, uint16_t fifo_samples);
 size_t adxl372_get_packet_size(const struct adxl372_dev_config *cfg);
-int adxl372_set_op_mode(const struct device *dev, enum adxl372_op_mode op_mode);
 #endif /* CONFIG_ADXL372_STREAM */
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADXL372_ADXL372_H_ */

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Analog Devices Inc.
+# Copyright (c) 2026 Daniel Kampert
 # SPDX-License-Identifier: Apache-2.0
 
 include: sensor-device.yaml
@@ -90,6 +91,22 @@ properties:
       Specify the FIFO watermark level in frame count.
     min: 0
     max: 512
+
+  op-mode:
+    type: int
+    default: 3
+    description: |
+          Operating mode set at init. Also changeable at runtime via
+          SENSOR_ATTR_CONFIGURATION.
+            0 # ADXL372_OP_MODE_STANDBY
+            1 # ADXL372_OP_MODE_WAKE_UP
+            2 # ADXL372_OP_MODE_INSTANT_ON
+            3 # ADXL372_OP_MODE_FULL_BW_MEASUREMENT
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
 
 examples:
   - |

--- a/include/zephyr/drivers/sensor/adxl372.h
+++ b/include/zephyr/drivers/sensor/adxl372.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Analog Devices Inc.
+ * Copyright (c) 2026 Daniel Kampert
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file adxl372.h
+ * @brief Header file for extended sensor API of ADXL372 sensor
+ *
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL372_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL372_H_
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief ADXL372 operating modes.
+ *
+ * Set via SENSOR_ATTR_CONFIGURATION, passed in the sensor_value.val1 field.
+ * Applies to the whole device, independent of sensor_channel.
+ */
+enum adxl372_op_mode {
+	/** Lowest-power mode. Activity/inactivity detection is disabled. */
+	ADXL372_STANDBY,
+	/**
+	 * Duty-cycled low-power mode: the device sleeps between samples and
+	 * wakes up periodically to compare acceleration against the
+	 * instant-on threshold. The wake-up rate is set via
+	 * SENSOR_ATTR_SAMPLING_FREQUENCY while this mode is active.
+	 */
+	ADXL372_WAKE_UP,
+	/** Instant-on threshold detection, without duty-cycling. */
+	ADXL372_INSTANT_ON,
+	/**
+	 * Continuous measurement at the configured output data rate. This is
+	 * the highest-power mode. The output data rate is set via
+	 * SENSOR_ATTR_SAMPLING_FREQUENCY while this mode is active.
+	 */
+	ADXL372_FULL_BW_MEASUREMENT,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADXL372_H_ */

--- a/include/zephyr/dt-bindings/sensor/adxl372.h
+++ b/include/zephyr/dt-bindings/sensor/adxl372.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Analog Devices Inc.
+ * Copyright (c) 2026 Daniel Kampert
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +31,19 @@
 #define ADXL372_FIFO_MODE_STREAMED  0x1 /**< Continuous stream, overwrite oldest */
 #define ADXL372_FIFO_MODE_TRIGGERED 0x2 /**< Capture samples around a trigger event */
 #define ADXL372_FIFO_MODE_OLD_SAVED 0x3 /**< Stop when full, keep oldest samples */
+/** @} */
+
+/**
+ * @name Operating mode options
+ *
+ * Values for the `op-mode` devicetree property. Also settable at runtime via
+ * SENSOR_ATTR_CONFIGURATION.
+ * @{
+ */
+#define ADXL372_OP_MODE_STANDBY             0x0 /**< Lowest power, detection disabled */
+#define ADXL372_OP_MODE_WAKE_UP             0x1 /**< Duty-cycled low-power detection */
+#define ADXL372_OP_MODE_INSTANT_ON          0x2 /**< Always-on threshold detection */
+#define ADXL372_OP_MODE_FULL_BW_MEASUREMENT 0x3 /**< Continuous measurement, highest power */
 /** @} */
 
 /** @} */


### PR DESCRIPTION
The ADXL372 driver had no way to change its operating mode or wake-up rate (WUR) from application code:

- adxl372_set_op_mode() was declared only under CONFIG_ADXL372_STREAM, so it could not be called unless RTIO streaming was enabled.
- Even with that Kconfig on, nothing routed SENSOR_ATTR_CONFIGURATION (or any other sensor attribute) to adxl372_set_op_mode(), so the operating mode set at init from the config struct's hardcoded op-mode field could never be changed afterwards.
- adxl372_set_wakeup_rate() had the same problem: it was only ever called once at init with cfg->wur, with no attribute wired up to call it again at runtime.

In practice this made the chip's own low-power Wake-Up mode unreachable from application code - only ADXL372_FULL_BW_MEASUREMENT (continuous conversion, the highest-current mode the chip has) could ever be selected, since that is the config struct's default and nothing could change it later.

Fix this by:

- Moving enum adxl372_op_mode into a new public header, include/zephyr/drivers/sensor/adxl372.h, so application code has something to include for the mode values without pulling in the private driver header.
- Un-gating the adxl372_set_op_mode() declaration from CONFIG_ADXL372_STREAM in the private header - the function definition itself was never actually gated, only its declaration.
- Wiring SENSOR_ATTR_CONFIGURATION to adxl372_set_op_mode(), and SENSOR_ATTR_SAMPLING_FREQUENCY - while the device is in ADXL372_WAKE_UP mode - to adxl372_set_wakeup_rate(), converting the requested frequency to the nearest supported wake-up period. Both the current op mode and WUR are now tracked in struct adxl372_data so attr_set() knows which of ODR or WUR "sampling frequency" currently refers to.
- Adding an op-mode devicetree property so the mode selected at init is configurable too, not just at runtime. Defaults to ADXL372_OP_MODE_FULL_BW_MEASUREMENT, so existing users see no behavior change unless they opt in.

Tested on real ADXL372 hardware (Thingy:91, nRF9160): switched between ADXL372_FULL_BW_MEASUREMENT and ADXL372_WAKE_UP at runtime via sensor_attr_set(), and set several wake-up rates via SENSOR_ATTR_SAMPLING_FREQUENCY, confirming each is applied.

Fixes: #118373