### PR TITLE
flash: nrf_rram: Add support for writing into UICR

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -128,4 +128,11 @@ config NRF_RRAM_FILL_SKIP_IF_FILLED
 	  NOTE: Feature does not protect against simultaneous writes to the
 	  scanned area.
 
+config SOC_FLASH_NRF_RRAM_UICR
+	bool "Access to UICR"
+	depends on !TRUSTED_EXECUTION_NONSECURE
+	help
+	  Enable operations on UICR. Once enabled UICR are written or read as
+	  ordinary flash memory. Erase is not supported.
+
 endif # SOC_FLASH_NRF_RRAM

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -14,6 +14,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/barrier.h>
 #include <hal/nrf_rramc.h>
+#include <hal/nrf_common.h>
 
 #include <zephyr/../../drivers/flash/soc_flash_nrf.h>
 #include <soc_secure.h>
@@ -109,6 +110,20 @@ static inline bool is_within_bounds(off_t addr, size_t len, off_t boundary_start
 		(len <= (boundary_start + boundary_size - addr)));
 }
 
+static inline bool is_regular_addr_valid(off_t addr, size_t len)
+{
+	return is_within_bounds(addr, len, 0, RRAM_SIZE);
+}
+
+static inline bool is_uicr_addr_valid(off_t addr, size_t len)
+{
+#ifdef CONFIG_SOC_FLASH_NRF_RRAM_UICR
+	return is_within_bounds(addr, len, (off_t)NRF_UICR, sizeof(NRF_UICR_Type));
+#else
+	return false;
+#endif /* CONFIG_SOC_FLASH_NRF_UICR */
+}
+
 #if WRITE_BUFFER_ENABLE
 static void commit_changes(off_t addr, size_t len)
 {
@@ -159,7 +174,29 @@ static void commit_changes(off_t addr, size_t len)
  */
 static void rram_write(off_t addr, const void *data, uint8_t fill_val, size_t len)
 {
-	if (data) {
+	if (is_uicr_addr_valid(addr, len) && (len % sizeof(uint32_t) == 0)) {
+		const size_t chunk_len = sizeof(uint32_t);
+		uint32_t *uicr_mem = (uint32_t *)addr;
+		uint32_t fill_val_32 = 0;
+
+		/* The UICR memory can be written once, in 32-bit chunks.
+		 * Enforce the writes to be 32-bit long by using direct accesses
+		 * to the memory location instead of using memcpy()/memset().
+		 */
+		memset((void *)&fill_val_32, fill_val, chunk_len);
+
+		while (len > 0) {
+			if (data) {
+				*uicr_mem = *((uint32_t *)data);
+			} else {
+				*uicr_mem = fill_val_32;
+			}
+
+			uicr_mem += 1;
+			data = (const uint8_t *)data + chunk_len;
+			len -= chunk_len;
+		}
+	} else if (data) {
 		memcpy((void *)addr, data, len);
 	} else {
 		memset((void *)addr, fill_val, len);
@@ -274,7 +311,6 @@ __weak void nrf_flash_sync_set_delay(uint32_t delay_us)
 static int nrf_write(off_t addr, const void *data, uint8_t fill_val, size_t len)
 {
 	int ret = 0;
-	addr += RRAM_START;
 
 	if (!len) {
 		return 0;
@@ -409,10 +445,12 @@ static int nrf_rram_read(const struct device *dev, off_t addr, void *data, size_
 {
 	ARG_UNUSED(dev);
 
-	if (!is_within_bounds(addr, len, 0, RRAM_SIZE)) {
+	if (is_regular_addr_valid(addr, len)) {
+		addr += RRAM_START;
+	} else if (!is_uicr_addr_valid(addr, len)) {
+		LOG_ERR("invalid address: 0x%08lx:%zu", (unsigned long)addr, len);
 		return -EINVAL;
 	}
-	addr += RRAM_START;
 
 	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
 		return soc_secure_mem_read(data, (void *)addr, len);
@@ -430,11 +468,28 @@ static int nrf_rram_write(const struct device *dev, off_t addr, const void *data
 		return -EINVAL;
 	}
 
-	if ((addr % WRITE_LINE_SIZE) != 0 || (len % WRITE_LINE_SIZE) != 0) {
-		return -EINVAL;
-	}
+	if (is_regular_addr_valid(addr, len)) {
+		if ((addr % WRITE_LINE_SIZE) != 0 || (len % WRITE_LINE_SIZE) != 0) {
+			return -EINVAL;
+		}
 
-	if (!is_within_bounds(addr, len, 0, RRAM_SIZE)) {
+		addr += RRAM_START;
+#ifdef CONFIG_SOC_FLASH_NRF_RRAM_UICR
+	} else if (is_uicr_addr_valid(addr, len)) {
+		/* UICR accesses must be aligned to 4 bytes. */
+		if ((addr % sizeof(uint32_t)) != 0 || (len % sizeof(uint32_t)) != 0) {
+			return -EINVAL;
+		}
+
+		/* If the UICR is not erased, return an error.
+		 * Otherwise - it will result in bus fault.
+		 */
+		if (*((uint32_t *)addr) != 0xFFFFFFFF) {
+			return -EIO;
+		}
+#endif /* CONFIG_SOC_FLASH_NRF_RRAM_UICR */
+	} else {
+		LOG_ERR("invalid address: 0x%08lx:%zu", (unsigned long)addr, len);
 		return -EINVAL;
 	}
 
@@ -453,9 +508,11 @@ static int nrf_rram_erase(const struct device *dev, off_t addr, size_t len)
 		return -EINVAL;
 	}
 
-	if (!is_within_bounds(addr, len, 0, RRAM_SIZE)) {
+	if (!is_regular_addr_valid(addr, len)) {
 		return -EINVAL;
 	}
+
+	addr += RRAM_START;
 
 	return nrf_rram_fill_impl(addr, ERASE_VALUE, len);
 }
@@ -473,9 +530,11 @@ static int nrf_rram_fill(const struct device *dev, uint8_t val, off_t addr, size
 		return -EINVAL;
 	}
 
-	if (!is_within_bounds(addr, len, 0, RRAM_SIZE)) {
+	if (!is_regular_addr_valid(addr, len)) {
 		return -EINVAL;
 	}
+
+	addr += RRAM_START;
 
 	return nrf_rram_fill_impl(addr, val, len);
 }


### PR DESCRIPTION
Ad support for writing data into UICRs through the nRF RRAM flash driver.