### PR TITLE
tests: drivers: gpio: add a user tracing scenario

### DIFF
--- a/tests/drivers/gpio/gpio_api_1pin/tests.yaml
+++ b/tests/drivers/gpio/gpio_api_1pin/tests.yaml
@@ -40,3 +40,9 @@ tests:
     filter: dt_compat_enabled("test-gpio-external-pulldown")
     harness_config:
       fixture: gpio_external_pull_down
+  drivers.gpio.1pin.tracing:
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y


### PR DESCRIPTION
`subsys/tracing/user/tracing_user.c` carries 28 `sys_trace_gpio_*()` wrappers plus their weak stubs, and no test in the tree builds with `CONFIG_TRACING_USER=y`.

This test suite already drives the GPIO API those hooks sit on, so a scenario reusing the same sources is enough.