### PR TITLE
drivers: entropy: stm32: mark dev_cfg as unused

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -950,7 +950,8 @@ static int entropy_stm32_rng_pm_action(const struct device *dev,
 	int res = 0;
 
 	/* Remove warning on some platforms */
-	ARG_UNUSED(dev_data);
+	(void)dev_data;
+	(void)dev_cfg;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:


### PR DESCRIPTION
dev_cfg is unused when health_test_config is not defined in DTS. Mark it with ARG_UNUSED() to prevent build errors on platforms like STM32F4.