### PR TITLE
Add a common --gdb-init runner option

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -302,6 +302,16 @@ LinkServer west runner   ``--probe`` option to pass the probe index.
    you would like to single step from the start of their application, you
    will need to add a breakpoint at ``main`` or the reset handler manually.
 
+5. That breakpoint, and any other GDB command, can be installed automatically
+   with ``--gdb-init``, which this runner appends to the GDB client for
+   ``west debug`` and ``west attach``, e.g.:
+
+   .. code-block:: console
+
+      west debug --runner=linkserver --gdb-init 'b main'
+
+   See :ref:`gdb-init-runner-option`.
+
 .. _jlink-debug-host-tools:
 .. _runner_jlink:
 
@@ -332,6 +342,41 @@ drivers. RTT Viewer and SystemView can be downloaded separately, but are not
 required.
 
 Note that the J-Link GDB server does not yet support Zephyr RTOS-awareness.
+
+.. _gdb-init-runner-option:
+
+Passing Extra GDB Commands
+--------------------------
+
+The ``jlink`` runner accepts ``--gdb-init``, which appends a command to the GDB
+client started by ``west debug`` and ``west attach``. The option can be given
+multiple times and the commands run in the order given, last of everything the
+runner sends to GDB and before the target is resumed. Since they are only
+appended, they cannot change the runner's own connect, load and reset sequence.
+``west flash``, ``west reset``, ``west rtt`` and ``west debugserver`` are
+unaffected.
+
+For example, to enable J-Link semihosting for the duration of a debug session:
+
+.. code-block:: console
+
+   west debug -r jlink --gdb-init 'monitor semihosting enable' \
+     --gdb-init 'monitor semihosting basedir .'
+
+The same commands can be made the default for a board by adding them to its
+:file:`board.cmake`:
+
+.. code-block:: cmake
+
+   board_runner_args(jlink "--gdb-init=monitor semihosting enable")
+
+Note that ``--gdb-init`` only reaches the GDB client. Options for the J-Link GDB
+server itself are passed with ``--tool-opt``, and J-Link Commander commands run
+while flashing are passed with ``--pre-script-cmd``.
+
+The ``linkserver``, ``openocd`` and ``intel_cyclonev`` runners accept the same
+option. Which commands it applies to, and where the commands are inserted, is up
+to each runner.
 
 .. _openocd-debug-host-tools:
 .. _runner_openocd:

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -350,6 +350,10 @@ class RunnerCaps:
       can be given multiple times and is passed on to the underlying tool
       that the runner wraps.
 
+    - gdb_init: whether the runner supports a --gdb-init option, which can be
+      given multiple times and appends commands, in the order given, to the GDB
+      client invocation, after the ones the runner issues itself.
+
     - file: whether the runner supports a --file option, which specifies
       exactly the file that should be used to flash, overriding any default
       discovered in the build directory.
@@ -374,6 +378,7 @@ class RunnerCaps:
     reset_types_supported: list[str] | None = None
     extload: bool = False
     tool_opt: bool = False
+    gdb_init: bool = False
     file: bool = False
     hide_load_files: bool = False
     rtt: bool = False  # This capability exists separately from the rtt command
@@ -700,6 +705,14 @@ class ZephyrBinaryRunner(abc.ABC):
                             help=(cls.tool_opt_help() if caps.tool_opt
                                   else argparse.SUPPRESS))
 
+        parser.add_argument('--gdb-init', dest='gdb_init',
+                            default=[], action='append',
+                            metavar='COMMAND',
+                            help=('command to run in the GDB client, after the '
+                                  'ones the runner issues itself; may be given '
+                                  'multiple times, in order'
+                                  if caps.gdb_init else argparse.SUPPRESS))
+
         if caps.rtt:
             parser.add_argument('--rtt-address', dest='rtt_address',
                                 type=lambda x: int(x, 0),
@@ -760,6 +773,8 @@ class ZephyrBinaryRunner(abc.ABC):
             _missing_cap(cls, '--extload')
         if args.tool_opt and not caps.tool_opt:
             _missing_cap(cls, '--tool-opt')
+        if args.gdb_init and not caps.gdb_init:
+            _missing_cap(cls, '--gdb-init')
         if args.file and not caps.file:
             _missing_cap(cls, '--file')
         if args.file_type and not caps.file:
@@ -936,6 +951,13 @@ class ZephyrBinaryRunner(abc.ABC):
                   by this runner. This can be given multiple times;
                   the resulting arguments will be given to the tool
                   in the order they appear on the command line.'''
+
+    @staticmethod
+    def gdb_ex_args(commands: list[str] | None) -> list[str]:
+        '''Turn GDB commands into '-ex', <command> pairs for a GDB argv.
+
+        The commands are passed on verbatim.'''
+        return [arg for command in (commands or []) for arg in ('-ex', command)]
 
     @staticmethod
     def require(program: str, path: str | None = None) -> str:

--- a/scripts/west_commands/runners/intel_cyclonev.py
+++ b/scripts/west_commands/runners/intel_cyclonev.py
@@ -88,7 +88,7 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
         self.targets_arg = [] if no_targets else ['-c targets']
         self.serial = ['-c set _ZEPHYR_BOARD_SERIAL ' + serial] if serial else []
         self.use_elf = use_elf
-        self.gdb_init = gdb_init
+        self.gdb_init = gdb_init or []
         self.load_arg = ['-ex', 'load'] if load else []
 
     @classmethod
@@ -98,7 +98,8 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'attach'},
-                          dev_id=False, flash_addr=False, erase=False, skip_load=True)
+                          dev_id=False, flash_addr=False, erase=False, skip_load=True,
+                          gdb_init=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -143,8 +144,6 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
                             help='openocd telnet port, defaults to 4444')
         parser.add_argument('--gdb-port', default=DEFAULT_OPENOCD_GDB_PORT,
                             help='openocd gdb port, defaults to 3333')
-        parser.add_argument('--gdb-init', action='append',
-                            help='if given, add GDB init commands')
         parser.add_argument('--no-halt', action='store_true',
                             help='if given, no halt issued in gdb server cmd')
         parser.add_argument('--no-init', action='store_true',
@@ -245,12 +244,9 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
         gdb_cmd2 = (self.gdb_cmd + self.tui_arg +
                    ['-ex', f'target extended-remote localhost:{self.gdb_port}' , '-batch'])
         echo = ['echo']
-        if self.gdb_init is not None:
-            for i in self.gdb_init:
-                gdb_cmd.append("-ex")
-                gdb_cmd.append(i)
-                gdb_cmd2.append("-ex")
-                gdb_cmd2.append(i)
+        gdb_init_args = self.gdb_ex_args(self.gdb_init)
+        gdb_cmd += gdb_init_args
+        gdb_cmd2 += gdb_init_args
 
         if self.gdb_cmds is not None:
             for i in self.gdb_cmds:
@@ -309,12 +305,9 @@ class IntelCycloneVBinaryRunner(ZephyrBinaryRunner):
                    ['-ex', f'target extended-remote :{self.gdb_port}' , '-batch'])
 
 
-        if self.gdb_init is not None:
-            for i in self.gdb_init:
-                gdb_cmd.append("-ex")
-                gdb_cmd.append(i)
-                gdb_cmd2.append("-ex")
-                gdb_cmd2.append(i)
+        gdb_init_args = self.gdb_ex_args(self.gdb_init)
+        gdb_cmd += gdb_init_args
+        gdb_cmd2 += gdb_init_args
 
         if self.gdb_cmds is not None:
             for i in self.gdb_cmds:

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -58,7 +58,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  rtt_port=DEFAULT_JLINK_RTT_PORT,
                  rtt_channel=None,
                  tui=False, tool_opt=None, dev_id_type=None, batch=False,
-                 pre_script_cmds=None):
+                 pre_script_cmds=None, gdb_init=None):
         super().__init__(cfg)
         self.file = cfg.file
         self.file_type = cfg.file_type
@@ -88,6 +88,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.dev_id_type = dev_id_type
         self.is_batch = batch
         self.pre_script_cmds = pre_script_cmds
+        self.gdb_init = gdb_init or []
 
         self.tool_opt = []
         if tool_opt is not None:
@@ -127,7 +128,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt', 'reset'},
                           dev_id=True, flash_addr=True, erase=True, reset=True, reset_types=True,
-                          tool_opt=True, file=True, rtt=True, batch_debug=True)
+                          tool_opt=True, file=True, rtt=True, batch_debug=True, gdb_init=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
@@ -237,7 +238,8 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  tui=args.tui, tool_opt=args.tool_opt,
                                  dev_id_type=args.dev_id_type,
                                  batch=args.batch,
-                                 pre_script_cmds=args.pre_script_cmds)
+                                 pre_script_cmds=args.pre_script_cmds,
+                                 gdb_init=args.gdb_init)
 
     def print_gdbserver_message(self):
         if not self.thread_info_enabled:
@@ -456,11 +458,15 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                '-ex', 'monitor reset',
                                '-ex', 'load']
             if command in ('debug', 'attach'):
+                if self.reset and not self.is_batch:
+                    client_cmd += ['-ex', 'monitor reset']
+                # Run the user's commands after the last reset, so that nothing
+                # discards their effect, and while the target is still halted.
+                client_cmd += self.gdb_ex_args(self.gdb_init)
                 if self.is_batch:
                     client_cmd += ['-ex', 'monitor go', '-ex', 'disconnect', '-ex', 'quit']
-                elif self.reset:
-                    client_cmd += ['-ex', 'monitor reset']
             if command == 'reset':
+                # A fixed sequence with no user session, so no gdb_init here.
                 client_cmd += [
                     '-ex', 'monitor halt',
                     '-ex', 'monitor reset',

--- a/scripts/west_commands/runners/linkserver.py
+++ b/scripts/west_commands/runners/linkserver.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 NXP
+# Copyright 2023-2024, 2026 NXP
 # Copyright (c) 2017 Linaro Limited.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -29,7 +29,7 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
                  gdb_port=DEFAULT_LINKSERVER_GDB_PORT,
                  semihost_port=DEFAULT_LINKSERVER_SEMIHOST_PORT,
                  override=None,
-                 tui=False, tool_opt=None, batch=False):
+                 tui=False, tool_opt=None, batch=False, gdb_init=None):
         super().__init__(cfg)
         self.file = cfg.file
         self.file_type = cfg.file_type
@@ -50,6 +50,7 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
         self.override = override if override else []
         self.override_cli = self._build_override_cli()
         self.is_batch = batch
+        self.gdb_init = gdb_init or []
 
         self.tool_opt = []
         if tool_opt is not None:
@@ -64,7 +65,7 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
                           dev_id=True, flash_addr=True, erase=True,
-                          tool_opt=True, file=True, batch_debug=True)
+                          tool_opt=True, file=True, batch_debug=True, gdb_init=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -106,7 +107,8 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
                                  gdb_port=args.gdb_port,
                                  override=args.override,
                                  tui=args.tui, tool_opt=args.tool_opt,
-                                 batch=args.batch)
+                                 batch=args.batch,
+                                 gdb_init=args.gdb_init)
 
     @property
     def linkserver_version_str(self):
@@ -157,11 +159,14 @@ class LinkServerBinaryRunner(ZephyrBinaryRunner):
                     # the ram as inaccessible and does not flash.
                     gdb_cmd += ['-ex', 'set mem inaccessible-by-default off']
                     gdb_cmd += ['-ex', 'monitor reset', '-ex', 'load']
+                    # Run the user's commands while the target is still halted.
+                    gdb_cmd += self.gdb_ex_args(self.gdb_init)
                     if self.is_batch:
                         gdb_cmd += ['-ex', 'monitor ondisconnect cont', '-ex',
                                     'monitor kill_server', '-ex', 'quit']
 
                 if command == 'attach':
+                    gdb_cmd += self.gdb_ex_args(self.gdb_init)
                     linkserver_cmd += ['--attach']
 
                 self.run_server_and_client(linkserver_cmd, gdb_cmd)

--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -129,7 +129,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         self.serial = ['-c set _ZEPHYR_BOARD_SERIAL ' + serial] if serial else []
         self.image_type = image_type
         self.flash_address = flash_address
-        self.gdb_init = gdb_init
+        self.gdb_init = gdb_init or []
         self.load_arg = ['-ex', 'load'] if load else []
         self.target_handle = target_handle
         self.log_file = Path(log_file).as_posix() if log_file else None
@@ -144,7 +144,8 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
-                          dev_id=True, rtt=True, erase=True, skip_load=True, file=True)
+                          dev_id=True, rtt=True, erase=True, skip_load=True, file=True,
+                          gdb_init=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
@@ -217,8 +218,6 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--gdb-client-port', default=DEFAULT_OPENOCD_GDB_PORT,
                             help='''openocd gdb client port if multiple ports come
                             up, defaults to 3333''')
-        parser.add_argument('--gdb-init', action='append',
-                            help='if given, add GDB init commands')
         parser.add_argument('--no-halt', action='store_true',
                             help='if given, no halt issued in gdb server cmd')
         parser.add_argument('--no-init', action='store_true',
@@ -486,10 +485,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             for i in self.gdb_pre_debug:
                 gdb_cmd.append("-ex")
                 gdb_cmd.append(i)
-        if self.gdb_init is not None:
-            for i in self.gdb_init:
-                gdb_cmd.append("-ex")
-                gdb_cmd.append(i)
+        gdb_cmd.extend(self.gdb_ex_args(self.gdb_init))
         if command == 'rtt':
             rtt_address = self.get_rtt_address()
             if rtt_address is None:

--- a/scripts/west_commands/tests/test_jlink.py
+++ b/scripts/west_commands/tests/test_jlink.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+'''Tests for the argv the J-Link runner hands to the GDB client.'''
+
+import argparse
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from conftest import RC_GDB, RC_KERNEL_ELF
+
+from runners.jlink import JLinkBinaryRunner
+
+#
+# Test values. The J-Link version only matters because some argv contents are
+# gated on it; this one is recent enough that nothing is gated out.
+#
+
+TEST_DEVICE = 'test-device'
+TEST_JLINK_VERSION = (7, 88, 0)
+
+#
+# Expected results.
+#
+# The fragments the runner appends to the GDB client argv, in the order it
+# appends them.
+#
+
+# The runner passes an empty string in place of '-batch' when batch mode is off.
+CLIENT_HEAD = [RC_GDB, RC_KERNEL_ELF, '']
+CLIENT_HEAD_BATCH = [RC_GDB, RC_KERNEL_ELF, '-batch']
+
+CONNECT = ['-ex', 'target remote :2331']
+CONNECT_HOST = ['-ex', 'target remote h:2331']
+LOAD = ['-ex', 'monitor halt', '-ex', 'monitor reset', '-ex', 'load']
+MONITOR_RESET = ['-ex', 'monitor reset']
+GO_AND_QUIT = ['-ex', 'monitor go', '-ex', 'disconnect', '-ex', 'quit']
+HALT_AND_CONFIRM = ['-ex', 'monitor halt', '-ex', 'monitor reset', '-ex', 'set confirm off']
+RESET_SEQUENCE = HALT_AND_CONFIRM + GO_AND_QUIT
+
+# Two --gdb-init commands, and the argv they must produce.
+INIT_ARGS = ['--gdb-init', 'monitor semihosting enable', '--gdb-init', 'b main']
+INIT_EX = ['-ex', 'monitor semihosting enable', '-ex', 'b main']
+
+
+#
+# Helpers
+#
+
+
+def require_patch(program, path=None):
+    # The commander name is platform-dependent and the runner resolves it to an
+    # absolute path, but neither reaches the GDB client argv checked here.
+    return program
+
+
+def create_from_args(runner_config, argv):
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    JLinkBinaryRunner.add_parser(parser)
+    args = parser.parse_args(['--device', TEST_DEVICE, *argv])
+    # The shared fixture leaves a non-None cfg.file; force it to None so the
+    # runner does not mistake it for a user-provided image.
+    return JLinkBinaryRunner.create(runner_config._replace(file=None), args)
+
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture
+def client_cmd(runner_config):
+    '''Run a command and return the argv handed to the GDB client.'''
+
+    def _run(command, argv=()):
+        runner = create_from_args(runner_config, argv)
+        # Bypass the version probe, which loads the J-Link shared library, and
+        # the build directory read. Both are platform-specific, and neither
+        # affects the client argv.
+        runner._jlink_version = TEST_JLINK_VERSION
+        runner._build_conf = SimpleNamespace(getboolean=lambda option: False)
+
+        with (
+            patch('runners.jlink.MISSING_REQUIREMENTS', False),
+            patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch),
+            patch.object(JLinkBinaryRunner, 'run_server_and_client') as with_server,
+            patch.object(JLinkBinaryRunner, 'check_call_ignore_sigint') as client_only,
+        ):
+            runner.run(command)
+
+        # --gdb-host connects to an existing server, so no server is started.
+        return client_only.call_args[0][0] if runner.gdb_host else with_server.call_args[0][1]
+
+    return _run
+
+
+#
+# Test cases
+#
+# --gdb-init commands are appended after the ones the runner issues itself and
+# before the target is resumed, so they cannot change the runner's defaults and
+# still take effect while the target is halted.
+#
+
+
+@pytest.mark.parametrize(
+    'command, argv, expected',
+    [
+        # Interactive 'debug' hands the prompt to the user, so it must not tear
+        # the session down.
+        ('debug', [], CLIENT_HEAD + CONNECT + LOAD),
+        ('debug', INIT_ARGS, CLIENT_HEAD + CONNECT + LOAD + INIT_EX),
+        # Batch mode resumes the target and exits instead of waiting for input.
+        ('debug', ['--batch'], CLIENT_HEAD_BATCH + CONNECT + LOAD + GO_AND_QUIT),
+        (
+            'debug',
+            ['--batch', *INIT_ARGS],
+            CLIENT_HEAD_BATCH + CONNECT + LOAD + INIT_EX + GO_AND_QUIT,
+        ),
+        # --reset restarts the target once the image is loaded. It leaves the
+        # CPU halted, so the user's commands come after it, not before.
+        ('debug', ['--reset'], CLIENT_HEAD + CONNECT + LOAD + MONITOR_RESET),
+        ('debug', ['--reset', *INIT_ARGS], CLIENT_HEAD + CONNECT + LOAD + MONITOR_RESET + INIT_EX),
+        # 'attach' leaves the target running and loads nothing.
+        ('attach', [], CLIENT_HEAD + CONNECT),
+        ('attach', INIT_ARGS, CLIENT_HEAD + CONNECT + INIT_EX),
+        # --reset applies to 'attach' too, and the user's commands still come
+        # after it.
+        ('attach', ['--reset'], CLIENT_HEAD + CONNECT + MONITOR_RESET),
+        ('attach', ['--reset', *INIT_ARGS], CLIENT_HEAD + CONNECT + MONITOR_RESET + INIT_EX),
+        # 'reset' is a fixed sequence with no user session, so it ignores the
+        # option even when a board passes it through shared runner args.
+        ('reset', [], CLIENT_HEAD + CONNECT + RESET_SEQUENCE),
+        ('reset', INIT_ARGS, CLIENT_HEAD + CONNECT + RESET_SEQUENCE),
+        # --gdb-host only changes where the client connects.
+        ('debug', ['--gdb-host', 'h'], CLIENT_HEAD + CONNECT_HOST + LOAD),
+    ],
+)
+def test_client_cmd(client_cmd, command, argv, expected):
+    assert client_cmd(command, argv) == expected
+
+
+def test_gdb_init_passed_verbatim(client_cmd):
+    '''The commands are not parsed, so GDB expression syntax survives.'''
+    command = 'p {int}0x20000000'
+    assert client_cmd('attach', ['--gdb-init', command])[-2:] == ['-ex', command]
+
+
+def test_gdb_init_requires_the_capability(runner_config):
+    '''Runners without the capability reject the option instead of ignoring it.
+
+    Exercises the shared gate in runners/core.py through a runner that declares
+    the capability, with it switched back off.
+    '''
+
+    class NoGdbInit(JLinkBinaryRunner):
+        @classmethod
+        def capabilities(cls):
+            return replace(super().capabilities(), gdb_init=False)
+
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    NoGdbInit.add_parser(parser)
+    args = parser.parse_args(['--device', TEST_DEVICE, '--gdb-init', 'p 1'])
+
+    with pytest.raises(ValueError, match="doesn't support --gdb-init"):
+        NoGdbInit.create(runner_config._replace(file=None), args)

--- a/scripts/west_commands/tests/test_linkserver.py
+++ b/scripts/west_commands/tests/test_linkserver.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+'''Tests for the argv the LinkServer runner hands to the GDB client.'''
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+from conftest import RC_GDB, RC_KERNEL_ELF
+
+from runners.linkserver import DEFAULT_LINKSERVER_EXE, LinkServerBinaryRunner
+
+#
+# Test values. The LinkServer version only matters because some argv contents
+# are gated on it; this one is recent enough that nothing is gated out.
+#
+
+TEST_DEVICE = 'test-device'
+TEST_LINKSERVER_VERSION = 'v1.5.30'
+
+#
+# Expected results.
+#
+# The fragments the runner appends to the GDB client argv, in the order it
+# appends them.
+#
+
+# The runner passes an empty string in place of '-batch' when batch mode is off.
+CLIENT_HEAD = [RC_GDB, RC_KERNEL_ELF, '']
+CLIENT_HEAD_BATCH = [RC_GDB, RC_KERNEL_ELF, '-batch']
+
+CONNECT = ['-ex', 'target remote :3333']
+# LinkServer reports a flash node pointing at RAM as inaccessible, so the runner
+# turns that check off before loading.
+LOAD = ['-ex', 'set mem inaccessible-by-default off', '-ex', 'monitor reset', '-ex', 'load']
+TEARDOWN = ['-ex', 'monitor ondisconnect cont', '-ex', 'monitor kill_server', '-ex', 'quit']
+
+# Two --gdb-init commands, and the argv they must produce.
+INIT_ARGS = ['--gdb-init', 'monitor semihosting enable', '--gdb-init', 'b main']
+INIT_EX = ['-ex', 'monitor semihosting enable', '-ex', 'b main']
+
+
+#
+# Helpers
+#
+
+
+def require_patch(program, path=None):
+    assert program == DEFAULT_LINKSERVER_EXE
+    return program
+
+
+def create_from_args(runner_config, argv):
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    LinkServerBinaryRunner.add_parser(parser)
+    args = parser.parse_args(['--device', TEST_DEVICE, *argv])
+    return LinkServerBinaryRunner.create(runner_config, args)
+
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture
+def client_cmd(runner_config, tmpdir):
+    '''Run a command and return the argv handed to the GDB client.'''
+
+    def _run(command, argv=()):
+        # The runner refuses to debug unless the ELF file exists, so create an
+        # empty one; the commands using it are patched out below.
+        tmpdir.ensure(RC_KERNEL_ELF)
+        tmpdir.chdir()
+
+        runner = create_from_args(runner_config, argv)
+
+        with (
+            patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch),
+            # Answer the 'LinkServer -v' probe without running anything.
+            patch.object(
+                LinkServerBinaryRunner,
+                'check_output',
+                return_value=f'LinkServer {TEST_LINKSERVER_VERSION}'.encode(),
+            ),
+            patch.object(LinkServerBinaryRunner, 'run_server_and_client') as with_server,
+        ):
+            runner.run(command)
+
+        return with_server.call_args[0][1]
+
+    return _run
+
+
+#
+# Test cases
+#
+# --gdb-init commands are appended after the ones the runner issues itself and
+# before the session ends, so they cannot change the runner's defaults and still
+# take effect while the target is halted.
+#
+
+
+@pytest.mark.parametrize(
+    'command, argv, expected',
+    [
+        # Interactive 'debug' hands the prompt to the user, so it must not tear
+        # the session down.
+        ('debug', [], CLIENT_HEAD + CONNECT + LOAD),
+        ('debug', INIT_ARGS, CLIENT_HEAD + CONNECT + LOAD + INIT_EX),
+        # Batch mode ends the session itself instead of waiting for input.
+        ('debug', ['--batch'], CLIENT_HEAD_BATCH + CONNECT + LOAD + TEARDOWN),
+        ('debug', ['--batch', *INIT_ARGS], CLIENT_HEAD_BATCH + CONNECT + LOAD + INIT_EX + TEARDOWN),
+        # 'attach' leaves the target running and loads nothing.
+        ('attach', [], CLIENT_HEAD + CONNECT),
+        ('attach', INIT_ARGS, CLIENT_HEAD + CONNECT + INIT_EX),
+    ],
+)
+def test_client_cmd(client_cmd, command, argv, expected):
+    assert client_cmd(command, argv) == expected

--- a/scripts/west_commands/tests/test_openocd.py
+++ b/scripts/west_commands/tests/test_openocd.py
@@ -150,3 +150,55 @@ def test_no_dev_id_no_serial(runner_config):
     '''Without a selector no _ZEPHYR_BOARD_SERIAL command is emitted.'''
     runner = create_from_args(runner_config, [])
     assert runner.serial == []
+
+
+#
+# --gdb-init commands are appended, in the order given, after the ones the
+# runner issues itself, so they cannot change the runner's default behavior.
+# Twenty-two in-tree board.cmake files rely on this.
+#
+
+INIT_A = 'set print asm-demangle on'
+INIT_B = 'mem 0x90000000 0x90020000 ro'
+INIT_ARGS = ['--gdb-init', INIT_A, '--gdb-init', INIT_B]
+INIT_EX = ['-ex', INIT_A, '-ex', INIT_B]
+LOAD = ['-ex', 'load']
+PRE_DEBUG = 'monitor reset halt'
+
+
+@pytest.mark.parametrize(
+    'command, argv, expected_tail',
+    [
+        # 'debug' loads the image first, so the user's commands come last.
+        ('debug', INIT_ARGS, LOAD + INIT_EX),
+        # Without the option the client gets no extra commands.
+        ('debug', [], LOAD),
+        # 'attach' loads nothing.
+        ('attach', INIT_ARGS, INIT_EX),
+        # --gdb-pre-debug is the other append point, and keeps its place.
+        ('debug', ['--gdb-pre-debug', PRE_DEBUG, *INIT_ARGS], LOAD + ['-ex', PRE_DEBUG] + INIT_EX),
+        # --no-load drops the load command.
+        ('debug', ['--no-load', *INIT_ARGS], INIT_EX),
+    ],
+)
+@patch('runners.openocd.OpenOcdBinaryRunner.read_version', return_value=(0, 12, 0))
+@patch('runners.openocd.OpenOcdBinaryRunner.check_call_ignore_sigint')
+@patch('runners.openocd.OpenOcdBinaryRunner.popen_ignore_int', return_value=MagicMock())
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_gdb_init(
+    require,
+    popen_ignore_int,
+    check_call_ignore_sigint,
+    read_version,
+    command,
+    argv,
+    expected_tail,
+    runner_config,
+):
+    runner = create_from_args(runner_config, argv)
+    # Inject a fake build configuration so no real build dir is read.
+    runner._build_conf = FakeBuildConf({'CONFIG_DEBUG_THREAD_INFO': True})
+    runner.run(command)
+
+    cmd = check_call_ignore_sigint.call_args[0][0]
+    assert cmd[-len(expected_tail) :] == expected_tail


### PR DESCRIPTION
`--gdb-init` was a local option in `openocd.py` and `intel_cyclonev.py`, so no other runner could offer it, and runners without it silently ignored the option instead of reporting it. This moves it to a `RunnerCaps.gdb_init` capability and enables it on `jlink` and `linkserver`.

```bash
west debug -r jlink --gdb-init "monitor semihosting enable"
west debug -r linkserver --gdb-init "b main"
```

Each value becomes one `-ex <value>` pair. The option is repeatable, order is preserved, and values are passed to GDB verbatim, so GDB expression syntax keeps working. For `jlink` and `linkserver` the commands are appended last of what the runner sends to GDB and before the target is resumed, so they take effect while it is still halted; `flash`, `reset`, `rtt` and `debugserver` are unaffected. With the option absent, every runner produces a byte-identical GDB argv.

`openocd` and `intel_cyclonev` are migrated in the same commit because core now registers the option for every runner, which would otherwise clash with their local definitions. Their behaviour and the 22 existing `board_runner_args(openocd --gdb-init ...)` lines are unchanged, and the commit adds the openocd tests that pin that argv.

`jlink` and `linkserver` had no test files at all; this adds them, covering the GDB client argv for `debug` (interactive, `--batch`, `--reset`), `attach` and `reset`, with and without the new option. All process launches, version probes and build-configuration reads are mocked, so no debug probe or vendor software is needed on any host.

implement #115020
