### PR TITLE
tests: fs: littlefs: exercise the littlefs disk version

### DIFF
--- a/tests/subsys/fs/littlefs/tests.yaml
+++ b/tests/subsys/fs/littlefs/tests.yaml
@@ -51,3 +51,4 @@ tests:
     extra_configs:
       - CONFIG_APP_TEST_CUSTOM=y
       - CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=16384
+      - CONFIG_FS_LITTLEFS_DISK_VERSION=y


### PR DESCRIPTION
`CONFIG_FS_LITTLEFS_DISK_VERSION` is only `default y` when a `zephyr,fstab,littlefs` node carries a `disk-version` property, which no coverage platform's devicetree has, and no test in the tree sets it. The blocks it guards in `subsys/fs/littlefs_fs.c` — the disk-version selection in the mount path and the version reporting in the format path — are therefore never compiled and never reach the coverage report.

It rides an existing scenario rather than adding one, so the only cost is one Kconfig line. Measured under `--coverage` on `native_sim`: +7 covered lines in `littlefs_fs.c`, all of the 7 it adds to the denominator. The suite passes.
