### PR TITLE
tests: kernel: exercise the tracing hooks

### DIFF
--- a/tests/kernel/common/tests.yaml
+++ b/tests/kernel/common/tests.yaml
@@ -93,3 +93,9 @@ tests:
     integration_platforms:
       - qemu_x86
       - mps2/an385
+  kernel.common.tracing:
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/condvar/condvar_api/tests.yaml
+++ b/tests/kernel/condvar/condvar_api/tests.yaml
@@ -5,3 +5,14 @@ tests:
       - kernel
       - userspace
       - condition_variables
+  kernel.condvar.tracing:
+    ignore_faults: true
+    tags:
+      - kernel
+      - userspace
+      - condition_variables
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/events/event_api/tests.yaml
+++ b/tests/kernel/events/event_api/tests.yaml
@@ -3,3 +3,12 @@ tests:
     tags:
       - kernel
       - userspace
+  kernel.events.tracing:
+    tags:
+      - kernel
+      - userspace
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/mbox/mbox_api/tests.yaml
+++ b/tests/kernel/mbox/mbox_api/tests.yaml
@@ -3,3 +3,15 @@ tests:
     tags:
       - kernel
       - mailbox
+  kernel.mailbox.api.tracing:
+    tags:
+      - kernel
+      - mailbox
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/kernel/mbox/mbox_api/tests.yaml
+++ b/tests/kernel/mbox/mbox_api/tests.yaml
@@ -15,3 +15,12 @@ tests:
       - CONFIG_TRACING_BACKEND_POSIX=y
       - CONFIG_TRACING_PACKET_MAX_SIZE=256
       - CONFIG_TRACING_SYNC=y
+  kernel.mailbox.api.tracing_user:
+    tags:
+      - kernel
+      - mailbox
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/mem_slab/mslab_api/tests.yaml
+++ b/tests/kernel/mem_slab/mslab_api/tests.yaml
@@ -29,3 +29,12 @@ tests:
       - qemu_arc/qemu_arc_hs
     extra_configs:
       - CONFIG_MULTITHREADING=n
+  kernel.memory_slabs.api.tracing:
+    tags:
+      - kernel
+      - memory_slabs
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/msgq/msgq_api/tests.yaml
+++ b/tests/kernel/msgq/msgq_api/tests.yaml
@@ -16,3 +16,9 @@ tests:
       - CONFIG_TRACING_BACKEND_POSIX=y
       - CONFIG_TRACING_PACKET_MAX_SIZE=256
       - CONFIG_TRACING_SYNC=y
+  kernel.message_queue.tracing_user:
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/msgq/msgq_api/tests.yaml
+++ b/tests/kernel/msgq/msgq_api/tests.yaml
@@ -7,3 +7,12 @@ tests:
   kernel.message_queue.put_front:
     extra_configs:
       - CONFIG_TEST_MSGQ_PUT_FRONT=y
+  kernel.message_queue.tracing:
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/kernel/pipe/pipe_api/tests.yaml
+++ b/tests/kernel/pipe/pipe_api/tests.yaml
@@ -3,3 +3,14 @@ tests:
     tags:
       - kernel
       - userspace
+  kernel.pipe.api.tracing:
+    tags:
+      - kernel
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/kernel/poll/tests.yaml
+++ b/tests/kernel/poll/tests.yaml
@@ -17,3 +17,13 @@ tests:
       - nrf52dk/nrf52810
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
+  kernel.poll.tracing:
+    ignore_faults: true
+    tags:
+      - kernel
+      - userspace
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/queue/tests.yaml
+++ b/tests/kernel/queue/tests.yaml
@@ -13,3 +13,14 @@ tests:
     ignore_faults: true
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y
+  kernel.queue.tracing:
+    tags:
+      - kernel
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/kernel/semaphore/semaphore/tests.yaml
+++ b/tests/kernel/semaphore/semaphore/tests.yaml
@@ -4,3 +4,13 @@ tests:
       - kernel
       - userspace
     ignore_faults: true
+  kernel.semaphore.tracing:
+    ignore_faults: true
+    tags:
+      - kernel
+      - userspace
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/workq/work/tests.yaml
+++ b/tests/kernel/workq/work/tests.yaml
@@ -10,3 +10,14 @@ tests:
       - hifive1
       - qemu_rx
     timeout: 80
+  kernel.workqueue.api.tracing:
+    tags: kernel
+    timeout: 80
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y

--- a/tests/kernel/workq/work/tests.yaml
+++ b/tests/kernel/workq/work/tests.yaml
@@ -21,3 +21,11 @@ tests:
       - CONFIG_TRACING_BACKEND_POSIX=y
       - CONFIG_TRACING_PACKET_MAX_SIZE=256
       - CONFIG_TRACING_SYNC=y
+  kernel.workqueue.api.tracing_user:
+    tags: kernel
+    timeout: 80
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_USER=y

--- a/tests/kernel/workq/work_queue/tests.yaml
+++ b/tests/kernel/workq/work_queue/tests.yaml
@@ -11,3 +11,15 @@ tests:
       - workqueue
     extra_configs:
       - CONFIG_WORKQUEUE_WORK_TIMEOUT=y
+  kernel.workqueue.tracing:
+    tags:
+      - kernel
+      - workqueue
+    platform_allow:
+      - native_sim
+    extra_configs:
+      - CONFIG_TRACING=y
+      - CONFIG_TRACING_CTF=y
+      - CONFIG_TRACING_BACKEND_POSIX=y
+      - CONFIG_TRACING_PACKET_MAX_SIZE=256
+      - CONFIG_TRACING_SYNC=y


### PR DESCRIPTION
The tracing tests enable tracing but hardly touch kernel objects, and the kernel test suites exercise those objects but never enable tracing. `subsys/tracing/` is therefore built and then mostly never runs. These scenarios turn tracing on for suites that already drive the kernel APIs.

Measured with twister `--coverage` on `native_sim`, against the current coverage CI run: +1186 lines covered.