### PR TITLE
tests: drivers: udc: also run the skeleton on 32-bit native_sim

### DIFF
--- a/tests/drivers/udc/tests.yaml
+++ b/tests/drivers/udc/tests.yaml
@@ -25,6 +25,7 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="udc_skeleton.overlay"
       - CONFIG_UDC_BUF_POOL_SIZE=32768
     platform_allow:
+      - native_sim
       - native_sim/native/64
     integration_platforms:
       - native_sim/native/64


### PR DESCRIPTION
The skeleton scenario allows `native_sim/native/64` only, but the code coverage CI job runs `twister -p native_sim`, which resolves to the 32-bit target. `drivers/usb/udc/udc_skeleton.c` therefore never reaches the coverage report.

The virtual controller and its overlay are word-size agnostic. Measured under `--coverage` on `native_sim`: +95 covered lines in `udc_skeleton.c` and +49 in `udc_common.c`, which is already compiled but barely exercised.