### PR TITLE
drivers: usb: uhc: fix claimed IN buffer size after pool rounding

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -82,7 +82,19 @@ int uhc_xfer_append(const struct device *dev,
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
 				   const size_t size)
 {
-	return net_buf_alloc_len(&uhc_ep_pool, size, K_NO_WAIT);
+	struct net_buf *buf = net_buf_alloc_len(&uhc_ep_pool, size, K_NO_WAIT);
+
+	/*
+	 * The pool rounds the payload up to DCACHE_LINE_SIZE, but UHC
+	 * drivers (e.g. mcux, virtual, max3421e) use net_buf_tailroom()
+	 * as the IN transfer length. Keep the claimed size at what the
+	 * caller requested so IN transfers do not exceed wLength.
+	 */
+	if (buf != NULL && buf->size > size) {
+		buf->size = size;
+	}
+
+	return buf;
 }
 
 void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)


### PR DESCRIPTION
## Summary

- Cap `buf->size` in `uhc_xfer_buf_alloc()` back to the requested length after the USB_BUF pool rounds the payload up to `DCACHE_LINE_SIZE`.
- In-tree UHC drivers (e.g. mcux, virtual, max3421e) use `net_buf_tailroom()` as the host bulk/control IN transfer length, so a rounded claimed size can exceed `dCBWDataTransferLength` / `wLength` and cause devices to STALL.
- The underlying allocation remains cache-line aligned; only the claimed capacity is corrected.

## Test plan

- [ ] Verified by code review against in-tree UHC paths that program IN length from `net_buf_tailroom()`
- [ ] checkpatch clean on this commit
- [ ] Await Zephyr CI (compliance / twister as applicable)