### PR TITLE
manifest: tf-m: include impl. of __assert_no_args in platform/ext/

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: c821782bcf12b01807359a51de76066317cc616b
+      revision: ef35073337e66e3117a6ef33fc60f69596d2afbc
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Bump TF-M commit to include the implementation of the __assert_no_args funtion in platform/ext/common. The lack of this function was causing the buildsystem.debug.build test to fail on non-secure targets.

See: https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/228