### PR TITLE
tests: subsys: debug: run symtab on mps2/an385

### DIFF
--- a/tests/subsys/debug/symtab/tests.yaml
+++ b/tests/subsys/debug/symtab/tests.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 common:
   platform_allow:
+    - mps2/an385
     - qemu_riscv32
     - qemu_riscv64
     - qemu_cortex_a53


### PR DESCRIPTION
`CONFIG_SYMTAB` is set by this suite alone, and its `platform_allow` lists no platform the coverage job runs, so `subsys/debug/symtab/symtab.c` is never built. The suite is plain ztest with no hardware dependency, and mps2/an385 is already one of the coverage platforms.

Verified with twister on mps2/an385: the suite passes and symtab.c gains 22 covered lines. 
