### PR TITLE
drivers: *: stm32: include arch/cpu.h instead of generic implementation

### DIFF
--- a/drivers/audio/dmic_stm32_dfsdm.c
+++ b/drivers/audio/dmic_stm32_dfsdm.c
@@ -4,7 +4,7 @@
  */
 
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/arch/common/ffs.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/audio/dmic.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>

--- a/drivers/clock_control/clock_stm32_ll_wb0.c
+++ b/drivers/clock_control/clock_stm32_ll_wb0.c
@@ -18,8 +18,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/arch/common/sys_io.h>
-#include <zephyr/arch/common/sys_bitops.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
 /* Driver definitions */

--- a/drivers/clock_control/clock_stm32_ll_wl3.c
+++ b/drivers/clock_control/clock_stm32_ll_wl3.c
@@ -15,8 +15,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/arch/common/sys_io.h>
-#include <zephyr/arch/common/sys_bitops.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/arch/common/ffs.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>
 #include <stm32_bitops.h>

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
-#include <zephyr/arch/common/ffs.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>


### PR DESCRIPTION
Instead of including the header containing the generic implementation of certain arch services, include the top-level `<zephyr/arch/cpu.h>` header which will provide the correct implementation for the target arch. Notably important for `sys_io.h` which has memory barriers on Cortex-A.