### PR TITLE
usb: usb_c: transitions to unattached.snk at tc_init on a dead battery port

### DIFF
--- a/drivers/usb_c/tcpc/ucpd_numaker.c
+++ b/drivers/usb_c/tcpc/ucpd_numaker.c
@@ -2310,6 +2310,18 @@ int numaker_tcpc_vbus_enable(const struct device *dev, bool enable)
 
 /* End of "*_tcpc_vbus_*" functions */
 
+/**
+ * @brief Report whether this port applies the Dead Battery resistor
+ *
+ * @retval 0 on success
+ */
+static int numaker_tcpc_dead_battery_enabled(const struct device *dev, bool *enabled)
+{
+	*enabled = numaker_utcpd_deadbattery_query_enable(dev);
+
+	return 0;
+}
+
 static DEVICE_API(tcpc, numaker_tcpc_driver_api) = {
 	.init = numaker_tcpc_init_recycle,
 	.get_cc = numaker_tcpc_get_cc,
@@ -2331,6 +2343,7 @@ static DEVICE_API(tcpc, numaker_tcpc_driver_api) = {
 	.sop_prime_enable = numaker_tcpc_sop_prime_enable,
 	.set_bist_test_mode = numaker_tcpc_set_bist_test_mode,
 	.set_alert_handler_cb = numaker_tcpc_set_alert_handler_cb,
+	.dead_battery_enabled = numaker_tcpc_dead_battery_enabled,
 };
 
 /* Same as RESET_DT_SPEC_INST_GET_BY_IDX, except by name */

--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -354,6 +354,24 @@ static int ucpd_get_rp_value(const struct device *dev, enum tc_rp_value *rp)
 }
 
 /**
+ * @brief Report whether this port applies the Dead Battery resistors
+ *
+ * @retval 0 on success
+ */
+static int ucpd_dead_battery_enabled(const struct device *dev, bool *enabled)
+{
+#ifdef CONFIG_SOC_SERIES_STM32G0X
+	const struct tcpc_config *const config = dev->config;
+
+	*enabled = (stm32_reg_read(&config->ucpd_port->CR) & UCPD_CR_DBATTEN) != 0;
+#else
+	*enabled = LL_PWR_IsEnabledUCPDDeadBattery();
+#endif
+
+	return 0;
+}
+
+/**
  * @brief Enable or disable Dead Battery resistors
  */
 static void dead_battery(const struct device *dev, bool en)
@@ -1397,6 +1415,7 @@ static DEVICE_API(tcpc, driver_api) = {
 	.dump_std_reg = ucpd_dump_std_reg,
 	.set_bist_test_mode = ucpd_set_bist_test_mode,
 	.sop_prime_enable = ucpd_sop_prime_enable,
+	.dead_battery_enabled = ucpd_dead_battery_enabled,
 };
 
 #define DEV_INST_INIT(n) dev_inst[n] = DEVICE_DT_INST_GET(n);

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -371,6 +371,13 @@ typedef int (*tcpc_api_set_alert_handler_cb_t)(const struct device *dev,
 					       tcpc_alert_handler_cb_t handler, void *data);
 
 /**
+ * @brief Callback API to query the dead battery configuration of the TCPC.
+ *
+ * See tcpc_dead_battery_enabled() for argument description.
+ */
+typedef int (*tcpc_api_dead_battery_enabled_t)(const struct device *dev, bool *enabled);
+
+/**
  * @driver_ops{USB Type-C Port Controller}
  */
 __subsystem struct tcpc_driver_api {
@@ -430,6 +437,8 @@ __subsystem struct tcpc_driver_api {
 	tcpc_api_set_bist_test_mode_t set_bist_test_mode;
 	/** @driver_ops_mandatory @copybrief tcpc_set_alert_handler_cb */
 	tcpc_api_set_alert_handler_cb_t set_alert_handler_cb;
+	/** @driver_ops_optional @copybrief tcpc_dead_battery_enabled */
+	tcpc_api_dead_battery_enabled_t dead_battery_enabled;
 };
 
 /** @} */
@@ -1082,6 +1091,27 @@ static inline int tcpc_sop_prime_enable(const struct device *dev, bool enable)
 	}
 
 	return api->sop_prime_enable(dev, enable);
+}
+
+/**
+ * @brief Queries whether the TCPC applies the USB-C dead battery terminations
+ *
+ * @param dev Runtime device structure
+ * @param enabled True if the TCPC applies the dead battery terminations,
+ *                false otherwise.
+ *
+ * @retval 0 on success
+ * @retval -ENOSYS if not implemented
+ */
+static inline int tcpc_dead_battery_enabled(const struct device *dev, bool *enabled)
+{
+	const struct tcpc_driver_api *api = DEVICE_API_GET(tcpc, dev);
+
+	if (api->dead_battery_enabled == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->dead_battery_enabled(dev, enabled);
 }
 
 /**

--- a/subsys/usb/usb_c/usbc_tc_common.c
+++ b/subsys/usb/usb_c/usbc_tc_common.c
@@ -176,8 +176,29 @@ static int tc_init(const struct device *dev)
 #endif
 
 	/* Initialize the state machine */
+#ifdef CONFIG_USBC_CSM_SUPPORTS_SINK
+	/* Check if dead battery support is enabled */
+	bool dead_battery = false;
+
+	ret = tcpc_dead_battery_enabled(tcpc, &dead_battery);
+	if (ret != 0 && ret != -ENOSYS) {
+		LOG_ERR("Couldn't get the dead battery configuration: %d", ret);
+		return ret;
+	}
+
+	if (dead_battery) {
+		/*
+		 * Transition directly to UNATTACHED.SNK state if dead battery support
+		 * is enabled to prevent source vbus drop due to TC_CC_OPEN_SUPER_STATE in
+		 * TC_DISABLED_STATE and TC_ERROR_RECOVERY_STATE states.
+		 */
+		tc_set_state(dev, TC_UNATTACHED_SNK_STATE);
+		return 0;
+	}
+#endif
 	/*
-	 * Transition to Disabled state to ensure port is in a known disabled state.
+	 * Transition to Disabled state to ensure port is in a known disabled
+	 * state.
 	 */
 	tc_set_state(dev, TC_DISABLED_STATE);
 


### PR DESCRIPTION
TCPC drivers implement a dead-battery mechanism, enabled per board with a `dead-battery` property in the devicetree overlay. It applies Rd to the CC lines so upon connection a USB-C Source detects the Sink and turns on VBUS, which is what powers the board.

However, there is an issue in the `usb_c` subsystem that breaks this feature.

`tc_init()` unconditionally sets the Type-C state to `TC_DISABLED_STATE` and then `TC_ERROR_RECOVERY_STATE`. Both descend from `TC_CC_OPEN_SUPER_STATE`, whose entry action opens the CC lines. So once the board boots from VBUS and runs `tc_init()`, the CC lines go to open state. To the Source that will look like a detach, so it removes VBUS and the board powers down.

## Changes

**`drivers: usb_c: tcpc: add dead_battery_enabled operation`**

Add an optional TCPC operation reporting whether a port applies the USB-C dead battery resistors to its CC lines, and implement it for `ucpd_stm32` and `ucpd_numaker`.

**`usb: usb_c: transitions to unattached.snk at tc_init on a dead battery port`**

Transition directly to `TC_UNATTACHED_SNK_STATE` instead when the port's Type-C Port Controller reports that it applies the dead battery terminations, so that the Rd super state takes them over without the CC lines ever being opened. A controller that reports no dead battery resistors, and any build that cannot act as a Sink, keeps the previous behaviour.

## Testing

Verified on hardware: with these changes I am able to boot from USB-C on the `nucleo_h563zi` with `JP2` set to `USB USER`.

Build tested on every board with a `usb_c` sample overlay:

| Sample | Boards |
| --- | --- |
| sink | `nucleo_h563zi`, `stm32g081b_eval`, `b_g474e_dpow1`, `weact_stm32g431_core`, `numaker_m2l31ki` |
| drp | `stm32g081b_eval` |
| source | `stm32g081b_eval` |

`tests/drivers/build_all/usb` was also built in both variants, which covers the `fusb307`, `rt1715` and `ps8xxx` controllers that do not implement the new operation and so take the `-ENOSYS` path.

After fixing this, I am now able to boot from USB-C on the `nucleo_h563zi` with `JP2` set to `USB USER`.

### Before:

```
[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[0[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:00:00�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:0�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:0�[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:00[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
```

<img width="723" height="480" alt="Image" src="https://github.com/user-attachments/assets/fa0cae6c-7e29-4fce-928b-67827c357b41" />

<img width="971" height="877" alt="Image" src="https://github.com/user-attachments/assets/fb26ece6-7816-41b1-8a85-c30b640fce04" />

### After:

```
[00:00:00.000,000] <inf> usbc_stack: Startup
[00:00:00.000,000] <inf> usbc_stack: PE_SUSPEND
[00:00:00.000,000] <inf> usbc_stack: PRL_HR_SUSPEND
[00:00:00.000,000] <inf> usbc_stack: PRL_TX_SUSPEND
*** Booting Zephyr OS build v4.4.0-14048-g7be1c324ffd0 ***
[00:00:00.000,000] <inf> usbc_stack: Unattached.SNK
[00:00:00.005,000] <inf> usbc_stack: AttachWait.SNK
[00:00:00.209,000] <inf> usbc_stack: Attached.SNK
[00:00:00.209,000] <inf> usbc_stack: PE_SNK_Startup
[00:00:00.209,000] <inf> usbc_stack: PRL_INIT
[00:00:00.209,000] <inf> usbc_stack: PRL_HR_Wait_for_Request
[00:00:00.209,000] <inf> usbc_stack: PRL_Tx_PHY_Layer_Reset
[00:00:00.209,000] <inf> usbc_stack: PRL_Tx_Wait_for_Message_Request
[00:00:00.209,000] <inf> usbc_stack: PE_SNK_Discovery
[00:00:00.209,000] <inf> usbc_stack: PE_SNK_Wait_For_Capabilities
[00:00:00.230,000] <inf> main: PWR 3A0
[00:00:00.264,000] <inf> usbc_stack: RECV 0x41a1/4[Source_Capabilities]
[00:00:00.265,000] <inf> usbc_stack:    [0]2F01912C 
[00:00:00.265,000] <inf> usbc_stack:    [1]0002D12C 
[00:00:00.265,000] <inf> usbc_stack:    [2]0004B12C 
[00:00:00.265,000] <inf> usbc_stack:    [3]000641F4 
[00:00:00.265,000] <inf> usbc_stack: PE_SNK_Evaluate_Capability
[00:00:00.265,000] <inf> usbc_stack: PE_SNK_Select_Capability
[00:00:00.265,000] <inf> usbc_stack: SEND 0x1082/1[Request]
[00:00:00.265,000] <inf> usbc_stack:    [0]1100280A 
[00:00:00.266,000] <inf> usbc_stack: PRL_Tx_Wait_for_PHY_response
[00:00:00.266,000] <inf> usbc_stack: PRL_Tx_Wait_for_Message_Request
[00:00:00.273,000] <inf> usbc_stack: RECV 0x03a3/0[Accept]
[00:00:00.273,000] <inf> usbc_stack: PE_SNK_Transition_Sink
[00:00:00.315,000] <inf> usbc_stack: RECV 0x05a6/0[PS_RDY]
[00:00:00.315,000] <inf> usbc_stack: PE_SNK_Ready
[00:00:00.535,000] <inf> usbc_stack: RECV 0x07a9/0[DR_Swap]
[00:00:00.535,000] <inf> usbc_stack: SEND 0x0284/0[Reject]
[00:00:00.536,000] <inf> usbc_stack: PRL_Tx_Wait_for_PHY_response
[00:00:00.536,000] <inf> usbc_stack: PRL_Tx_Wait_for_Message_Request
[00:00:00.542,000] <inf> usbc_stack: PE_SNK_Ready
[00:00:00.545,000] <inf> usbc_stack: RECV 0x19af/1[Vendor_Defined]
[00:00:00.545,000] <inf> usbc_stack:    [0]FF00A001 
[00:00:00.545,000] <inf> usbc_stack: PE_Not_Supported
[00:00:00.545,000] <inf> usbc_stack: SEND 0x0490/0[Not_Supported]
[00:00:00.547,000] <inf> usbc_stack: PRL_Tx_Wait_for_PHY_response
[00:00:00.547,000] <inf> usbc_stack: PRL_Tx_Wait_for_Message_Request
[00:00:00.552,000] <inf> usbc_stack: PE_SNK_Ready
```

<img width="778" height="472" alt="Image" src="https://github.com/user-attachments/assets/97030d88-1019-4b00-9cd8-7d958f061e5e" />

<img width="986" height="833" alt="Image" src="https://github.com/user-attachments/assets/098697ca-a684-4f75-84e0-2a1ea384b14a" />

Fixes zephyrproject-rtos/zephyr#113162

This is the second of the two problems described in the issue. The first, the UCPD1 peripheral clock, was fixed by zephyrproject-rtos/zephyr#114521.