### PR TITLE
manifest: hal_nxp: enable 40MHz on 2.4GHz band edge channels for Murata 2EL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 14d44be6e81e0e98582f9bf3eb202e055309badf
+      revision: pull/810/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to include the fix that regenerates
compressed TX power tables for Murata 2EL (JP, US, EU, CA)
with 40MHz power values populated for band edge channels,
preventing uAP 40MHz from being disabled on ch1/2/10/11.

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/810