### PR TITLE
twister: coverage: do not lose a whole platform to one unreadable object

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -247,6 +247,9 @@ class Json_report:
                 if not x:
                     continue
 
+                if not covered_file['lines']:
+                    continue
+
                 file_name = covered_file['file'][covered_file['file'].rfind('/') + 1 :]
                 file_path = covered_file['file']
                 file_coverage, file_lines, file_hit = self._calculate_coverage_of_file(covered_file)

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -18,6 +18,8 @@ import sys
 import tempfile
 import time
 
+from packaging import version
+
 logger = logging.getLogger('twister')
 
 supported_coverage_formats = {
@@ -533,7 +535,7 @@ class Gcovr(CoverageTool):
             version_lines = result.stdout.strip().split('\n')
             if version_lines:
                 version_output = version_lines[0].replace('gcovr ', '')
-                return version_output
+                return version.parse(version_output)
         except subprocess.CalledProcessError as e:
             logger.error(f"Unable to determine gcovr version: {e}")
             sys.exit(1)
@@ -571,9 +573,9 @@ class Gcovr(CoverageTool):
                "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
                "--gcov-executable", self.gcov_tool,
                "-e", "tests/*"]
-        if self.version >= "7.0":
+        if self.version >= version.parse("7.0"):
             cmd += ["--gcov-object-directory", outdir]
-        if self.version >= "8.0":
+        if self.version >= version.parse("8.0"):
             cmd += ["--gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file"]
         cmd += excludes + self.options + ["--json", "-o", coverage_file, outdir]
         cmd_str = " ".join(cmd)
@@ -589,7 +591,7 @@ class Gcovr(CoverageTool):
         cmd += ["--gcov-executable", self.gcov_tool,
                 "-f", "tests/ztest", "-e", "tests/ztest/test/*",
                 "--json", "-o", ztest_file, outdir]
-        if self.version >= "7.0":
+        if self.version >= version.parse("7.0"):
             cmd += ["--gcov-object-directory", outdir]
 
         cmd_str = " ".join(cmd)

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -571,6 +571,7 @@ class Gcovr(CoverageTool):
         # We want to remove tests/* and tests/ztest/test/* but save tests/ztest
         cmd = ["gcovr", "-r", self.base_dir,
                "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
+               "--gcov-ignore-errors=all",
                "--gcov-executable", self.gcov_tool,
                "-e", "tests/*"]
         if self.version >= version.parse("7.0"):

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -5,7 +5,7 @@ canopen
 clang-format>=15.0.0
 elasticsearch<9
 exceptiongroup>=1.0.0rc8
-gcovr==6.0
+gcovr==8.6
 gitlint-core>=0.19.1
 gitpython>=3.1.50
 ijson

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -313,6 +313,7 @@ colorama==0.4.6 \
     # via
     #   awscli
     #   click
+    #   colorlog
     #   halo
     #   log-symbols
     #   pylint
@@ -320,6 +321,10 @@ colorama==0.4.6 \
     #   tox
     #   tqdm
     #   west
+colorlog==6.12.0 \
+    --hash=sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f \
+    --hash=sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e
+    # via gcovr
 cryptography==50.0.0 \
     --hash=sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03 \
     --hash=sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7 \
@@ -402,9 +407,9 @@ filelock==3.32.2 \
     #   python-discovery
     #   tox
     #   virtualenv
-gcovr==6.0 \
-    --hash=sha256:2e52019fdb76c6e327f48c2a2d8555fb5e362570b79cc74c5498804d1ce54a60 \
-    --hash=sha256:8638d5f44def10e38e3166c8a33bef6643ec204687e0ac7d345ce41a98c5750b
+gcovr==8.6 \
+    --hash=sha256:b2e7042abca9321cadbab8a06eb34d19f801b831557b28cdc30a029313de8b9e \
+    --hash=sha256:dbf9d87c38042752ad6f530aa8210427e22b526611bb7b7bfed0e81977d1f1ef
     # via -r requirements-actions.in
 gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -10,7 +10,7 @@ colorama
 ply>=3.10
 
 # used for code coverage
-gcovr>=6.0
+gcovr>=8.0
 coverage
 
 # used for west-command testing


### PR DESCRIPTION
The `mps2/an385` leg of the codecov workflow has been flaky for a while, and when it fails no coverage report is uploaded for it at all — the artifact carries only the testplan. `merged.json` then holds no `arch/arm/` files and the published number is effectively `native_sim` + `qemu_x86`. It has failed on every `main` run since 2026-08-19.

gcovr gets the whole `twister-out` tree and one gcov binary, and aborts outright on the first object that binary cannot read — LLVM notes from a suite built through `integration_toolchains`, or a `.gcda` truncated by a target that faulted mid-dump — discarding every other object with it. `--gcov-ignore-errors` fixes that, but gcovr 6.0 — released in March 2023, three and a half years ago — only accepts it for `no_working_dir_found`, so the pin moves too; it dates from 2024 and guarded a cross-version merge that can no longer happen now that both jobs install the same requirements file. The bump in turn exposes a `ZeroDivisionError` in the report generator on files gcovr 8 reports with no instrumented lines, fixed here as well.

Measured on a tree seeded with unreadable notes: exit 64 and no coverage as twister invokes gcovr today, exit 0 and full coverage with the flag. The whole pipeline was re-run on gcovr 8.6 output and matches the 6.0 totals to within 0.03%. This workflow only runs on pushes to `main`, `v*-branch` and `collab-*`, so this PR will not exercise it. @nashif maybe you can test on zephyr-testing? Thanks!

