### PR TITLE
tests: net: socket: add an object core scenario

### DIFF
--- a/tests/net/socket/misc/tests.yaml
+++ b/tests/net/socket/misc/tests.yaml
@@ -19,3 +19,8 @@ tests:
   net.socket.misc.v4_mapping_to_v6_disabled:
     extra_configs:
       - CONFIG_NET_IPV4_MAPPING_TO_IPV6=n
+  net.socket.misc.obj_core:
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=n
+      - CONFIG_OBJ_CORE=y
+      - CONFIG_NET_SOCKETS_OBJ_CORE=y


### PR DESCRIPTION
`CONFIG_NET_SOCKETS_OBJ_CORE` is set by no test in the tree, so `subsys/net/lib/sockets/socket_obj_core.c` is never compiled and is absent from the coverage report. This suite already opens and closes sockets of every kind the object core registers, so a scenario is all that is needed.

Measured under `--coverage` with twister: +71 covered lines in `socket_obj_core.c` and +70 in `kernel/obj_core.c`, on both `native_sim` and `qemu_x86`. All configurations of the suite pass.
