### PR TITLE
drivers: i2c: fixes for dw and bitbang drivers

### DIFF
--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -153,12 +153,14 @@ static void i2c_stop(struct i2c_bitbang *context)
 
 static void i2c_write_bit(struct i2c_bitbang *context, int bit)
 {
-	/* SDA hold time is zero, so no need for a delay here */
+	/* Need to set SDA high earlier to meet the spec */
 	i2c_set_sda(context, bit);
+	i2c_delay(context->delays[T_LOW] / 2);
 	i2c_set_scl(context, 1);
 	i2c_delay(context->delays[T_HIGH]);
 	i2c_set_scl(context, 0);
-	i2c_delay(context->delays[T_LOW]);
+	i2c_set_sda(context, 0);
+	i2c_delay(context->delays[T_LOW] / 2);
 }
 
 static bool i2c_read_bit(struct i2c_bitbang *context)

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -838,6 +838,82 @@ bool i2c_dw_is_busy(const struct device *dev)
 	return false;
 }
 
+static int i2c_dw_atomic_write_read(const struct device *dev, struct i2c_msg *write_msg,
+				    struct i2c_msg *read_msg)
+{
+	struct i2c_dw_dev_config *const dw = dev->data;
+	uint32_t reg_base = get_regs(dev);
+	int ret = 0;
+
+	union ic_comp_param_1_register ic_comp_param_1;
+	ic_comp_param_1.raw = read_comp_param_1(reg_base);
+	int tx_buffer_depth = ic_comp_param_1.bits.tx_buffer_depth + 1;
+
+	if (1 + read_msg->len > tx_buffer_depth) {
+		return -ENOTSUP;
+	}
+
+	if (read_txflr(reg_base) > 0) {
+		return -EBUSY;
+	}
+
+	dw->xfr_buf = read_msg->buf;
+	dw->xfr_len = read_msg->len;
+	dw->rx_pending = read_msg->len;
+	dw->request_bytes = 0U;
+	dw->state = I2C_DW_CMD_RECV;
+	dw->xfr_flags = read_msg->flags;
+
+	uint32_t cmd = write_msg->buf[0];
+	if (write_msg->flags & I2C_MSG_RESTART) {
+		cmd |= IC_DATA_CMD_RESTART;
+	}
+	write_cmd_data(cmd, reg_base);
+
+	for (size_t i = 0U; i < read_msg->len; i++) {
+		cmd = IC_DATA_CMD_CMD;
+		if (i == 0U) {
+			cmd |= IC_DATA_CMD_RESTART;
+		}
+		if (i == (read_msg->len - 1U)) {
+			if (read_msg->flags & I2C_MSG_STOP) {
+				cmd |= IC_DATA_CMD_STOP;
+			}
+		}
+		write_cmd_data(cmd, reg_base);
+	}
+
+	(void)read_clr_tx_abrt(reg_base);
+
+	write_intr_mask((DW_ENABLE_TX_INT_I2C_MASTER | DW_ENABLE_RX_INT_I2C_MASTER), reg_base);
+
+	ret = k_sem_take(&dw->device_sync_sem, K_MSEC(CONFIG_I2C_DW_RW_TIMEOUT_MS));
+
+	write_intr_mask(DW_DISABLE_ALL_I2C_INT, reg_base);
+
+	if (ret != 0) {
+		if (test_bit_con_master_mode(reg_base)) {
+			set_bit_enable_abort(reg_base);
+			(void)k_sem_take(&dw->device_sync_sem, K_MSEC(1));
+		}
+		(void)read_clr_intr(reg_base);
+		ret = -ETIMEDOUT;
+		k_sem_reset(&dw->device_sync_sem);
+	} else if (dw->state & I2C_DW_CMD_ERROR) {
+		ret = -EIO;
+	} else if (dw->xfr_len > 0) {
+		ret = -EIO;
+	} else if (dw->state & I2C_DW_ERR_MASK) {
+		if (dw->state & (I2C_DW_SDA_STUCK | I2C_DW_SCL_STUCK)) {
+			ret = -ETIME;
+		} else if (dw->state & (I2C_DW_NACK | I2C_DW_CMD_ERROR)) {
+			ret = -EIO;
+		}
+	}
+
+	return ret;
+}
+
 static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 			   uint16_t target_address)
 {
@@ -920,6 +996,22 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 	 * can handle everything
 	 */
 	pm_device_busy_set(dev);
+
+	/*
+	 * If we detect a write-read transaction (within certain limits, like
+	 * 1 byte to write and up to 8 bytes to read), we execute it atomically.
+	 * This pre-fills the TX FIFO with both write and read commands so that
+	 * the hardware executes them back-to-back with a repeated start without
+	 * CPU intervention, preventing preemption/latency between the phases.
+	 * Otherwise, we fall back to the regular interrupt-driven path.
+	 */
+	if (num_msgs == 2U && !i2c_is_read_op(&msgs[0]) &&
+	    i2c_is_read_op(&msgs[1]) && msgs[0].len == 1U &&
+	    msgs[1].len <= 8U) {
+		ret = i2c_dw_atomic_write_read(dev, &msgs[0], &msgs[1]);
+		pm_device_busy_clear(dev);
+		goto error;
+	}
 
 	/* Process all the messages */
 	while (msg_left > 0) {

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -698,10 +698,10 @@ static int i2c_dw_setup(const struct device *dev, uint16_t target_address)
 	/* Disable the device controller to be able set TAR */
 	clear_bit_enable_en(reg_base);
 
-	/* enable bus clear feature */
-	ic_con.bits.bus_clear = 1U;
-	/* enable tx empty control to fix timing issue */
-	ic_con.bits.tx_empty_ctl = 1U;
+	/* disable bus clear feature */
+	ic_con.bits.bus_clear = 0U;
+	/* disable tx empty control to fix timing issue */
+	ic_con.bits.tx_empty_ctl = 0U;
 
 	/* Disable interrupts */
 	write_intr_mask(0, reg_base);

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -154,8 +154,8 @@ static int i2c_write_from_buffer(const struct shell *sh,
 			buf + MAX_BYTES_FOR_REGISTER_INDEX - reg_addr_bytes,
 			reg_addr_bytes + data_length, dev_addr);
 	if (ret < 0) {
-		shell_error(sh, "Failed to write to device: %s", s_dev_addr);
-		return -EIO;
+		shell_error(sh, "Failed to write to device: %s (error %d)", s_dev_addr, ret);
+		return ret;
 	}
 
 	return 0;
@@ -211,8 +211,8 @@ static int i2c_read_to_buffer(const struct shell *sh,
 	}
 
 	if (ret < 0) {
-		shell_error(sh, "Failed to read from device: %s", s_dev_addr);
-		return -EIO;
+		shell_error(sh, "Failed to read from device: %s (error %d)", s_dev_addr, ret);
+		return ret;
 	}
 
 	return 0;
@@ -312,8 +312,8 @@ static int cmd_i2c_speed(const struct shell *sh, size_t argc, char **argv)
 
 	ret = i2c_configure(dev, dev_config);
 	if (ret < 0) {
-		shell_error(sh, "I2C: Failed to configure device: %s", s_dev_name);
-		return -EIO;
+		shell_error(sh, "I2C: Failed to configure device: %s (error %d)", s_dev_name, ret);
+		return ret;
 	}
 	return 0;
 }

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -414,8 +414,8 @@ static int i3c_write_from_buffer(const struct shell *sh, char *s_dev_name, char 
 	ret = i3c_write(desc, buf + MAX_BYTES_FOR_REGISTER_INDEX - reg_addr_bytes,
 			reg_addr_bytes + data_length);
 	if (ret < 0) {
-		shell_error(sh, "Failed to write to device: %s", tdev->name);
-		return -EIO;
+		shell_error(sh, "Failed to write to device: %s (error %d)", tdev->name, ret);
+		return ret;
 	}
 
 	return 0;
@@ -469,8 +469,8 @@ static int i3c_read_to_buffer(const struct shell *sh, char *s_dev_name, char *s_
 	ret = i3c_write_read(desc, reg_addr_buf + MAX_BYTES_FOR_REGISTER_INDEX - reg_addr_bytes,
 			     reg_addr_bytes, buf, buf_length);
 	if (ret < 0) {
-		shell_error(sh, "Failed to read from device: %s", tdev->name);
-		return -EIO;
+		shell_error(sh, "Failed to read from device: %s (error %d)", tdev->name, ret);
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
This PR introduces several fixes and improvements for the I2C DesignWare and bitbang drivers, including atomic write-read support and shell status codes fixes.
