### PR TITLE
espressif: use the generic mcuboot defaults under sysbuild

### DIFF
--- a/boards/01space/esp32c3_042_oled/Kconfig.sysbuild
+++ b/boards/01space/esp32c3_042_oled/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/feather_esp32c6/Kconfig.sysbuild
+++ b/boards/adafruit/feather_esp32c6/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/feather_esp32s2/Kconfig.sysbuild
+++ b/boards/adafruit/feather_esp32s2/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/feather_esp32s3/Kconfig.sysbuild
+++ b/boards/adafruit/feather_esp32s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/feather_esp32s3_tft/Kconfig.sysbuild
+++ b/boards/adafruit/feather_esp32s3_tft/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.sysbuild
+++ b/boards/adafruit/feather_esp32s3_tft_reverse/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/adafruit/qt_py_esp32s3/Kconfig.sysbuild
+++ b/boards/adafruit/qt_py_esp32s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/aithinker/esp32_cam/Kconfig.sysbuild
+++ b/boards/aithinker/esp32_cam/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/alientek/dnesp32s3b/Kconfig.sysbuild
+++ b/boards/alientek/dnesp32s3b/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/arduino/nesso_n1/Kconfig.sysbuild
+++ b/boards/arduino/nesso_n1/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/dfrobot/beetle_esp32c3/Kconfig.sysbuild
+++ b/boards/dfrobot/beetle_esp32c3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/dptechnics/walter/Kconfig.sysbuild
+++ b/boards/dptechnics/walter/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/ebyte/eora_hub_900tb/Kconfig.sysbuild
+++ b/boards/ebyte/eora_hub_900tb/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32_ethernet_kit/Kconfig.sysbuild
+++ b/boards/espressif/esp32_ethernet_kit/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c3_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32c3_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c3_devkitm/Kconfig.sysbuild
+++ b/boards/espressif/esp32c3_devkitm/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c3_rust/Kconfig.sysbuild
+++ b/boards/espressif/esp32c3_rust/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c5_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32c5_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c61_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32c61_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32c6_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32c6_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32h2_devkitm/Kconfig.sysbuild
+++ b/boards/espressif/esp32h2_devkitm/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32p4_function_ev_board/Kconfig.sysbuild
+++ b/boards/espressif/esp32p4_function_ev_board/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32p4x_function_ev_board/Kconfig.sysbuild
+++ b/boards/espressif/esp32p4x_function_ev_board/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32s2_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32s2_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32s2_saola/Kconfig.sysbuild
+++ b/boards/espressif/esp32s2_saola/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32s3_box3/Kconfig.sysbuild
+++ b/boards/espressif/esp32s3_box3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32s3_devkitc/Kconfig.sysbuild
+++ b/boards/espressif/esp32s3_devkitc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp32s3_eye/Kconfig.sysbuild
+++ b/boards/espressif/esp32s3_eye/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp8684_devkitm/Kconfig.sysbuild
+++ b/boards/espressif/esp8684_devkitm/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp_threadbr/Kconfig.sysbuild
+++ b/boards/espressif/esp_threadbr/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/espressif/esp_wrover_kit/Kconfig.sysbuild
+++ b/boards/espressif/esp_wrover_kit/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/franzininho/esp32s2_franzininho/Kconfig.sysbuild
+++ b/boards/franzininho/esp32s2_franzininho/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/hardkernel/odroid_go/Kconfig.sysbuild
+++ b/boards/hardkernel/odroid_go/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/heltec/heltec_wifi_lora32_v2/Kconfig.sysbuild
+++ b/boards/heltec/heltec_wifi_lora32_v2/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/heltec/heltec_wifi_lora32_v3/Kconfig.sysbuild
+++ b/boards/heltec/heltec_wifi_lora32_v3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/heltec/heltec_wireless_stick_lite_v3/Kconfig.sysbuild
+++ b/boards/heltec/heltec_wireless_stick_lite_v3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/heltec/heltec_wireless_tracker/Kconfig.sysbuild
+++ b/boards/heltec/heltec_wireless_tracker/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/kincony/kincony_kc868_a32/Kconfig.sysbuild
+++ b/boards/kincony/kincony_kc868_a32/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/kincony/kincony_kc868_a8/Kconfig.sysbuild
+++ b/boards/kincony/kincony_kc868_a8/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/t_deck/Kconfig.sysbuild
+++ b/boards/lilygo/t_deck/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/tdongle_s3/Kconfig.sysbuild
+++ b/boards/lilygo/tdongle_s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_lora32/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_lora32/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_t7v1_5/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_t7v1_5/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_t8c3/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_t8c3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_t8s3/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_t8s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_tbeam/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_tbeam/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/ttgo_toiplus/Kconfig.sysbuild
+++ b/boards/lilygo/ttgo_toiplus/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/lilygo/twatch_s3/Kconfig.sysbuild
+++ b/boards/lilygo/twatch_s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/luatos/esp32c3_luatos_core/Kconfig.sysbuild
+++ b/boards/luatos/esp32c3_luatos_core/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/luatos/esp32s3_luatos_core/Kconfig.sysbuild
+++ b/boards/luatos/esp32s3_luatos_core/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_atoms3/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_atoms3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_atoms3_lite/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_atoms3_lite/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_cores3/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_cores3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_nanoc6/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_nanoc6/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_paper_color/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_paper_color/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stack_unitc6l/Kconfig.sysbuild
+++ b/boards/m5stack/m5stack_unitc6l/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/m5stickc_plus/Kconfig.sysbuild
+++ b/boards/m5stack/m5stickc_plus/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/m5stack/stamp_c3/Kconfig.sysbuild
+++ b/boards/m5stack/stamp_c3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/makerfabs/matouch_mtro128g/Kconfig.sysbuild
+++ b/boards/makerfabs/matouch_mtro128g/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/olimex/esp32p4_pc/Kconfig.sysbuild
+++ b/boards/olimex/esp32p4_pc/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/olimex/olimex_esp32_evb/Kconfig.sysbuild
+++ b/boards/olimex/olimex_esp32_evb/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/others/doit_esp32_devkit_v1/Kconfig.sysbuild
+++ b/boards/others/doit_esp32_devkit_v1/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/others/esp32c3_lckfb/Kconfig.sysbuild
+++ b/boards/others/esp32c3_lckfb/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/others/esp32c3_supermini/Kconfig.sysbuild
+++ b/boards/others/esp32c3_supermini/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/others/esp32h2_supermini/Kconfig.sysbuild
+++ b/boards/others/esp32h2_supermini/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/others/icev_wireless/Kconfig.sysbuild
+++ b/boards/others/icev_wireless/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/pcbcupid/glyph_c3/Kconfig.sysbuild
+++ b/boards/pcbcupid/glyph_c3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/pcbcupid/glyph_c6/Kconfig.sysbuild
+++ b/boards/pcbcupid/glyph_c6/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/pcbcupid/glyph_h2/Kconfig.sysbuild
+++ b/boards/pcbcupid/glyph_h2/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/rakwireless/rak3112/Kconfig.sysbuild
+++ b/boards/rakwireless/rak3112/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/reterminal_e1001/Kconfig.sysbuild
+++ b/boards/seeed/reterminal_e1001/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/reterminal_e1002/Kconfig.sysbuild
+++ b/boards/seeed/reterminal_e1002/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/reterminal_e1003/Kconfig.sysbuild
+++ b/boards/seeed/reterminal_e1003/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/xiao_esp32c3/Kconfig.sysbuild
+++ b/boards/seeed/xiao_esp32c3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/xiao_esp32c5/Kconfig.sysbuild
+++ b/boards/seeed/xiao_esp32c5/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/xiao_esp32c6/Kconfig.sysbuild
+++ b/boards/seeed/xiao_esp32c6/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/seeed/xiao_esp32s3/Kconfig.sysbuild
+++ b/boards/seeed/xiao_esp32s3/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/udoo/udoo_key/Kconfig.sysbuild
+++ b/boards/udoo/udoo_key/Kconfig.sysbuild
@@ -7,8 +7,4 @@ choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
 
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice
-
 endif

--- a/boards/vcc-gnd/yd_esp32/Kconfig.sysbuild
+++ b/boards/vcc-gnd/yd_esp32/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/viewe/uedx24240013_md50e/Kconfig.sysbuild
+++ b/boards/viewe/uedx24240013_md50e/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/viewe/uedx24320028e_wb_a/Kconfig.sysbuild
+++ b/boards/viewe/uedx24320028e_wb_a/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/viewe/uedx32480035e_wb_a/Kconfig.sysbuild
+++ b/boards/viewe/uedx32480035e_wb_a/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32c6_lcd_1_47/Kconfig.sysbuild
+++ b/boards/waveshare/esp32c6_lcd_1_47/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32p4_eth/Kconfig.sysbuild
+++ b/boards/waveshare/esp32p4_eth/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32p4_wifi6/Kconfig.sysbuild
+++ b/boards/waveshare/esp32p4_wifi6/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32p4_wifi6_dev_kit/Kconfig.sysbuild
+++ b/boards/waveshare/esp32p4_wifi6_dev_kit/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32s3_geek/Kconfig.sysbuild
+++ b/boards/waveshare/esp32s3_geek/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/waveshare/esp32s3_matrix/Kconfig.sysbuild
+++ b/boards/waveshare/esp32s3_matrix/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/we/orthosie1ev/Kconfig.sysbuild
+++ b/boards/we/orthosie1ev/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/weact/can485dbv1/Kconfig.sysbuild
+++ b/boards/weact/can485dbv1/Kconfig.sysbuild
@@ -8,7 +8,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/weact/esp32c3_mini/Kconfig.sysbuild
+++ b/boards/weact/esp32c3_mini/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/weact/esp32c6_mini/Kconfig.sysbuild
+++ b/boards/weact/esp32c6_mini/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/weact/esp32s3_b/Kconfig.sysbuild
+++ b/boards/weact/esp32s3_b/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/weact/esp32s3_mini/Kconfig.sysbuild
+++ b/boards/weact/esp32s3_mini/Kconfig.sysbuild
@@ -5,7 +5,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/boards/wemos/lolin32_lite/Kconfig.sysbuild
+++ b/boards/wemos/lolin32_lite/Kconfig.sysbuild
@@ -4,7 +4,3 @@
 choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
-
-choice BOOT_SIGNATURE_TYPE
-	default BOOT_SIGNATURE_TYPE_NONE
-endchoice

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1908,6 +1908,11 @@ MCUboot
   this change rejects unsigned images, so the bootloader and the application must be
   reflashed together when a device is moved to the new defaults.
 
+* The shared Espressif partition tables no longer define a ``scratch_partition``, so
+  :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_SWAP_SCRATCH` is no longer available on boards using
+  them. The other partitions keep their offsets. Projects that need it can add the partition
+  back in a board overlay.
+
 MCUmgr
 ======
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1898,6 +1898,16 @@ MCUboot
 * ``CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_WITHOUT_SCRATCH`` has been removed. Use
   :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE` instead.
 
+* Sysbuild no longer forces the MCUboot overwrite-only mode and unsigned images on Espressif
+  SoCs. Boards using them now get the generic defaults: swap using offset, which keeps the
+  previous image for a revert, and RSA-2048 signatures with the MCUboot development key.
+  Projects with their own key must set :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_KEY_FILE`,
+  and projects that relied on the previous behavior can select
+  :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY` and
+  :kconfig:option:`SB_CONFIG_BOOT_SIGNATURE_TYPE_NONE` explicitly. A bootloader built after
+  this change rejects unsigned images, so the bootloader and the application must be
+  reflashed together when a device is moved to the new defaults.
+
 MCUmgr
 ======
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1889,6 +1889,11 @@ Other notable changes
     key. The first entry is the key the application is signed with and the rest are
     verification-only public keys. See :ref:`build-signing`.
 
+  * Espressif boards no longer force overwrite-only mode and unsigned images under sysbuild.
+    They now build a swap-using-offset MCUboot with rollback and an RSA-2048 signed
+    application, and the shared Espressif partition tables no longer reserve a scratch
+    partition. See the :ref:`migration guide <migration_4.5>`.
+
 * NXP
 
   * The NXP LPC DTSI files have been reorganized from the flat

--- a/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_128M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_16M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0xfe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_2M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_32M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_4M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_64M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_amp_8M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_128M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_16M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0xfe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_2M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_32M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_4M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_64M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x0_default_8M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_128M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_16M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0xfe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_2M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_32M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_4M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_64M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_amp_8M.dtsi
@@ -64,12 +64,6 @@
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_128M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x7fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_16M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0xfe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_2M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x1b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_32M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_4M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x3b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_64M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x3fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@3fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x3fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@3fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x1000_default_8M.dtsi
@@ -52,12 +52,6 @@
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x2000_default_16M.dtsi
+++ b/dts/vendor/espressif/partitions_0x2000_default_16M.dtsi
@@ -55,12 +55,6 @@
 			reg = <0xfb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0xfe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x2000_default_32M.dtsi
+++ b/dts/vendor/espressif/partitions_0x2000_default_32M.dtsi
@@ -55,12 +55,6 @@
 			reg = <0x1fb0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@1fe0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x1fe0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@1fff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
+++ b/dts/vendor/espressif/partitions_0x2000_default_8M.dtsi
@@ -55,12 +55,6 @@
 			reg = <0x7b0000 DT_SIZE_K(192)>;
 		};
 
-		scratch_partition: partition@7e0000 {
-			compatible = "zephyr,mapped-partition";
-			label = "image-scratch";
-			reg = <0x7e0000 DT_SIZE_K(124)>;
-		};
-
 		coredump_partition: partition@7ff000 {
 			compatible = "zephyr,mapped-partition";
 			label = "coredump";

--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -32,8 +32,6 @@ if BOOTLOADER_MCUBOOT
 
 choice MCUBOOT_MODE
 	prompt "Mode of operation"
-	# Should be removed if board dts is updated
-	default MCUBOOT_MODE_SWAP_USING_MOVE if SOC_FAMILY_ESPRESSIF_ESP32
 	default MCUBOOT_MODE_SWAP_USING_OFFSET
 	help
 	  The operating mode of MCUboot (which will also be propagated to the application).

--- a/soc/espressif/Kconfig.sysbuild
+++ b/soc/espressif/Kconfig.sysbuild
@@ -1,6 +1,0 @@
-# Copyright (c) 2024 Nordic Semiconductor ASA
-# SPDX-License-Identifier: Apache-2.0
-
-choice MCUBOOT_MODE
-	default MCUBOOT_MODE_OVERWRITE_ONLY if SOC_FAMILY_ESPRESSIF_ESP32
-endchoice


### PR DESCRIPTION
Stop forcing overwrite-only and unsigned images on Espressif boards, and drop the unused scratch partition from the shared partition tables, so sysbuild builds a rollback-capable, signature-checking MCUboot like it does for other vendors. 

MCUboot part: https://github.com/mcu-tools/mcuboot/pull/2853