### PR TITLE
tracing: ctf: add CPU id to event stream for SMP support

### DIFF
--- a/scripts/tracing/trace_viewer.py
+++ b/scripts/tracing/trace_viewer.py
@@ -76,9 +76,10 @@ def safe_open(path, mode, **kwargs):
 # Record framing, identical for every event:
 #   uint64_t timestamp (ns)   <- present when CONFIG_TRACING_CTF_TIMESTAMP=y
 #   uint16_t id
+#   uint8_t  cpu_id           <- stream event.context (SMP support)
 #   <packed, byte-aligned event specific fields>
-HDR = struct.Struct("<QH")
-HDR_NO_TS = struct.Struct("<H")
+HDR = struct.Struct("<QHB")
+HDR_NO_TS = struct.Struct("<HB")
 
 # Map a TSDL integer typedef to a struct format character and byte size.
 TYPES = {
@@ -450,9 +451,9 @@ class TraceReader:
         new = 0
         while off + hsz <= n:
             if self.has_ts:
-                ts, eid = self.hdr.unpack_from(data, off)
+                ts, eid, cpu_id = self.hdr.unpack_from(data, off)
             else:
-                (eid,) = self.hdr.unpack_from(data, off)
+                eid, cpu_id = self.hdr.unpack_from(data, off)
                 ts = None
             edef = self.defs.get(eid)
             if edef is None:
@@ -472,6 +473,7 @@ class TraceReader:
                 self._prev_raw = ts
                 ts += self._ts_off
             fields, _ = edef.decode(data, off + hsz)
+            fields["cpu_id"] = cpu_id
             off += rec
             self._consume(ts, eid, edef.name, fields)
             new += 1

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -13,6 +13,7 @@
 #include <ctf_map.h>
 #include <zephyr/tracing/tracing_format.h>
 #include <zephyr/net/net_ip.h>
+#include <zephyr/kernel.h>
 
 /* Limit strings to 20 bytes to optimize bandwidth */
 #define CTF_MAX_STRING_LEN 20
@@ -58,19 +59,32 @@ static inline uint64_t ctf_top_timestamp_get(void)
 	return timing_ns_get();
 }
 
-#define CTF_EVENT(...)                                                                             \
+/*
+ * CTF_EVENT takes the event id as the first argument, followed by an
+ * optional payload. cpu_id is inserted between id and payload so that
+ * the binary layout matches:
+ *   [event header: timestamp, id][event context: cpu_id][event payload]
+ * The id is pulled out as a named arg so ##__VA_ARGS__ can drop the
+ * trailing comma for events that carry no payload (e.g. idle).
+ */
+#define CTF_EVENT(id, ...)                                                                         \
 	{                                                                                          \
 		if (!is_tracing_enabled()) {                                                       \
 			return;                                                                    \
 		}                                                                                  \
 		int key = irq_lock();                                                              \
 		const uint64_t tstamp = ctf_top_timestamp_get();                                   \
+		const uint8_t cpu_id = CPU_ID;                                                     \
                                                                                                    \
-		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
+		CTF_GATHER_FIELDS(tstamp, id, cpu_id, ##__VA_ARGS__)                               \
 		irq_unlock(key);                                                                   \
 	}
 #else
-#define CTF_EVENT(...) {CTF_GATHER_FIELDS(__VA_ARGS__)}
+#define CTF_EVENT(id, ...)                                                                         \
+	{                                                                                          \
+		const uint8_t cpu_id = CPU_ID;                                                     \
+		CTF_GATHER_FIELDS(id, cpu_id, ##__VA_ARGS__)                                       \
+	}
 #endif
 
 /* Anonymous compound literal with 1 member. Legal since C99.

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2026 Picoheart Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* CTF 1.8 */
 typealias integer { size = 8; align = 8; signed = true; } := int8_t;
 typealias integer { size = 8; align = 8; signed = false; } := uint8_t;
@@ -20,6 +25,9 @@ trace {
 
 stream {
 	event.header := struct event_header;
+	event.context := struct {
+		uint8_t cpu_id;
+	};
 };
 
 event {


### PR DESCRIPTION
On SMP systems, CTF events from multiple CPUs are interleaved in the same stream, making it impossible to attribute a tracepoint to the CPU that produced it. Add a per-event uint8_t cpu_id that is placed in the CTF event context (between the event header and the event payload) so the binary layout becomes:

  [event header: timestamp, id][event context: cpu_id][event payload]

Under CONFIG_SMP the id is read from arch_curr_cpu()->id; otherwise it is a compile-time 0 so the non-SMP binary layout is unchanged in content (the context field is still present to keep the metadata and parser in sync).

The TSDL metadata gains a matching stream event.context declaration.