### PR TITLE
cmake: support ram_, rom_, footprint report targets through sysbuild

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -12,7 +12,7 @@ elseif(DEFINED WEST_TOPDIR)
 endif()
 
 foreach(report ram rom)
-  add_custom_target(
+  zephyr_custom_target_shared(
     ${report}_report
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/footprint/size_report
@@ -28,7 +28,7 @@ foreach(report ram rom)
     USES_TERMINAL
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
-  add_custom_target(
+  zephyr_custom_target_shared(
     ${report}_plot
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/footprint/plot.py
@@ -39,7 +39,7 @@ foreach(report ram rom)
     )
 endforeach()
 
-add_custom_target(
+zephyr_custom_target_shared(
   footprint
   DEPENDS ram_report rom_report
   )

--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -5,6 +5,11 @@ set(flag_for_rom_report rom)
 set(flag_for_footprint all)
 set(report_depth 99)
 
+if(KCONFIG_VARIANT_SOURCE)
+  # A variant build should not create report targets, those belongs in the main image.
+  return()
+endif()
+
 if(DEFINED ZEPHYR_WORKSPACE)
   set(workspace_arg "--workspace=${ZEPHYR_WORKSPACE}")
 elseif(DEFINED WEST_TOPDIR)


### PR DESCRIPTION
Use `zephyr_custom_target_shared()` to share report targets for images through sysbuild.