### PR TITLE
usb: device_next: cdc_ncm: advertise SetEthernetPacketFilter support

### DIFF
--- a/include/zephyr/usb/class/usb_cdc.h
+++ b/include/zephyr/usb/class/usb_cdc.h
@@ -158,6 +158,31 @@
 #define GET_CRC_MODE           0x89
 #define SET_CRC_MODE           0x8A
 
+/**
+ * @name Network Capabilities Bitmap of the NCM Functional Descriptor
+ * @note NCM100.pdf, 5.2.1, Table 5-2
+ * @{
+ */
+/** Function can process SetEthernetPacketFilter requests */
+#define USB_CDC_NCM_NCAP_ETH_FILTER		BIT(0)
+/** Function can process GetNetAddress and SetNetAddress requests */
+#define USB_CDC_NCM_NCAP_NET_ADDRESS		BIT(1)
+/** Function can process SendEncapsulatedCommand and
+ *  GetEncapsulatedResponse requests
+ */
+#define USB_CDC_NCM_NCAP_ENCAP_COMMAND		BIT(2)
+/** Function can process SetMaxDatagramSize and GetMaxDatagramSize
+ *  requests
+ */
+#define USB_CDC_NCM_NCAP_MAX_DATAGRAM_SIZE	BIT(3)
+/** Function can process SetCrcMode and GetCrcMode requests */
+#define USB_CDC_NCM_NCAP_CRC_MODE		BIT(4)
+/** Function can process 8-byte forms of GetNtbInputSize and
+ *  SetNtbInputSize requests
+ */
+#define USB_CDC_NCM_NCAP_NTB_INPUT_SIZE		BIT(5)
+/** @} */
+
 /** Ethernet Packet Filter Bitmap */
 #define PACKET_TYPE_MULTICAST		0x10
 #define PACKET_TYPE_BROADCAST		0x08

--- a/subsys/usb/device_next/class/usbd_cdc_ncm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_ncm.c
@@ -1290,7 +1290,7 @@ static struct usbd_cdc_ncm_desc cdc_ncm_desc_##n = {				\
 		.bDescriptorType = USB_DESC_CS_INTERFACE,			\
 		.bDescriptorSubtype = ETHERNET_FUNC_DESC_NCM,			\
 		.bcdNcmVersion = sys_cpu_to_le16(0x100),			\
-		.bmNetworkCapabilities = 0,					\
+		.bmNetworkCapabilities = USB_CDC_NCM_NCAP_ETH_FILTER,		\
 	},									\
 										\
 	.if0_int_ep = {								\


### PR DESCRIPTION
Set D0 (SetEthernetPacketFilter) in bmNetworkCapabilities of the NCM Functional Descriptor and add the Network Capabilities bitmap values from NCM 1.0, 5.2.1, Table 5-2 to usb_cdc.h.

The request handler already accepts SET_ETHERNET_PACKET_FILTER, but without D0 the macOS NCM host driver refuses to enable promiscuous mode on the interface, so Internet Sharing cannot add it to its bridge and starts no DHCP or DNS service for it. There is no filtering on the device side, as with commit 89e778d5b2f7
("usb: device_next: usbd_cdc_{ecm,ncm}: support promisc mode").

Assisted-by: Claude:claude-opus-5