### PR TITLE
soc: espressif: place flash rodata after text on esp32c6 and esp32h2

### DIFF
--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -999,6 +999,16 @@ SECTIONS
     . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(ROMABLE_REGION)
 
+  /* Move drom0 after the .text region in the shared I/D cache window.
+   * irom0_0_seg and drom0_0_seg share the same origin (unified cache),
+   * so advance the drom counter past the aligned IROM span; otherwise
+   * .flash.rodata would land in the same flash mapping as .text.
+   */
+  .flash_rodata_dummy (NOLOAD) :
+  {
+    . += ALIGN(_instruction_reserved_end - _instruction_reserved_start, CACHE_ALIGN);
+  } GROUP_LINK_IN(RODATA_REGION)
+
   /* Symbols used during the application memory mapping */
   _image_drom_start = LOADADDR(.flash.rodata);
   _image_drom_size = _image_rodata_end -  _image_rodata_start;

--- a/soc/espressif/esp32c6/memory.h
+++ b/soc/espressif/esp32c6/memory.h
@@ -74,9 +74,18 @@
 #define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 #define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
-/* Cached memory */
+/* Cached memory - ESP32-C6 uses unified I/D address space
+ * From HAL ext_mem_defs.h: SOC_IRAM0_CACHE_ADDRESS_LOW = 0x42000000
+ */
 #define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE
 #define IROM_SEG_ORG 0x42000000
 #define IROM_SEG_LEN FLASH_SIZE
-#define DROM_SEG_ORG 0x42800000
+/* DROM shares the unified-cache linear address space with IROM. Placing
+ * drom0_0_seg at the same origin lets the linker emit .flash.rodata
+ * immediately after .text, so the linear range the memory mapper
+ * reserves for the image (irom_len + drom_len) matches the virtual
+ * range the image actually occupies and later mappings cannot land on
+ * it.
+ */
+#define DROM_SEG_ORG IROM_SEG_ORG
 #define DROM_SEG_LEN FLASH_SIZE

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -845,6 +845,16 @@ SECTIONS
     . = ALIGN(CACHE_ALIGN);
   } GROUP_LINK_IN(ROMABLE_REGION)
 
+  /* Move drom0 after the .text region in the shared I/D cache window.
+   * irom0_0_seg and drom0_0_seg share the same origin (unified cache),
+   * so advance the drom counter past the aligned IROM span; otherwise
+   * .flash.rodata would land in the same flash mapping as .text.
+   */
+  .flash_rodata_dummy (NOLOAD) :
+  {
+    . += ALIGN(_instruction_reserved_end - _instruction_reserved_start, CACHE_ALIGN);
+  } GROUP_LINK_IN(RODATA_REGION)
+
   /* Symbols used during the application memory mapping */
   _image_drom_start = LOADADDR(.flash.rodata);
   _image_drom_size = _image_rodata_end -  _image_rodata_start;

--- a/soc/espressif/esp32h2/memory.h
+++ b/soc/espressif/esp32h2/memory.h
@@ -70,9 +70,18 @@
 #define FLASH_SIZE         DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
 #define FLASH_BASE_ADDRESS DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 
-/* Cached memory */
+/* Cached memory - ESP32-H2 uses unified I/D address space
+ * From HAL ext_mem_defs.h: SOC_IRAM0_CACHE_ADDRESS_LOW = 0x42000000
+ */
 #define CACHE_ALIGN  CONFIG_MMU_PAGE_SIZE
 #define IROM_SEG_ORG 0x42000000
 #define IROM_SEG_LEN FLASH_SIZE
-#define DROM_SEG_ORG 0x42800000
+/* DROM shares the unified-cache linear address space with IROM. Placing
+ * drom0_0_seg at the same origin lets the linker emit .flash.rodata
+ * immediately after .text, so the linear range the memory mapper
+ * reserves for the image (irom_len + drom_len) matches the virtual
+ * range the image actually occupies and later mappings cannot land on
+ * it.
+ */
+#define DROM_SEG_ORG IROM_SEG_ORG
 #define DROM_SEG_LEN FLASH_SIZE


### PR DESCRIPTION
On ESP32-C6 and ESP32-H2 the drom0 segment origin was set to 0x42800000 while text starts at 0x42000000, although both SoCs map instructions and data through a single unified flash cache window. The memory mapper reserves irom plus drom bytes contiguously from the window start, so the gap between the two mappings was never accounted for and a later mapping could land on rodata.

