### PR TITLE
tests: kernel: tickless: tickless_concept: Fix RTC clock source on nRF

### DIFF
--- a/tests/kernel/tickless/tickless_concept/Kconfig
+++ b/tests/kernel/tickless/tickless_concept/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 32768 if NRF_RTC_TIMER
+	default 128 if NRF_RTC_TIMER
 	default 100
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Use low frequency system clock frequency for the test like for other targets. Test is expecting tick precision but when high frequency tick is used (like 32768 Hz) then kernel processing (task switching, slicing, etc.) can take few ticks and it is causing the test to fail.

Using 128 Hz because default 100 Hz cannot be achieved by dividing 32768.

Fixes #113406.