### PR TITLE
net: tcp: wake connect() poll waiters when the handshake fails

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1001,7 +1001,7 @@ static int tcp_conn_close(struct tcp *conn, int status)
 		}
 
 		conn->in_connect = false;
-		k_sem_reset(&conn->connect_sem);
+		k_sem_give(&conn->connect_sem);
 	} else if (conn->context->recv_cb) {
 		conn->context->recv_cb(conn->context, NULL, NULL, NULL,
 				       status, conn->recv_user_data);
@@ -3882,7 +3882,7 @@ int net_tcp_put(struct net_context *context, bool force_close)
 		}
 	} else if (conn->in_connect && conn->state != TCP_CLOSED && conn->state != TCP_UNUSED) {
 		conn->in_connect = false;
-		k_sem_reset(&conn->connect_sem);
+		k_sem_give(&conn->connect_sem);
 		tcp_conn_close(conn, -ECONNABORTED);
 	}
 
@@ -4215,8 +4215,11 @@ int net_tcp_connect(struct net_context *context,
 		} else if ((K_TIMEOUT_EQ(timeout, K_NO_WAIT)) && conn->state != TCP_ESTABLISHED) {
 			ret = -EINPROGRESS;
 			goto out;
-		} else if (k_sem_take(&conn->connect_sem, timeout) != 0 &&
-			   conn->state != TCP_ESTABLISHED) {
+		}
+
+		(void)k_sem_take(&conn->connect_sem, timeout);
+
+		if (conn->state != TCP_ESTABLISHED) {
 			if (conn->in_connect) {
 				conn->in_connect = false;
 				tcp_conn_close(conn, -ETIMEDOUT);
@@ -4229,6 +4232,7 @@ int net_tcp_connect(struct net_context *context,
 			}
 			goto out;
 		}
+
 		conn->in_connect = false;
 	}
 


### PR DESCRIPTION
`tests/net/socket/tcp` fails on every platform in `main` ([run 34101337834](https://github.com/zephyrproject-rtos/zephyr/actions/runs/34101337834)): `test_connect_and_wait_for_v4_poll_pollout` trips `poll() should quit before a timeout`.

`tcp_conn_close()` and `net_tcp_put()` reset `connect_sem`, which used to wake both the thread blocked in `net_tcp_connect()` and the `k_poll()` waiter the socket layer registers there for a pending non-blocking connect.

Since a08e6b959764 ("kernel: sem: do not wake pollers on reset") that poll waiter is no longer woken, so a connect refused with RST — or a socket closed mid-handshake — leaves `poll()` and `select()` blocked until their own timeout. Give the semaphore instead, and let `net_tcp_connect()` decide from the connection state rather than the `k_sem_take()` return value.