### PR TITLE
dts: arm: realtek: amebad: fix system clock rate

### DIFF
--- a/dts/arm/realtek/amebad/amebad.dtsi
+++ b/dts/arm/realtek/amebad/amebad.dtsi
@@ -35,7 +35,7 @@
 		clk_sys: clk_sys {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_M(260)>;
+			clock-frequency = <DT_FREQ_M(200)>;
 		};
 
 		rcc: rcc@40000000 {


### PR DESCRIPTION
## Summary

AmebaD initialization selects `CLK_KM4_200M`, but `clk_sys` in
devicetree is declared as 260 MHz. This makes
`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` disagree with the hardware and
causes SysTick-based uptime and periodic work to advance at about
`200 / 260` of the requested rate.

Set `clk_sys` to 200 MHz so devicetree matches the CPU clock configured
by `soc_early_init_hook()`.

## Validation

- `scripts/checkpatch.pl --git HEAD^..HEAD`
- Built `samples/hello_world` for `rtl872xd_evb`
- Hardware smoke-tested on NUCODE NU87 using the pending board support
  from #115156:
  - Before the change, 20.106 seconds of host time advanced Zephyr
    uptime by 15.415 seconds (about 76.7%).
  - After the change, 30.04761 seconds of host time advanced Zephyr
    uptime by 30.077 seconds.
  - A nominal 100 Hz input sampler produced 3,007 samples (99.98 Hz),
    with no input, send, or deadline error increments during the
    measurement.
