### PR TITLE
tests: settings: nvs: add a name cache scenario

### DIFF
--- a/tests/subsys/settings/functional/nvs/tests.yaml
+++ b/tests/subsys/settings/functional/nvs/tests.yaml
@@ -50,3 +50,14 @@ tests:
     tags:
       - settings
       - nvs
+  settings.functional.nvs.name_cache:
+    extra_configs:
+      - CONFIG_SETTINGS_NVS_NAME_CACHE=y
+    platform_allow:
+      - qemu_x86
+      - native_sim
+    integration_platforms:
+      - native_sim
+    tags:
+      - settings
+      - nvs


### PR DESCRIPTION
The name cache is only enabled by `tests/subsys/settings/performance`, and there only on mps2/an385 among the coverage platforms. This scenario covers it on native_sim and qemu_x86 too, where the functional suite already saves, loads and deletes the entries the cache indexes.

Measured with twister `--coverage` on `native_sim`: +38 covered lines in `subsys/settings/src/settings_nvs.c`. The scenario passes on both platforms.
