### PR TITLE
doc: migration-guide: Mention deprecation of bank2-flash-size property

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -617,6 +617,10 @@ Flash
   of each plane in the flash device. For devices with a single plane, this should be set to the
   same value as ``size-bytes``.
 
+* The :dtcompatible:`st,stm32-nv-flash` property ``bank2-flash-size`` has been deprecated in favor
+  of determining flash bank sizes using ``reg`` size cells. No changes need be made to the
+  devicetree save for removing the aforementioned property. (:github:`114971`)
+
 Fuel Gauge
 ==========
 


### PR DESCRIPTION
2e84d6ac6b1d8 deprecated the st,stm32-nv-flash bank2-flash-size devicetree property. Add a bullet point to the migration guide instructing users to remove it.

This is an addendum to #114971 - requested by @etienne-lms in [this thread](https://github.com/zephyrproject-rtos/zephyr/pull/114971#pullrequestreview-4845345353) - which never made it into the original PR.