### PR TITLE
drivers: mspi: add MSPI_MEMMAP transfer mode

### DIFF
--- a/doc/hardware/peripherals/mspi.rst
+++ b/doc/hardware/peripherals/mspi.rst
@@ -80,6 +80,14 @@ MSPI bus inside the device driver initialization function:
 
       * :c:func:`mspi_memmap_config` for memory mapped access (e.g. :term:`XIP`)
 
+        Once memory mapping is enabled, a device driver may ask for a transfer
+        to be serviced through the mapped region by setting
+        ``xfer_mode`` to ``MSPI_MEMMAP``. This only applies to packets that
+        access the memory array of the peripheral; command and register
+        accesses stay on ``MSPI_PIO`` or ``MSPI_DMA``. Controllers that do not
+        implement it return ``-ENOTSUP``, so the device driver should be
+        prepared to repeat the transfer in one of the other modes.
+
       * :c:func:`mspi_scramble_config` for scrambling feature
 
       * :c:func:`mspi_timing_config` for platform specific timing setup.

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -798,6 +798,17 @@ MSPI
     -> ``MSPI_MEMMAP_CFG_STRUCT_DECLARE``/``MSPI_MEMMAP_BASE_ADDR_DECLARE``/``MSPI_MEMMAP_BASE_ADDR_INIT``
   * devicetree property ``xip-config`` -> ``memmap-config`` on MSPI device nodes
 
+* ``MSPI_MEMMAP`` has been added to ``enum mspi_xfer_mode``. Out-of-tree MSPI
+  controller drivers that dispatch on ``xfer_mode`` must reject it with
+  ``-ENOTSUP`` unless they service the transfer through the memory mapped
+  region. Drivers that treat anything other than ``MSPI_DMA`` as
+  ``MSPI_PIO`` would otherwise silently run the transfer in the wrong mode.
+  :c:func:`flash_write` on ``jedec,nor`` now asks for ``MSPI_MEMMAP`` on page
+  programs when memory mapping is enabled with
+  ``MSPI_MEMMAP_READ_WRITE`` permission, and falls back to the configured
+  transfer mode for the rest of the run time if the controller reports
+  ``-ENOTSUP``.
+
 Nordic
 ======
 

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -473,6 +473,26 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 	return 0;
 }
 
+#if defined(CONFIG_MSPI_MEMMAP)
+/* Page programs can be serviced through the memory mapped region when the
+ * controller has memory mapping enabled for this chip and writes are permitted
+ * there. This is optional, so a controller that cannot do it reports -ENOTSUP
+ * and the driver keeps using the regular data transfer mode afterwards.
+ */
+static enum mspi_xfer_mode page_program_xfer_mode(const struct device *dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	if (dev_data->no_memmap_write || !dev_config->memmap_cfg.enable ||
+	    dev_config->memmap_cfg.permission != MSPI_MEMMAP_READ_WRITE) {
+		return dev_config->data_xfer_mode;
+	}
+
+	return MSPI_MEMMAP;
+}
+#endif /* CONFIG_MSPI_MEMMAP */
+
 static int api_write(const struct device *dev, off_t addr, const void *src,
 		     size_t size)
 {
@@ -500,15 +520,36 @@ static int api_write(const struct device *dev, off_t addr, const void *src,
 		uint16_t page_offset = (uint16_t)(addr % page_size);
 		uint16_t page_left = page_size - page_offset;
 		uint16_t to_write = (uint16_t)MIN(size, page_left);
+		enum mspi_xfer_mode xfer_mode = dev_config->data_xfer_mode;
+
+#if defined(CONFIG_MSPI_MEMMAP)
+		xfer_mode = page_program_xfer_mode(dev);
+#endif
 
 		if (cmd_wren(dev) < 0) {
 			break;
 		}
 
-		set_up_xfer_with_addr(dev, MSPI_TX, addr, dev_config->data_xfer_mode);
+		set_up_xfer_with_addr(dev, MSPI_TX, addr, xfer_mode);
 		dev_data->packet.data_buf  = (uint8_t *)src;
 		dev_data->packet.num_bytes = to_write;
 		rc = perform_xfer(dev, dev_data->cmd_info.pp_cmd);
+
+#if defined(CONFIG_MSPI_MEMMAP)
+		if ((rc == -ENOTSUP) && (xfer_mode == MSPI_MEMMAP)) {
+			/* The controller rejected the request before driving the
+			 * bus, so the write enable latch is still set and this page
+			 * can be retried right away.
+			 */
+			dev_data->no_memmap_write = true;
+
+			set_up_xfer_with_addr(dev, MSPI_TX, addr, dev_config->data_xfer_mode);
+			dev_data->packet.data_buf = (uint8_t *)src;
+			dev_data->packet.num_bytes = to_write;
+			rc = perform_xfer(dev, dev_data->cmd_info.pp_cmd);
+		}
+#endif
+
 		if (rc < 0) {
 			LOG_ERR("Page program xfer failed: %d", rc);
 			break;

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -134,6 +134,9 @@ struct flash_mspi_nor_data {
 	uint32_t enter_dpd_cycle;
 #endif
 	bool chip_initialized;
+#if defined(CONFIG_MSPI_MEMMAP)
+	bool no_memmap_write;
+#endif
 	const struct mspi_dev_cfg *read_cfg;
 	struct mspi_dev_cfg mspi_dev_read_cfg;
 	const struct mspi_dev_cfg *write_cfg;

--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -1406,6 +1406,8 @@ static int mspi_ambiq_transceive(const struct device      *controller,
 		return mspi_pio_transceive(controller, xfer, cb, cb_ctx);
 	} else if (xfer->xfer_mode == MSPI_DMA) {
 		return mspi_dma_transceive(controller, xfer, cb, cb_ctx);
+	} else if (xfer->xfer_mode == MSPI_MEMMAP) {
+		return -ENOTSUP;
 	} else {
 		return -EIO;
 	}

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -1824,6 +1824,8 @@ static int mspi_ambiq_transceive(const struct device      *controller,
 		return mspi_pio_transceive(controller, xfer, cb, cb_ctx);
 	} else if (xfer->xfer_mode == MSPI_DMA) {
 		return mspi_dma_transceive(controller, xfer, cb, cb_ctx);
+	} else if (xfer->xfer_mode == MSPI_MEMMAP) {
+		return -ENOTSUP;
 	} else {
 		return -EIO;
 	}

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1726,6 +1726,11 @@ static int api_transceive(const struct device *dev,
 		return -EINVAL;
 	}
 
+	if (req->xfer_mode == MSPI_MEMMAP) {
+		LOG_ERR("Memory mapped transfers are not supported");
+		return -ENOTSUP;
+	}
+
 	if (req->async) {
 		if (!IS_ENABLED(CONFIG_MULTITHREADING)) {
 			LOG_ERR("Asynchronous transfers require multithreading");

--- a/drivers/mspi/mspi_emul.c
+++ b/drivers/mspi/mspi_emul.c
@@ -313,7 +313,12 @@ static inline int mspi_dev_cfg_check_save(const struct device *controller,
  */
 static inline int mspi_xfer_check(const struct mspi_xfer *xfer)
 {
-	if (xfer->xfer_mode > MSPI_DMA) {
+	if (xfer->xfer_mode == MSPI_MEMMAP) {
+		LOG_ERR("%u, MSPI_MEMMAP not supported.", __LINE__);
+		return -ENOTSUP;
+	}
+
+	if (xfer->xfer_mode > MSPI_MEMMAP) {
 		LOG_ERR("%u, Invalid xfer xfer_mode.", __LINE__);
 		return -EINVAL;
 	}

--- a/drivers/mspi/mspi_mchp_xec_qmspi.c
+++ b/drivers/mspi/mspi_mchp_xec_qmspi.c
@@ -1536,6 +1536,11 @@ static int api_mspi_mchp_xec_qmspi_tc(const struct device *ctrl, const struct ms
 		return -ENOTSUP;
 	}
 
+	if (req->xfer_mode == MSPI_MEMMAP) {
+		LOG_ERR("Memory mapped transfers are not supported");
+		return -ENOTSUP;
+	}
+
 	if (req->num_packet == 0) {
 		return 0; /* nothing to do */
 	}

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -977,6 +977,11 @@ static int mspi_stm32_ospi_transceive(const struct device *controller,
 		return -ESTALE;
 	}
 
+	if (xfer->xfer_mode == MSPI_MEMMAP) {
+		LOG_ERR("transceive : memory mapped transfers are not supported");
+		return -ENOTSUP;
+	}
+
 	/* Need to map the xfer to the data context */
 	dev_data->ctx.xfer = *xfer;
 

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -1137,6 +1137,9 @@ static int mspi_stm32_qspi_transceive(const struct device *controller,
 		LOG_ERR("DMA mode not enabled (CONFIG_MSPI_DMA not set)");
 		return -ENOTSUP;
 #endif
+	case MSPI_MEMMAP:
+		LOG_ERR("Memory mapped transfers are not supported");
+		return -ENOTSUP;
 	default:
 		LOG_ERR("Invalid transfer mode: %d", xfer->xfer_mode);
 		return -EINVAL;

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1744,6 +1744,11 @@ static int mspi_stm32_xspi_transceive(const struct device *controller,
 		return -ESTALE;
 	}
 
+	if (xfer->xfer_mode == MSPI_MEMMAP) {
+		LOG_ERR("transceive : memory mapped transfers are not supported");
+		return -ENOTSUP;
+	}
+
 	/* Need to map the xfer to the data context */
 	dev_data->ctx.xfer = *xfer;
 

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -148,8 +148,20 @@ enum mspi_bus_event_cb_mask {
  * @brief MSPI transfer modes
  */
 enum mspi_xfer_mode {
+	/** @brief The controller moves the data with programmed IO */
 	MSPI_PIO,
+	/** @brief The controller moves the data with a DMA engine */
 	MSPI_DMA,
+	/** @brief The controller services the packets through the memory
+	 * mapped region set up with mspi_memmap_config().
+	 *
+	 * Only valid for packets that access the memory array of the
+	 * peripheral, and only once memory mapping has been enabled for
+	 * that peripheral. Controllers that cannot service the packets
+	 * this way return -ENOTSUP without touching the bus, so that the
+	 * requester can fall back to MSPI_PIO or MSPI_DMA.
+	 */
+	MSPI_MEMMAP,
 };
 
 /**
@@ -686,12 +698,17 @@ static inline int z_impl_mspi_get_channel_status(const struct device *controller
  * if the callback had been registered. Or not to trigger any callback at all
  * with MSPI_BUS_NO_CB even if the callbacks are already registered.
  *
+ * When @see mspi_xfer requests MSPI_MEMMAP, the packets are to be serviced
+ * through the memory mapped region set up with mspi_memmap_config(). This is
+ * an optional capability, so the requester should be prepared to repeat the
+ * transfer with MSPI_PIO or MSPI_DMA when -ENOTSUP is returned.
+ *
  * @param controller Pointer to the device structure for the driver instance.
  * @param dev_id Pointer to the device ID structure from a device.
  * @param req Content of the request and request specific settings.
  *
  * @retval 0 If successful.
- * @retval -ENOTSUP
+ * @retval -ENOTSUP requested transfer mode not supported by the controller.
  * @retval -EIO General input / output error, failed to send over the bus.
  */
 __syscall int mspi_transceive(const struct device *controller,


### PR DESCRIPTION
Fixes #111038

`flash_mspi_nor` sends page programs and erases both as `MSPI_TX`, so a controller that can write through its memory mapped region has no way to tell them apart short of looking at `packet->cmd`.

#111038 suggested `MSPI_RD`/`MSPI_WR` on `enum mspi_xfer_direction`
#113517 tried an advisory packet flag. RD/WR isn't a direction, and a flag leaves the controller guessing from packet contents with no way to tell the requester which path it took.

So instead, add `MSPI_MEMMAP` to `enum mspi_xfer_mode`. The transfer mode is already the per-transfer transport choice and the requester picks it, so `api_write()` asks for it and `api_erase()` doesn't. Direction stays binary, `mspi_xfer_packet` is untouched, and the value is appended so `MSPI_PIO` and `MSPI_DMA` keep theirs.

No in-tree controller implements it yet, so they all return `-ENOTSUP`. `mspi_dw`, `mspi_mchp_xec_qmspi` and `mspi_stm32_xspi` needed an explicit check because they treat anything that isn't `MSPI_DMA` as `MSPI_PIO`; the rest already rejected unknown values, just with `-EIO`/`-EINVAL`.

**Effect on existing boards.** `MSPI_MEMMAP_READ_WRITE` is 0, so any board with `memmap-config` and no explicit permission asks for the mode on its first page program. The controller answers `-ENOTSUP` before touching the bus, so WEL is still set, the page retries on `data_xfer_mode`, and the mode isn't tried again. One rejected transfer and one `LOG_ERR` per boot. Reads are unchanged.

**Open question.** Keep the `-ENOTSUP` fallback in `api_write()`, or make the memory mapped page program path a devicetree opt-in? I'd keep the fallback: it costs one rejected transfer per boot and no binding change, where a property would have to be set on every board whose controller later gains the capability.

**Testing.** Built on `main` at `434233e` across native_sim, apollo3p_evb, apollo510_evb, mec_assy6941, nrf7120dk, b_u585i_iot02a, stm32h573i_dk and stm32l496g_disco, picked so every modified file actually gets compiled. Both native_sim MSPI suites pass. Nothing in tree enables `CONFIG_MSPI_MEMMAP` alongside `jedec,nor`, so the new path needed a build of its own — `b_u585i_iot02a` with `CONFIG_MSPI_MEMMAP=y` and `memmap-config` on `mx25lm51245`. It compiles, and both the request and the retry are in the image. CI won't cover that path unless a config is added for it.

Supersedes #113517.

@FRASTM this is the device side you asked for in #111038 — the stm32 change to service `MSPI_MEMMAP` would go on top. @swift-tk