### PR TITLE
boards: arduino: uno_r4: console over the ESP32-S3 USB bridge

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi-pinctrl.dtsi
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi-pinctrl.dtsi
@@ -14,6 +14,19 @@
 		};
 	};
 
+	sci9_default: sci9_default {
+		group1 {
+			/* TXD9 */
+			psels = <RA_PSEL(RA_PSEL_SCI_9, 1, 9)>;
+			drive-strength = "medium";
+		};
+
+		group2 {
+			/* RXD9 */
+			psels = <RA_PSEL(RA_PSEL_SCI_9, 1, 10)>;
+		};
+	};
+
 	spi0_default: spi0_default {
 		group1 {
 			/* MOSI MISO RSPCK SSL */

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -108,6 +108,25 @@
 	status = "okay";
 };
 
+/*
+ * SCI9 is wired to the on-board ESP32-S3, which bridges it to the USB-C
+ * connector as a USB CDC ACM port. The RA4M1 ICU links events to NVIC slots
+ * freely, so the numbers below are arbitrary but must not repeat any slot
+ * claimed by another enabled node on this board.
+ */
+&sci9 {
+	pinctrl-0 = <&sci9_default>;
+	pinctrl-names = "default";
+	interrupts = <18 1>, <19 1>, <21 1>, <22 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+
+	uart9: uart {
+		current-speed = <115200>;
+		status = "okay";
+	};
+};
+
 &iic0 {
 	pinctrl-0 = <&iic0_default>;
 	pinctrl-names = "default";

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -13,6 +13,15 @@
 / {
 	model = "Arduino Uno R4 WiFi";
 
+	chosen {
+		/*
+		 * Reach the console over the USB-C connector, through the
+		 * ESP32-S3 bridge. SCI2 remains available on the D0/D1 header.
+		 */
+		zephyr,console = &uart9;
+		zephyr,shell-uart = &uart9;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 

--- a/boards/arduino/uno_r4/doc/index.rst
+++ b/boards/arduino/uno_r4/doc/index.rst
@@ -22,6 +22,31 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+Serial Console
+==============
+
+On the Arduino UNO R4 WiFi the console is routed over SCI9, which the on-board
+ESP32-S3 bridges to the USB-C connector as a USB CDC ACM port. No external
+adapter is needed -- open the same port you flash through, at 115200 baud.
+
+Do not open that port at 1200 or 2400 baud: the bridge firmware treats those
+line rates as a request to reset the RA4M1 or to enter its DFU bootloader.
+
+The UART on the D0/D1 header (SCI2) remains available. To use it as the console
+instead, override the choice in an application overlay:
+
+.. code-block:: devicetree
+
+   / {
+       chosen {
+           zephyr,console = &uart2;
+           zephyr,shell-uart = &uart2;
+       };
+   };
+
+On the Arduino UNO R4 Minima the console is on SCI2 (D0/D1); that board has no
+ESP32-S3 and so no USB bridge.
+
 Programming and debugging
 *************************
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -293,6 +293,24 @@ Boards
   ``SOC_STM32MP15_M4`` must select :kconfig:option:`CONFIG_SOC_STM32MP157CXX_M4` instead.
   (:github:`118151`)
 
+* On the Arduino UNO R4 WiFi, ``zephyr,console`` and ``zephyr,shell-uart`` now
+  default to SCI9, which the on-board ESP32-S3 bridges to the USB-C connector as
+  a USB CDC ACM port, instead of SCI2 on the D0/D1 header pins. Console output is
+  now visible on the same port used to flash the board, with no external
+  USB-serial adapter. Applications that relied on the console being on D0/D1 can
+  select it again in an application overlay:
+
+  .. code-block:: devicetree
+
+     / {
+         chosen {
+             zephyr,console = &uart2;
+             zephyr,shell-uart = &uart2;
+         };
+     };
+
+  The Arduino UNO R4 Minima is unaffected. (:github:`118433`)
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
The UNO R4 WiFi's USB-C connector is wired to the ESP32-S3, not to the RA4M1. With the console on SCI2 — the D0/D1 header pins — nothing appears on the port the board is flashed through, so today every user has to attach a USB-serial adapter to D0/D1 to see any output at all.

SCI9 (P109 TXD9 / P110 RXD9) reaches the ESP32-S3, which bridges it to USB as a CDC ACM port. That node was not described in the board files, so nothing in Zephyr could reach the connector. This adds it and points the console there.

After this, on a stock checkout:

```console
$ west build -b arduino_uno_r4@wifi samples/hello_world && west flash
$ # open /dev/cu.usbmodem… at 115200 — the same port west flash uses
*** Booting Zephyr OS build ... ***
Hello World! arduino_uno_r4@wifi/r7fa4m1ab3cfm
```

### How the pin mapping was established

The Arduino core builds this variant with `-DNO_USB`, so `Serial` resolves to `_UART1_` (`ArduinoCore-renesas` `cores/arduino/Arduino.h`), whose pins the `UNOWIFIR4` variant maps to P109/P110 (`variants/UNOWIFIR4/variant.cpp`), muxed as SCI channel 9 (`pinmux.inc`). The firmware side agrees: `UNOR4USBBridge.ino` opens its `Serial` (UART0) on GPIO 44/43 at 115200 and pumps it byte-for-byte to USB CDC.

For completeness, the board has two RA4M1↔ESP32-S3 links; only the first is touched here:

| RA4M1 | Pins | Arduino name | Purpose |
|---|---|---|---|
| **SCI9** | P109 / P110 | `Serial` | USB-CDC bridge (ESP GPIO 44/43) |
| SCI1 | P501 / P502 | `Serial2` | Wi-Fi AT command link (ESP GPIO 6/5) |
| SCI2 | P301 / P302 = D0/D1 | `Serial1` | Arduino header |

### Notes for review

- **Split into two commits deliberately.** The first adds the SCI9 node and is a pure addition with no behaviour change. The second switches `zephyr,console`/`zephyr,shell-uart`, which *is* a behaviour change for anyone currently using D0/D1. If you'd rather not change the default, the second commit can be dropped and the first still stands on its own.
- **WiFi variant only.** The Minima has no ESP32-S3 and its configuration is untouched.
- SCI2 stays enabled and available on the header; an application overlay can select it again, and the board doc shows how.
- SCI9 has no `interrupts` property in `ra4-cm4-common.dtsi`, so ICU slots are assigned by the board. 18/19/21/22 are unused here; 20 belongs to `adc0`.
- The board doc gains a Serial Console section, including a warning not to open the port at 1200 or 2400 baud — the bridge firmware treats those line rates as a request to reset the RA4M1 or to enter its DFU bootloader.

### Testing

Built and flashed `samples/hello_world` for `arduino_uno_r4@wifi` on real hardware; banner appears over USB CDC at 115200 with no application overlay and no external adapter. Also exercised as the console for a considerably noisier Wi-Fi bring-up (scan, DHCP, HTTP and HTTPS traffic logging) without loss.

Groundwork for #77064.
