### PR TITLE
tests: drivers: clock_control: also run on 32-bit native_sim

### DIFF
--- a/tests/drivers/clock_control/fixed_clock/tests.yaml
+++ b/tests/drivers/clock_control/fixed_clock/tests.yaml
@@ -4,4 +4,5 @@ tests:
       - drivers
       - clock
     platform_allow:
+      - native_sim
       - native_sim/native/64


### PR DESCRIPTION
The suite allows `native_sim/native/64` only, but the coverage CI job runs `twister -p native_sim`, which resolves to the 32-bit target, so `drivers/clock_control/clock_control_fixed_rate.c` never reaches the coverage report.

Nothing in the suite is 64-bit specific — its whole devicetree addition is a single `fixed-clock` node in `app.overlay`. Measured with twister `--coverage` on `native_sim`: +28 covered lines, and the suite passes.
