### PR TITLE
drivers: usb: uhc_dwc2: guard optional quirk data

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -2248,8 +2248,8 @@ static DEVICE_API(uhc, uhc_dwc2_api) = {
 	static const struct uhc_dwc2_config uhc_dwc2_config_##n = {		\
 		UHC_DWC2_DT_INST_REG_ADDR(n),					\
 		.quirks = UHC_DWC2_VENDOR_QUIRK_GET(n),				\
-		.quirk_data = &uhc_dwc2_quirk_data_##n,				\
-		.quirk_config = &uhc_dwc2_quirk_config_##n,			\
+		.quirk_data = UHC_DWC2_VENDOR_QUIRK_DATA_GET(n),		\
+		.quirk_config = UHC_DWC2_VENDOR_QUIRK_CONFIG_GET(n),		\
 		.stack = uhc_dwc2_stack_##n,					\
 		.stack_size = K_THREAD_STACK_SIZEOF(uhc_dwc2_stack_##n),	\
 		.irq_enable_func = uhc_dwc2_irq_enable_func_##n,		\

--- a/drivers/usb/uhc/uhc_dwc2.h
+++ b/drivers/usb/uhc/uhc_dwc2.h
@@ -70,9 +70,22 @@ struct uhc_dwc2_config {
 #include "uhc_dwc2_nrf_usbhs_nrf54l.h"
 #endif
 
+#define UHC_DWC2_HAS_VENDOR_QUIRK(n)						\
+	DT_NODE_VENDOR_HAS_IDX(DT_DRV_INST(n), 1)
+
 #define UHC_DWC2_VENDOR_QUIRK_GET(n)						\
-	COND_CODE_1(DT_NODE_VENDOR_HAS_IDX(DT_DRV_INST(n), 1),			\
+	COND_CODE_1(UHC_DWC2_HAS_VENDOR_QUIRK(n),				\
 			(&uhc_dwc2_vendor_quirks_##n),				\
+			(NULL))
+
+#define UHC_DWC2_VENDOR_QUIRK_DATA_GET(n)					\
+	COND_CODE_1(UHC_DWC2_HAS_VENDOR_QUIRK(n),				\
+			(&uhc_dwc2_quirk_data_##n),				\
+			(NULL))
+
+#define UHC_DWC2_VENDOR_QUIRK_CONFIG_GET(n)					\
+	COND_CODE_1(UHC_DWC2_HAS_VENDOR_QUIRK(n),				\
+			(&uhc_dwc2_quirk_config_##n),				\
 			(NULL))
 
 #define DWC2_QUIRK_FUNC_DEFINE(fname)						\


### PR DESCRIPTION
The DWC2 UHC driver allows vendor quirks to be absent, but `quirk_data` and `quirk_config` were still referenced unconditionally.

Guard these pointers with the same condition used for the vendor quirk table. Generic `snps,dwc2` instances now use `NULL`, while vendor-specific instances keep their existing quirk data and configuration.

Add a build-only regression test for a generic DWC2 instance without vendor quirks.
