### PR TITLE
tests: settings: zms: add a ZMS cache scenario

### DIFF
--- a/tests/subsys/settings/functional/zms/tests.yaml
+++ b/tests/subsys/settings/functional/zms/tests.yaml
@@ -7,3 +7,18 @@ tests:
     tags:
       - settings
       - zms
+  settings.functional.zms.cache:
+    extra_configs:
+      - CONFIG_ZMS_LOOKUP_CACHE=y
+      - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
+      - CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS=y
+      - CONFIG_SETTINGS_ZMS_LL_CACHE=y
+      - CONFIG_SETTINGS_ZMS_LL_CACHE_SIZE=32
+    platform_allow:
+      - qemu_x86
+      - native_sim
+    integration_platforms:
+      - native_sim
+    tags:
+      - settings
+      - zms


### PR DESCRIPTION
`CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS` and `CONFIG_SETTINGS_ZMS_LL_CACHE` are enabled by no test in the tree, so the settings-side cache paths in `settings_zms.c` and `zms.c` never reach the coverage report. This suite already exercises the save, load and delete operations they sit under, so a scenario is all that is needed.

Measured with twister `--coverage`: +26 covered lines in `subsys/settings/src/settings_zms.c` and +47 in `subsys/kvss/zms/zms.c`. The scenario passes on `native_sim` and `qemu_x86`.
