### PR TITLE
net: mdns: initialize sin6_scope_id

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -305,6 +305,9 @@ static void create_ipv6_addr(struct net_sockaddr_in6 *addr)
 	/* Well known IPv6 ff02::fb address */
 	net_ipv6_addr_create(&addr->sin6_addr,
 			     0xff02, 0, 0, 0, 0, 0, 0, 0x00fb);
+
+	/* Not scoped to any interface. */
+	addr->sin6_scope_id = 0;
 }
 
 static void create_ipv4_addr(struct net_sockaddr_in *addr)


### PR DESCRIPTION
create_ipv6_addr() sets sin6_family, sin6_port and sin6_addr, but leaves sin6_scope_id untouched. Most callers pass a stack allocated struct net_sockaddr_in6, so the scope id ends up being whatever happened to be on the stack.

The resulting address is handed to zsock_bind() when the responder sets up its IPv6 listener. net_context_bind() only looks at sin6_scope_id for link-local unicast addresses, so the native stack never notices. Socket offloading stacks do forward the field though: with CONFIG_NET_NATIVE_OFFLOADED_SOCKETS the indeterminate value reaches the host bind(), which rejects it with ENODEV, and the IPv6 listener never starts.

Set the field explicitly. The listener is not scoped to a single interface by its address - the interface is selected separately with SO_BINDTODEVICE - so zero is the correct value.