### PR TITLE
boards: lilygo: twatch_s3: add accel0 alias for the BMA423

### DIFF
--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
@@ -24,6 +24,7 @@
 		pwm-led0 = &backlight_pwm;
 		fuel-gauge0 = &fuel_gauge;
 		lora0 = &lora0;
+		accel0 = &bma423;
 	};
 
 	chosen {


### PR DESCRIPTION
Let the generic accelerometer samples pick up the sensor.