### PR TITLE
arch: arm64: require stack protection for safe exception stack

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -181,7 +181,7 @@ config WAIT_AT_RESET_VECTOR
 	  execution
 
 config ARM64_SAFE_EXCEPTION_STACK
-	bool "To enable the safe exception stack"
+	bool
 	help
 	  The safe exception stack is used for checking whether the kernel stack
 	  overflows during the exception happens from EL1. This stack is not


### PR DESCRIPTION
ARM64_SAFE_EXCEPTION_STACK is user-selectable without ARM64_STACK_PROTECTION, but thread->arch.stack_limit is only assigned when the latter is on (arch_new_thread). With the safe exception stack enabled standalone, current_stack_limit stays 0, so the overflow check in z_arm64_quick_stack_check() can never trip: every EL1 exception pays the entry overhead and the kernel stack overflow detection silently does not exist.

Make ARM64_STACK_PROTECTION the only way in. No in-tree configuration is affected: no AArch64 target selects ARM_MPU today, so ARM64_SAFE_EXCEPTION_STACK was never enabled in any built config.

Fixes #118385