### PR TITLE
tests: drivers: stepper: also run on 32-bit native_sim

### DIFF
--- a/tests/drivers/stepper/stepper_ctrl/tests.yaml
+++ b/tests/drivers/stepper/stepper_ctrl/tests.yaml
@@ -9,35 +9,39 @@ common:
 tests:
   drivers.stepper.stepper_ctrl.gpio_step_dir:
     extra_args:
-      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_gpio_step_dir.overlay"
+      - DTC_OVERLAY_FILE="boards/native_sim_gpio_step_dir.overlay"
     extra_configs:
       - CONFIG_GPIO=y
       - CONFIG_COUNTER=y
     platform_allow:
+      - native_sim
       - native_sim/native/64
   drivers.stepper.stepper_ctrl.gpio_step_dir_work_q:
     extra_args:
-      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_gpio_step_dir_workq.overlay"
+      - DTC_OVERLAY_FILE="boards/native_sim_gpio_step_dir_workq.overlay"
     extra_configs:
       - CONFIG_GPIO=y
       - CONFIG_STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT=130
       - CONFIG_STEPPER_CTRL_ISR_SAFE_EVENTS=n
     platform_allow:
+      - native_sim
       - native_sim/native/64
   drivers.stepper.stepper_ctrl.h_bridge_stepper:
     extra_args:
-      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_h_bridge_stepper.overlay"
+      - DTC_OVERLAY_FILE="boards/native_sim_h_bridge_stepper.overlay"
     extra_configs:
       - CONFIG_GPIO=y
       - CONFIG_COUNTER=y
     platform_allow:
+      - native_sim
       - native_sim/native/64
   drivers.stepper.stepper_ctrl.h_bridge_stepper_work_q:
     extra_args:
-      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_h_bridge_stepper_workq.overlay"
+      - DTC_OVERLAY_FILE="boards/native_sim_h_bridge_stepper_workq.overlay"
     extra_configs:
       - CONFIG_GPIO=y
       - CONFIG_STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT=130
       - CONFIG_STEPPER_CTRL_ISR_SAFE_EVENTS=n
     platform_allow:
+      - native_sim
       - native_sim/native/64


### PR DESCRIPTION
These scenarios allow `native_sim/native/64` only, but the code coverage CI job runs `twister -p native_sim`, which resolves to the 32-bit target. The stepper controller drivers therefore never reach the coverage report.

Verified with twister on both targets: 8/8 configurations pass. Measured under `--coverage` on `native_sim`, this adds roughly 370 covered lines across `gpio_step_dir_stepper_ctrl.c`, `h_bridge_stepper_ctrl.c`, `stepper_counter_timing.c`, `stepper_work_timing.c` and `stepper_ctrl_event_handler.c`.
