### PR TITLE
drivers: watchdog: sam0: protect against feed during closed window

### DIFF
--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -126,6 +126,7 @@ static int wdt_sam0_setup(const struct device *dev, uint8_t options)
 	}
 
 	/* Enable watchdog */
+	data->window_open = false;
 	wdt_sam0_set_enable(1);
 	wdt_sam0_wait_synchronization();
 
@@ -226,6 +227,7 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 	 */
 	data->cb = cfg->callback;
 	if (data->window_mode) {
+		WDT_REGS->INTFLAG.reg = WDT_INTFLAG_EW;
 		WDT_REGS->INTENSET.reg = WDT_INTENSET_EW;
 	} else if (data->cb) {
 		WDT_REGS->INTENSET.reg = WDT_INTENSET_EW;

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -191,6 +191,14 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 		WDT_REGS->CTRL.bit.WEN = 1;
 #endif
 		wdt_sam0_wait_synchronization();
+
+		/* EWOFFSET is ignored in window mode per datasheet 23.6.8.2:
+		 * the EW fires at the start of the open window regardless of
+		 * the offset value. Clear it to be defensive in case the
+		 * register was left over from a previous normal-mode config.
+		 */
+		WDT_REGS->EWCTRL.bit.EWOFFSET = 0;
+		wdt_sam0_wait_synchronization();
 	} else {
 		/* Normal mode */
 		data->window_mode = false;

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(wdt_sam0);
 struct wdt_sam0_dev_data {
 	wdt_callback_t cb;
 	bool timeout_valid;
+	bool window_mode;
+	bool window_open;
 };
 
 static struct wdt_sam0_dev_data wdt_sam0_data = { 0 };
@@ -89,6 +91,10 @@ static void wdt_sam0_isr(const struct device *dev)
 	struct wdt_sam0_dev_data *data = dev->data;
 
 	WDT_REGS->INTFLAG.reg = WDT_INTFLAG_EW;
+
+	if (data->window_mode) {
+		data->window_open = true;
+	}
 
 	if (data->cb != NULL) {
 		data->cb(dev, 0);
@@ -168,6 +174,8 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 
 	if (cfg->window.min) {
 		/* Window mode */
+		data->window_mode = true;
+		data->window_open = false;
 		window = wdt_sam0_timeout_to_wdt_period(cfg->window.min);
 		if (window > WDT_CONFIG_PER_8K_Val) {
 			LOG_ERR("Lower limit timeout out of range");
@@ -185,6 +193,7 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 		wdt_sam0_wait_synchronization();
 	} else {
 		/* Normal mode */
+		data->window_mode = false;
 		if (cfg->callback) {
 			if (per == WDT_CONFIG_PER_8_Val) {
 				/* Ensure we have time for the early warning */
@@ -204,9 +213,13 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 	WDT_REGS->CONFIG.reg = WDT_CONFIG_WINDOW(window) | WDT_CONFIG_PER(per);
 	wdt_sam0_wait_synchronization();
 
-	/* Only enable IRQ if a callback was provided */
+	/* Enable IRQ: always in window mode (to track window open),
+	 * otherwise only if a callback was provided.
+	 */
 	data->cb = cfg->callback;
-	if (data->cb) {
+	if (data->window_mode) {
+		WDT_REGS->INTENSET.reg = WDT_INTENSET_EW;
+	} else if (data->cb) {
 		WDT_REGS->INTENSET.reg = WDT_INTENSET_EW;
 	} else {
 		WDT_REGS->INTENCLR.reg = WDT_INTENCLR_EW;
@@ -233,11 +246,20 @@ static int wdt_sam0_feed(const struct device *dev, int channel_id)
 		return -EINVAL;
 	}
 
+	if (data->window_mode && !data->window_open) {
+		LOG_WRN("Feed rejected: closed window period has not elapsed");
+		return -EAGAIN;
+	}
+
 	if (WDT_SYNCBUSY) {
 		return -EAGAIN;
 	}
 
 	WDT_REGS->CLEAR.reg = WDT_CLEAR_CLEAR_KEY_Val;
+
+	if (data->window_mode) {
+		data->window_open = false;
+	}
 
 	return 0;
 }

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -240,7 +240,8 @@ static inline int wdt_install_timeout(const struct device *dev,
  * @return 0 on success, negative errno value on failure.
  * @retval -EAGAIN Completing the feed operation would stall the caller, for
  * example due to an in-progress watchdog operation such as a previous
- * wdt_feed() call.
+ * wdt_feed() call, or (in window mode) the closed window period has
+ * not yet elapsed. Retry later.
  * @retval -EINVAL There is no installed timeout for supplied channel.
  */
 __syscall int wdt_feed(const struct device *dev, int channel_id);

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -240,8 +240,7 @@ static inline int wdt_install_timeout(const struct device *dev,
  * @return 0 on success, negative errno value on failure.
  * @retval -EAGAIN Completing the feed operation would stall the caller, for
  * example due to an in-progress watchdog operation such as a previous
- * wdt_feed() call, or (in window mode) the closed window period has
- * not yet elapsed. Retry later.
+ * wdt_feed() call.
  * @retval -EINVAL There is no installed timeout for supplied channel.
  */
 __syscall int wdt_feed(const struct device *dev, int channel_id);


### PR DESCRIPTION
In window mode, writing 0xA5 to the WDT CLEAR register during the closed window period causes an immediate hardware reset. The driver previously made no attempt to detect the current window phase and fed blindly, exposing callers to a hard reset if wdt_feed() was called before the Early Warning interrupt fired.

The SAMC21/SAMD21 WDT has no hardware status register for the current window phase, so the only signal is the Early Warning interrupt, which fires at the start of the open window in window mode.

Fix by tracking the window phase in the ISR:
- Add window_mode and window_open flags to dev_data
- The ISR sets window_open = true when the EW fires (window opens)
- wdt_feed() returns -EAGAIN if the window is closed, allowing the caller to retry without crashing the system
- wdt_feed() clears window_open after a successful feed
- Always enable the EW interrupt in window mode even when the user does not provide a callback, since the driver needs it to track the window state

Also update the wdt_feed() documentation in watchdog.h to clarify that -EAGAIN may also indicate a closed window in window mode.

Tested on SAMC21N Xplained Pro (samc21n_xpro):
- Feed at 5s with 4s-8s window: EW fires at ~4s, feed succeeds at 5s
- Feed at 2s with 4s-8s window: feed rejected with -EAGAIN, no reset
- Feed stopped: early warning fires, then system resets at 8s (normal)

Assisted-by: opencode:deepseek-v4-pro