### PR TITLE
tests: net: socket: collect packet timestamps in the ttl scenario

### DIFF
--- a/tests/net/socket/udp/tests.yaml
+++ b/tests/net/socket/udp/tests.yaml
@@ -35,6 +35,8 @@ tests:
       - CONFIG_NET_STATISTICS_USER_API=y
       - CONFIG_NET_MGMT_EVENT=y
       - CONFIG_NET_MGMT=y
+      - CONFIG_NET_PKT_TXTIME_STATS=y
+      - CONFIG_NET_PKT_RXTIME_STATS=y
   net.socket.udp.tracing:
     platform_allow:
       - native_sim


### PR DESCRIPTION
`CONFIG_NET_PKT_TXTIME_STATS` and `CONFIG_NET_PKT_RXTIME_STATS` are enabled by no test in the tree, so their accounting blocks never reach the coverage report. They sit inside functions the `net.socket.udp.ttl` scenario already drives, so only the two Kconfigs were missing.

Measured with twister `--coverage` on `native_sim`: +18 covered lines, all of the 18 it adds. The scenario passes.
