### PR TITLE
drivers: wifi: nrf_wifi: Add radio test shell to driver

### DIFF
--- a/drivers/wifi/nrf_wifi/CMakeLists.txt
+++ b/drivers/wifi/nrf_wifi/CMakeLists.txt
@@ -62,6 +62,15 @@ zephyr_library_sources_ifdef(CONFIG_NRF70_UTIL
   src/wifi_util.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_NRF70_RADIO_TEST_SHELL
+  src/radio_test_shell.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_NRF70_RADIO_TEST_FICR_SHELL
+  src/ficr_prog.c
+  src/radio_test_ficr_shell.c
+)
+
 if(CONFIG_NRF70_UTIL OR CONFIG_NRF70_DEBUG_SHELL)
   zephyr_library_sources(src/shell.c)
 endif()

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -76,6 +76,23 @@ config NRF70_RADIO_TEST
 	  compliance. It provides direct control of the radio hardware
 	  for transmitting test patterns and measuring RF parameters.
 
+config NRF70_RADIO_TEST_SHELL
+	bool "Radio test shell commands"
+	default y
+	depends on NRF70_RADIO_TEST && SHELL
+	help
+	  Register the wifi_radio_test shell command set for nRF70 radio test
+	  mode. Disable to provide a custom shell integration in the application.
+
+config NRF70_RADIO_TEST_FICR_SHELL
+	bool "Radio test FICR/OTP programming shell"
+	default y
+	depends on NRF70_RADIO_TEST_SHELL
+	help
+	  Register the wifi_radio_ficr_prog shell command set for programming
+	  nRF7002 OTP memory. Disable if the application provides its own
+	  integration.
+
 config NRF70_OFFLOADED_RAW_TX
 	bool "Offloaded raw TX mode of the nRF70 driver"
 	help

--- a/drivers/wifi/nrf_wifi/inc/ficr_prog.h
+++ b/drivers/wifi/nrf_wifi/inc/ficr_prog.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Header containing address/offets and functions for writing
+ * the FICR fields of the OTP memory on nRF7002 device
+ */
+
+#ifndef __OTP_PROG_H_
+#define __OTP_PROG_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int write_otp_memory(unsigned int otp_addr, unsigned int *write_val);
+int read_otp_memory(unsigned int otp_addr, unsigned int *read_val, int len);
+unsigned int check_protection(unsigned int *buff, unsigned int off1, unsigned int off2,
+					unsigned int off3, unsigned int off4);
+
+#endif /* __OTP_PROG_H_ */

--- a/drivers/wifi/nrf_wifi/inc/radio_test_shell.h
+++ b/drivers/wifi/nrf_wifi/inc/radio_test_shell.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief nRF70 Wi-Fi radio test shell shared types
+ */
+
+#ifndef NRF_WIFI_RADIO_TEST_SHELL_H__
+#define NRF_WIFI_RADIO_TEST_SHELL_H__
+
+#include <zephyr/kernel.h>
+#include <host_rpu_sys_if.h>
+#include <radio_test/fmac_structs.h>
+#include <zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h>
+
+enum nrf_wifi_frequency_bands {
+	NRF_WIFI_FREQ_BAND_2_4_GHZ = 0,
+	NRF_WIFI_FREQ_BAND_5_GHZ,
+	NRF_WIFI_FREQ_BAND_6_GHZ,
+};
+
+/* RX capture sample and display constants */
+#define RX_CAP_BYTES_PER_SAMPLE 3
+#define SAMPLES_PER_LINE 16
+#define BYTES_PER_SAMPLE RX_CAP_BYTES_PER_SAMPLE
+#define BYTES_PER_LINE (SAMPLES_PER_LINE * BYTES_PER_SAMPLE)
+
+/* 24-bit IQ sample: 12-bit Q (imag), 12-bit I (real), 3 bytes packed. */
+struct rx_cap_iq_sample {
+	uint8_t bytes[RX_CAP_BYTES_PER_SAMPLE];
+} __packed;
+
+struct nrf_wifi_ctx_zep_rt {
+	struct nrf_wifi_fmac_priv *fmac_priv;
+	struct rpu_conf_params conf_params;
+};
+
+#endif /* NRF_WIFI_RADIO_TEST_SHELL_H__ */

--- a/drivers/wifi/nrf_wifi/src/ficr_prog.c
+++ b/drivers/wifi/nrf_wifi/src/ficr_prog.c
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* @file
+ * @brief NRF Wi-Fi radio FICR programming functions
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h>
+
+#include "common/rpu_if.h"
+#include <ficr_prog.h>
+
+LOG_MODULE_DECLARE(otp_prog, CONFIG_WIFI_LOG_LEVEL);
+
+static void write_word(unsigned int addr, unsigned int data)
+{
+	rpu_write(addr, &data, 4);
+}
+
+static void read_word(unsigned int addr, unsigned int *data)
+{
+	rpu_read(addr, data, 4);
+}
+
+unsigned int check_protection(unsigned int *buff, unsigned int off1, unsigned int off2,
+		    unsigned int off3, unsigned int off4)
+{
+	if ((buff[off1] == OTP_PROGRAMMED) &&
+		(buff[off2] == OTP_PROGRAMMED) &&
+		(buff[off3] == OTP_PROGRAMMED) &&
+		(buff[off4] == OTP_PROGRAMMED)) {
+		return OTP_PROGRAMMED;
+	} else if ((buff[off1] == OTP_FRESH_FROM_FAB) &&
+		(buff[off2] == OTP_FRESH_FROM_FAB) &&
+		(buff[off3] == OTP_FRESH_FROM_FAB) &&
+		(buff[off4] == OTP_FRESH_FROM_FAB)) {
+		return OTP_FRESH_FROM_FAB;
+	} else if ((buff[off1] == OTP_ENABLE_PATTERN) &&
+		(buff[off2] == OTP_ENABLE_PATTERN) &&
+		(buff[off3] == OTP_ENABLE_PATTERN) &&
+		(buff[off4] == OTP_ENABLE_PATTERN)) {
+		return OTP_ENABLE_PATTERN;
+	} else {
+		return OTP_INVALID;
+	}
+}
+
+static void set_otp_timing_reg_40mhz(void)
+{
+	write_word(OTP_TIMING_REG1_ADDR, OTP_TIMING_REG1_VAL);
+	write_word(OTP_TIMING_REG2_ADDR, OTP_TIMING_REG2_VAL);
+}
+
+static int poll_otp_ready(void)
+{
+	int otp_mem_status = 0;
+	int poll = 0;
+
+	while (poll != 100) {
+		read_word(OTP_POLL_ADDR, &otp_mem_status);
+
+		if ((otp_mem_status & OTP_READY) == OTP_READY) {
+			return 0;
+		}
+		poll++;
+	}
+	LOG_ERR("OTP is not ready");
+	return -ENOEXEC;
+}
+
+static int req_otp_standby_mode(void)
+{
+	write_word(OTP_RWSBMODE_ADDR, 0x0);
+	return poll_otp_ready();
+}
+
+static int otp_wr_voltage_2v5(void)
+{
+	int err;
+
+	err = req_otp_standby_mode();
+	if (err) {
+		LOG_ERR("Failed Setting OTP voltage IOVDD to 2.5V");
+		return -ENOEXEC;
+	}
+	write_word(OTP_VOLTCTRL_ADDR, OTP_VOLTCTRL_2V5);
+	return 0;
+}
+
+static int poll_otp_read_valid(void)
+{
+	int otp_mem_status = 0;
+	int poll = 0;
+
+	while (poll < 100) {
+		read_word(OTP_POLL_ADDR, &otp_mem_status);
+
+		if ((otp_mem_status & OTP_READ_VALID) == OTP_READ_VALID) {
+			return 0;
+		}
+		poll++;
+	}
+	LOG_ERR("%s: OTP read failed", __func__);
+	return -ENOEXEC;
+}
+
+static int poll_otp_wrdone(void)
+{
+	int otp_mem_status = 0;
+	int poll = 0;
+
+	while (poll < 100) {
+		read_word(OTP_POLL_ADDR, &otp_mem_status);
+
+		if ((otp_mem_status & OTP_WR_DONE) == OTP_WR_DONE) {
+			return 0;
+		}
+		poll++;
+	}
+	LOG_ERR("%s: OTP write done failed", __func__);
+	return -ENOEXEC;
+}
+
+static int req_otp_read_mode(void)
+{
+	write_word(OTP_RWSBMODE_ADDR, OTP_READ_MODE);
+	return poll_otp_ready();
+}
+
+static int req_otp_byte_write_mode(void)
+{
+	write_word(OTP_RWSBMODE_ADDR, OTP_BYTE_WRITE_MODE);
+	return poll_otp_ready();
+}
+
+static unsigned int read_otp_location(unsigned int offset, unsigned int *read_val)
+{
+	int err;
+
+	write_word(OTP_RDENABLE_ADDR, offset);
+	err = poll_otp_read_valid();
+	if (err) {
+		LOG_ERR("OTP read failed");
+		return err;
+	}
+	read_word(OTP_READREG_ADDR, read_val);
+
+	return 0;
+}
+
+static int write_otp_location(unsigned int otp_location_offset, unsigned int otp_data)
+{
+	write_word(OTP_WRENABLE_ADDR, otp_location_offset);
+	write_word(OTP_WRITEREG_ADDR, otp_data);
+
+	return poll_otp_wrdone();
+}
+
+static int otp_rd_voltage_1v8(void)
+{
+	int err;
+
+	err = req_otp_standby_mode();
+	if (err) {
+		LOG_ERR("error in %s", __func__);
+		return err;
+	}
+	write_word(OTP_VOLTCTRL_ADDR, OTP_VOLTCTRL_1V8);
+
+	return 0;
+}
+
+static int update_mac_addr(unsigned int index, unsigned int *write_val)
+{
+	int ret;
+
+	for (int i = 0; i < 2; i++) {
+		ret = write_otp_location(MAC0_ADDR + 2 * index + i, write_val[i]);
+		if (ret == -ENOEXEC) {
+			LOG_ERR("FICR: Failed to update MAC ADDR%d", index);
+			break;
+		}
+		LOG_INF("mac addr %d : Reg%d (0x%x) = 0x%04x",
+					index, (i+1), (MAC0_ADDR + i) << 2, write_val[i]);
+	}
+	return ret;
+}
+
+int write_otp_memory(unsigned int otp_addr, unsigned int *write_val)
+{
+	int err = 0;
+	int mask_val;
+	int ret = 0;
+	int retrim_loc = 0;
+
+	err = poll_otp_ready();
+	if (err) {
+		LOG_ERR("err in otp ready poll");
+		return err;
+	}
+
+	set_otp_timing_reg_40mhz();
+
+	err = otp_wr_voltage_2v5();
+	if (err) {
+		LOG_ERR("error in write_voltage 2v5");
+		goto _exit_otp_write;
+	}
+
+	err = req_otp_byte_write_mode();
+	if (err) {
+		LOG_ERR("error in OTP byte write mode");
+		goto _exit_otp_write;
+	}
+
+	switch (otp_addr) {
+	case REGION_PROTECT:
+		write_otp_location(REGION_PROTECT, write_val[0]);
+		write_otp_location(REGION_PROTECT+1, write_val[0]);
+		write_otp_location(REGION_PROTECT+2, write_val[0]);
+		write_otp_location(REGION_PROTECT+3, write_val[0]);
+
+		LOG_INF("Written REGION_PROTECT0 (0x%x) : 0x%04x",
+						(REGION_PROTECT << 2), write_val[0]);
+		LOG_INF("Written REGION_PROTECT1 (0x%x) : 0x%04x",
+						(REGION_PROTECT+1) << 2, write_val[0]);
+		LOG_INF("Written REGION_PROTECT2 (0x%x) : 0x%04x",
+						(REGION_PROTECT+2) << 2, write_val[0]);
+		LOG_INF("Written REGION_PROTECT3 (0x%x) : 0x%04x",
+						(REGION_PROTECT+3) << 2, write_val[0]);
+		break;
+	case QSPI_KEY:
+		mask_val = QSPI_KEY_FLAG_MASK;
+		for (int i = 0; i < QSPI_KEY_LENGTH_BYTES / 4; i++) {
+			ret = write_otp_location(QSPI_KEY + i, write_val[i]);
+			if (ret == -ENOEXEC) {
+				LOG_ERR("FICR: Failed to write QSPI key offset-%d", QSPI_KEY + i);
+				goto _exit_otp_write;
+			}
+			LOG_INF("Written QSPI_KEY0 (0x%x) : 0x%04x",
+						(QSPI_KEY + i) << 2, write_val[i]);
+		}
+		write_otp_location(REGION_DEFAULTS, mask_val);
+		LOG_INF("Written REGION_DEFAULTS (0x%x) : 0x%04x",
+						(REGION_DEFAULTS) << 2, mask_val);
+		break;
+	case MAC0_ADDR:
+		mask_val = MAC0_ADDR_FLAG_MASK;
+		ret = update_mac_addr(0, write_val);
+		if (ret == -ENOEXEC) {
+			goto _exit_otp_write;
+		}
+
+		write_otp_location(REGION_DEFAULTS, mask_val);
+		LOG_INF("Written MAC address 0");
+		LOG_INF("Written REGION_DEFAULTS (0x%x) : 0x%04x",
+						(REGION_DEFAULTS) << 2, mask_val);
+		break;
+	case MAC1_ADDR:
+		mask_val = MAC1_ADDR_FLAG_MASK;
+		ret = update_mac_addr(1, write_val);
+		if (ret == -ENOEXEC) {
+			goto _exit_otp_write;
+		}
+		write_otp_location(REGION_DEFAULTS, mask_val);
+		LOG_INF("Written MAC address 1");
+		LOG_INF("Written REGION_DEFAULTS (0x%x) : 0x%04x",
+						(REGION_DEFAULTS) << 2, mask_val);
+		break;
+	case CALIB_XO:
+		mask_val = CALIB_XO_FLAG_MASK;
+		ret = write_otp_location(CALIB_XO, write_val[0]);
+
+		if (ret == -ENOEXEC) {
+			LOG_ERR("XO_Update Exception");
+			goto _exit_otp_write;
+		} else {
+			write_otp_location(REGION_DEFAULTS, mask_val);
+
+			LOG_INF("Written CALIB_XO (0x%x) to 0x%04x",
+						CALIB_XO << 2, write_val[0]);
+			LOG_INF("Written REGION_DEFAULTS (0x%x) : 0x%04x",
+						(REGION_DEFAULTS) << 2, mask_val);
+		}
+		break;
+	case PRODRETEST_PROGVERSION:
+		ret = write_otp_location(PRODRETEST_PROGVERSION, *write_val);
+
+		if (ret == -ENOEXEC) {
+			LOG_ERR("PRODRETEST.PROGVERSION_Update Exception");
+			goto _exit_otp_write;
+		} else {
+			LOG_INF("Written PRODRETEST.PROGVERSION 0x%04x", *write_val);
+		}
+		break;
+	case PRODRETEST_TRIM0:
+	case PRODRETEST_TRIM1:
+	case PRODRETEST_TRIM2:
+	case PRODRETEST_TRIM3:
+	case PRODRETEST_TRIM4:
+	case PRODRETEST_TRIM5:
+	case PRODRETEST_TRIM6:
+	case PRODRETEST_TRIM7:
+	case PRODRETEST_TRIM8:
+	case PRODRETEST_TRIM9:
+	case PRODRETEST_TRIM10:
+	case PRODRETEST_TRIM11:
+	case PRODRETEST_TRIM12:
+	case PRODRETEST_TRIM13:
+	case PRODRETEST_TRIM14:
+		retrim_loc = otp_addr - PRODRETEST_TRIM0;
+		ret = write_otp_location(otp_addr, *write_val);
+
+		if (ret == -ENOEXEC) {
+			LOG_ERR("PRODRETEST.TRIM_Update Exception");
+			goto _exit_otp_write;
+		} else {
+			LOG_INF("Written PRODRETEST.TRIM%d 0x%04x",
+						retrim_loc, *write_val);
+		}
+		break;
+	case REGION_DEFAULTS:
+		write_otp_location(REGION_DEFAULTS, write_val[0]);
+
+		LOG_INF("Written REGION_DEFAULTS (0x%x) to 0x%04x",
+						REGION_DEFAULTS << 2, write_val[0]);
+		break;
+	default:
+		LOG_ERR("unknown field received: %d", otp_addr);
+
+	}
+	return ret;
+
+_exit_otp_write:
+	err = req_otp_standby_mode();
+	err |= otp_rd_voltage_1v8();
+	return err;
+}
+
+int read_otp_memory(unsigned int otp_addr, unsigned int *read_val, int len)
+{
+	int err;
+
+	err = poll_otp_ready();
+	if (err) {
+		LOG_ERR("err in otp ready poll");
+		return -ENOEXEC;
+	}
+
+	set_otp_timing_reg_40mhz();
+
+	err = otp_rd_voltage_1v8();
+	if (err) {
+		LOG_ERR("error in read_voltage 1v8");
+		return -ENOEXEC;
+	}
+
+	err = req_otp_read_mode();
+	if (err) {
+		LOG_ERR("error in req_otp_read_mode()");
+		return -ENOEXEC;
+	}
+
+	for (int i = 0; i < len; i++) {
+		read_otp_location(otp_addr + i, &read_val[i]);
+	}
+
+	return req_otp_standby_mode();
+}

--- a/drivers/wifi/nrf_wifi/src/radio_test_ficr_shell.c
+++ b/drivers/wifi/nrf_wifi/src/radio_test_ficr_shell.c
@@ -1,0 +1,537 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* @file
+ * @brief nRF70 Wi-Fi radio test FICR/OTP programming shell
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+#include <fmac_main.h>
+#include <util.h>
+#include <ficr_prog.h>
+
+#include "common/fmac_api_common.h"
+
+extern struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
+static struct nrf_wifi_ctx_zep *ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
+
+LOG_MODULE_REGISTER(otp_prog, CONFIG_WIFI_LOG_LEVEL);
+
+static void disp_location_status(const struct shell *sh, char *region, unsigned int ret)
+{
+	switch (ret) {
+
+	case OTP_PROGRAMMED:
+		shell_fprintf(sh, SHELL_INFO, "%s Region is locked!!!\n", region);
+		break;
+	case OTP_ENABLE_PATTERN:
+		shell_fprintf(sh, SHELL_INFO, "%s Region is open for R/W\n", region);
+		break;
+	case OTP_FRESH_FROM_FAB:
+		shell_fprintf(sh, SHELL_INFO,
+				"%s Region is unprogrammed - program to enable R/W\n", region);
+		break;
+	default:
+		shell_fprintf(sh, SHELL_ERROR, "%s Region is in invalid state\n", region);
+		break;
+	}
+	shell_fprintf(sh, SHELL_INFO, "\n");
+}
+
+static void disp_fields_status(const struct shell *sh, unsigned int flags)
+{
+	if (flags & (~QSPI_KEY_FLAG_MASK)) {
+		shell_fprintf(sh, SHELL_INFO, "QSPI Keys are not programmed in OTP\n");
+	} else {
+		shell_fprintf(sh, SHELL_INFO, "QSPI Keys are programmed in OTP\n");
+	}
+
+	if (flags & (~MAC0_ADDR_FLAG_MASK)) {
+		shell_fprintf(sh, SHELL_INFO, "MAC0 Address are not programmed in OTP\n");
+	} else {
+		shell_fprintf(sh, SHELL_INFO, "MAC0 Address is programmed in OTP\n");
+	}
+
+	if (flags & (~MAC1_ADDR_FLAG_MASK)) {
+		shell_fprintf(sh, SHELL_INFO, "MAC1 Address are not programmed in OTP\n");
+	} else {
+		shell_fprintf(sh, SHELL_INFO, "MAC1 Address is programmed in OTP\n");
+	}
+
+	if (flags & (~CALIB_XO_FLAG_MASK)) {
+		shell_fprintf(sh, SHELL_INFO, "CALIB_XO is not programmed in OTP\n");
+	} else {
+		shell_fprintf(sh, SHELL_INFO, "CALIB_XO is programmed in OTP\n");
+	}
+}
+
+
+static int nrf_wifi_radio_test_otp_get_status(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int ret, err;
+	unsigned int val[OTP_MAX_WORD_LEN];
+
+	/* read all the OTP memory */
+	err = read_otp_memory(0, &val[0], OTP_MAX_WORD_LEN);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_INFO, "Checking OTP PROTECT Region......\n");
+	ret = check_protection(&val[0], REGION_PROTECT, REGION_PROTECT + 1,
+							REGION_PROTECT + 2, REGION_PROTECT + 3);
+
+	disp_location_status(sh, "OTP", ret);
+	disp_fields_status(sh, val[REGION_DEFAULTS]);
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_read_params(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int val[OTP_MAX_WORD_LEN];
+	unsigned int ret, err;
+
+	err = read_otp_memory(0, &val[0], OTP_MAX_WORD_LEN);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	ret = check_protection(&val[0], REGION_PROTECT + 0, REGION_PROTECT + 1,
+							REGION_PROTECT + 2, REGION_PROTECT + 3);
+	disp_location_status(sh, "OTP", ret);
+
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.FT.PROGVERSION = 0x%08x\n",
+		val[PRODTEST_FT_PROGVERSION]);
+	shell_fprintf(sh, SHELL_INFO, "\n");
+
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM0 = 0x%08x\n", val[PRODTEST_TRIM0]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM1 = 0x%08x\n", val[PRODTEST_TRIM1]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM2 = 0x%08x\n", val[PRODTEST_TRIM2]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM3 = 0x%08x\n", val[PRODTEST_TRIM3]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM4 = 0x%08x\n", val[PRODTEST_TRIM4]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM5 = 0x%08x\n", val[PRODTEST_TRIM5]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM6 = 0x%08x\n", val[PRODTEST_TRIM6]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM7 = 0x%08x\n", val[PRODTEST_TRIM7]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM8 = 0x%08x\n", val[PRODTEST_TRIM8]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM9 = 0x%08x\n", val[PRODTEST_TRIM9]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM10 = 0x%08x\n",
+		val[PRODTEST_TRIM10]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM11 = 0x%08x\n",
+		val[PRODTEST_TRIM11]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM12 = 0x%08x\n",
+		val[PRODTEST_TRIM12]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM13 = 0x%08x\n",
+		val[PRODTEST_TRIM13]);
+	shell_fprintf(sh, SHELL_INFO, "PRODTEST.TRIM14 = 0x%08x\n",
+		val[PRODTEST_TRIM14]);
+	shell_fprintf(sh, SHELL_INFO, "\n");
+
+	shell_fprintf(sh, SHELL_INFO, "INFO.PART = 0x%08x\n", val[INFO_PART]);
+	shell_fprintf(sh, SHELL_INFO, "INFO.VARIANT = 0x%08x\n", val[INFO_VARIANT]);
+	shell_fprintf(sh, SHELL_INFO, "\n");
+
+	shell_fprintf(sh, SHELL_INFO, "INFO.UUID0 = 0x%08x\n", val[INFO_UUID + 0]);
+	shell_fprintf(sh, SHELL_INFO, "INFO.UUID1 = 0x%08x\n", val[INFO_UUID + 1]);
+	shell_fprintf(sh, SHELL_INFO, "INFO.UUID2 = 0x%08x\n", val[INFO_UUID + 2]);
+	shell_fprintf(sh, SHELL_INFO, "INFO.UUID3 = 0x%08x\n", val[INFO_UUID + 3]);
+	shell_fprintf(sh, SHELL_INFO, "\n");
+
+	shell_fprintf(sh, SHELL_INFO, "REGION.PROTECT0 = 0x%08x\n", val[REGION_PROTECT + 0]);
+	shell_fprintf(sh, SHELL_INFO, "REGION.PROTECT1 = 0x%08x\n", val[REGION_PROTECT + 1]);
+	shell_fprintf(sh, SHELL_INFO, "REGION.PROTECT2 = 0x%08x\n", val[REGION_PROTECT + 2]);
+	shell_fprintf(sh, SHELL_INFO, "REGION.PROTECT3 = 0x%08x\n", val[REGION_PROTECT + 3]);
+	shell_fprintf(sh, SHELL_INFO, "\n");
+
+	if (val[REGION_PROTECT + 0] != OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_INFO, "MAC0.ADDRESS0 = 0x%08x\n", val[MAC0_ADDR]);
+		shell_fprintf(sh, SHELL_INFO, "MAC0.ADDRESS1 = 0x%08x\n", val[MAC0_ADDR + 1]);
+		shell_fprintf(sh, SHELL_INFO, "MAC0.ADDRESS = %02x:%02x:%02x:%02x:%02x:%02x\n",
+			(uint8_t)(val[MAC0_ADDR]), (uint8_t)(val[MAC0_ADDR] >> 8),
+			(uint8_t)(val[MAC0_ADDR] >> 16), (uint8_t)(val[MAC0_ADDR] >> 24),
+			(uint8_t)(val[MAC0_ADDR + 1]), (uint8_t)(val[MAC0_ADDR + 1] >> 8));
+		shell_fprintf(sh, SHELL_INFO, "\n");
+
+		shell_fprintf(sh, SHELL_INFO, "MAC1.ADDRESS0 = 0x%08x\n", val[MAC1_ADDR]);
+		shell_fprintf(sh, SHELL_INFO, "MAC1.ADDRESS1 = 0x%08x\n", val[MAC1_ADDR + 1]);
+		shell_fprintf(sh, SHELL_INFO, "MAC1.ADDRESS = %02x:%02x:%02x:%02x:%02x:%02x\n",
+			(uint8_t)(val[MAC1_ADDR]), (uint8_t)(val[MAC1_ADDR] >> 8),
+			(uint8_t)(val[MAC1_ADDR] >> 16), (uint8_t)(val[MAC1_ADDR] >> 24),
+			(uint8_t)(val[MAC1_ADDR + 1]), (uint8_t)(val[MAC1_ADDR + 1] >> 8));
+		shell_fprintf(sh, SHELL_INFO, "\n");
+
+		shell_fprintf(sh, SHELL_INFO, "CALIB.XO = 0x%02x\n", val[CALIB_XO] & 0xFF);
+
+		shell_fprintf(sh, SHELL_INFO, "REGION_DEFAULTS = 0x%08x\n",
+			val[REGION_DEFAULTS]);
+		shell_fprintf(sh, SHELL_INFO, "\n");
+	}
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_read_retrim_version(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int val[1];
+	unsigned int err;
+
+	err = read_otp_memory(REGION_PROTECT, &val[0], 1);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	if (val[0] == OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_ERROR,
+				"Region is unprogrammed - program to enable R/W\n");
+	} else {
+		err = read_otp_memory(PRODRETEST_PROGVERSION, &val[0], 1);
+		if (err) {
+			shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+			return -ENOEXEC;
+		}
+		shell_fprintf(sh, SHELL_INFO, "\nPRODRETEST.PROGVERSION = 0x%08x\n",
+		val[0]);
+		shell_fprintf(sh, SHELL_INFO, "\n");
+	}
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_read_retrim_params(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int val[RETRIM_LEN];
+	unsigned int err;
+
+	err = read_otp_memory(REGION_PROTECT, val, 1);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	if (val[0] == OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_ERROR,
+				"Region is unprogrammed - program to enable R/W\n");
+	} else {
+		shell_fprintf(sh, SHELL_INFO, "\n");
+		err = read_otp_memory(PRODRETEST_TRIM0, val, RETRIM_LEN);
+		if (err) {
+			shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+			return -ENOEXEC;
+		}
+		for (int i = 0; i < RETRIM_LEN; i++) {
+			shell_fprintf(sh, SHELL_INFO, "PRODRETEST.TRIM%d = 0x%08x\n", i, val[i]);
+		}
+		shell_fprintf(sh, SHELL_INFO, "\n");
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_write_params(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int field;
+	unsigned int write_val[20];
+	unsigned int val[OTP_MAX_WORD_LEN];
+	unsigned int ret, err;
+	int status = 0;
+
+	if (argc < 2) {
+		shell_fprintf(sh, SHELL_ERROR, "invalid # of args : %d\n", argc);
+		return -ENOEXEC;
+	}
+
+	field = strtoul(argv[1], NULL, 0);
+	/* Align to 32-bit word address */
+	field >>= 2;
+
+	if (field < REGION_PROTECT) {
+		shell_fprintf(sh, SHELL_ERROR, "INVALID Address 0x%x......\n", field << 2);
+		return -ENOEXEC;
+	}
+
+	if ((field >= PRODRETEST_PROGVERSION) && (field <= PRODRETEST_TRIM14)) {
+		shell_fprintf(sh, SHELL_ERROR, "INVALID Address 0x%x......\n", field << 2);
+		return -ENOEXEC;
+	}
+
+	err = read_otp_memory(REGION_PROTECT, &val[REGION_PROTECT], 4);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	ret = check_protection(&val[0], REGION_PROTECT, REGION_PROTECT + 1,
+						REGION_PROTECT + 2, REGION_PROTECT + 3);
+	disp_location_status(sh, "OTP", ret);
+	if (ret != OTP_ENABLE_PATTERN && ret != OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_ERROR, "USER Region is not Writeable\n");
+		return -ENOEXEC;
+	}
+
+	switch (field) {
+	case REGION_PROTECT:
+		if (argc != 3) {
+			shell_fprintf(sh, SHELL_ERROR,
+					"invalid # of args for REGION_PROTECT (expected 3) : %d\n",
+					argc);
+			return -ENOEXEC;
+		}
+		write_val[0] = strtoul(argv[2], NULL, 0);
+		/* All consecutive 4 words of the REGION_PROTECT are written */
+		status = write_otp_memory(REGION_PROTECT, &write_val[0]);
+		break;
+	case MAC0_ADDR:
+	case MAC1_ADDR: {
+		struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = ctx->rpu_ctx;
+
+		if (!fmac_dev_ctx) {
+			shell_fprintf(sh, SHELL_ERROR, "Driver not initialized\n");
+			return -ENOEXEC;
+		}
+
+		if (argc != 4) {
+			shell_fprintf(sh, SHELL_ERROR,
+				   "invalid # of args for MAC ADDR write (expected 4) : %d\n",
+					argc);
+			return -ENOEXEC;
+		}
+		write_val[0] = strtoul(argv[2], NULL, 0);
+		write_val[1] = strtoul(argv[3], NULL, 0) & 0xFFFF;
+
+		if (!nrf_wifi_utils_is_mac_addr_valid((const char *)&write_val[0])) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid MAC address. MAC address cannot be all 0's, broadcast or multicast address\n");
+			return -ENOEXEC;
+		}
+
+		status = write_otp_memory(field, &write_val[0]);
+		break;
+	}
+	case CALIB_XO:
+	case REGION_DEFAULTS:
+		if (argc != 3) {
+			shell_fprintf(sh, SHELL_ERROR,
+			  "invalid # of args for field %d (expected 3) : %d\n", field, argc);
+			return -ENOEXEC;
+		}
+		write_val[0] = strtoul(argv[2], NULL, 0);
+		status = write_otp_memory(field, &write_val[0]);
+		break;
+	case QSPI_KEY:
+		if (argc != 6) {
+			shell_fprintf(sh, SHELL_ERROR,
+					"invalid # of args for QSPI_KEY (expected 6) : %d\n", argc);
+			return -ENOEXEC;
+		}
+		write_val[0] = strtoul(argv[2], NULL, 0);
+		write_val[1] = strtoul(argv[3], NULL, 0);
+		write_val[2] = strtoul(argv[4], NULL, 0);
+		write_val[3] = strtoul(argv[5], NULL, 0);
+		/* All consecutive 4 words of the qspi keys are written now */
+		status = write_otp_memory(QSPI_KEY, &write_val[0]);
+		break;
+	default:
+		shell_fprintf(sh, SHELL_ERROR, "unsupported field %d\n", field);
+		return -ENOEXEC;
+	}
+
+	if (!status) {
+		shell_fprintf(sh, SHELL_INFO, "Finished Writing OTP params\n");
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_write_retrim_version(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int field;
+	unsigned int write_val;
+	unsigned int val[OTP_MAX_WORD_LEN];
+	unsigned int ret, err;
+	int status = 0;
+
+	field = PRODRETEST_PROGVERSION;
+
+	if (argc != 2) {
+		shell_fprintf(sh, SHELL_ERROR,
+		  "invalid # of args for field %d (expected 2) : %d\n", field, argc);
+		return -ENOEXEC;
+	}
+
+	err = read_otp_memory(REGION_PROTECT, &val[REGION_PROTECT], 4);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	ret = check_protection(&val[0], REGION_PROTECT, REGION_PROTECT + 1,
+						REGION_PROTECT + 2, REGION_PROTECT + 3);
+	disp_location_status(sh, "OTP", ret);
+	if (ret != OTP_ENABLE_PATTERN && ret != OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_ERROR, "USER Region is not Writeable\n");
+		return -ENOEXEC;
+	}
+
+	write_val = strtoul(argv[1], NULL, 0);
+	status = write_otp_memory(field, &write_val);
+
+	if (!status) {
+		shell_fprintf(sh, SHELL_INFO, "Finished Writing Retrim version\n");
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_otp_write_retrim_params(const struct shell *sh,
+					size_t argc,
+					char *argv[])
+{
+	unsigned int index;
+	unsigned int field;
+	unsigned int write_val;
+	unsigned int val[OTP_MAX_WORD_LEN];
+	unsigned int ret, err;
+	int status = 0;
+
+	index = strtoul(argv[1], NULL, 0);
+	field = index+PRODRETEST_TRIM0;
+
+	if ((field < PRODRETEST_TRIM0) || (field > PRODRETEST_TRIM14)) {
+		shell_fprintf(sh, SHELL_ERROR, "INVALID Index %d......\n", index);
+		return -ENOEXEC;
+	}
+
+	err = read_otp_memory(REGION_PROTECT, &val[REGION_PROTECT], 4);
+	if (err) {
+		shell_fprintf(sh, SHELL_ERROR, "FAILED reading otp memory......\n");
+		return -ENOEXEC;
+	}
+
+	ret = check_protection(&val[0], REGION_PROTECT, REGION_PROTECT + 1,
+						REGION_PROTECT + 2, REGION_PROTECT + 3);
+	disp_location_status(sh, "OTP", ret);
+	if (ret != OTP_ENABLE_PATTERN && ret != OTP_FRESH_FROM_FAB) {
+		shell_fprintf(sh, SHELL_ERROR, "USER Region is not Writeable\n");
+		return -ENOEXEC;
+	}
+
+	switch (field) {
+	case PRODRETEST_TRIM0:
+	case PRODRETEST_TRIM1:
+	case PRODRETEST_TRIM2:
+	case PRODRETEST_TRIM3:
+	case PRODRETEST_TRIM4:
+	case PRODRETEST_TRIM5:
+	case PRODRETEST_TRIM6:
+	case PRODRETEST_TRIM7:
+	case PRODRETEST_TRIM8:
+	case PRODRETEST_TRIM9:
+	case PRODRETEST_TRIM10:
+	case PRODRETEST_TRIM11:
+	case PRODRETEST_TRIM12:
+	case PRODRETEST_TRIM13:
+	case PRODRETEST_TRIM14:
+		if (argc != 3) {
+			shell_fprintf(sh, SHELL_ERROR,
+				"invalid # of args for field %d (expected 3) : %d\n", field, argc);
+			return -ENOEXEC;
+		}
+		write_val = strtoul(argv[2], NULL, 0);
+		status = write_otp_memory(field, &write_val);
+		break;
+	default:
+		shell_fprintf(sh, SHELL_ERROR, "unsupported field %d\n", field);
+		return -ENOEXEC;
+	}
+
+	if (!status) {
+		shell_fprintf(sh, SHELL_INFO, "Finished Writing Retrim param\n");
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	nrf_wifi_radio_otp_subcmds,
+	SHELL_CMD_ARG(otp_get_status,
+			  NULL,
+			  "Read OTP status",
+			  nrf_wifi_radio_test_otp_get_status,
+			  1,
+			  0),
+	SHELL_CMD_ARG(otp_read_params,
+			  NULL,
+			  "Read User region status and information on programmed fields",
+			  nrf_wifi_radio_test_otp_read_params,
+			  1,
+			  0),
+	SHELL_CMD_ARG(otp_read_retrim_version,
+			  NULL,
+			  "Read Retrim Version",
+			  nrf_wifi_radio_test_otp_read_retrim_version,
+			  1,
+			  0),
+	SHELL_CMD_ARG(otp_read_retrim_params,
+			  NULL,
+			  "Read Retrim Params",
+			  nrf_wifi_radio_test_otp_read_retrim_params,
+			  1,
+			  0),
+	SHELL_CMD_ARG(otp_write_params,
+			  NULL,
+			  "Write OTP Params\n"
+			  "otp_write_params <addr offset> [arg1] [arg2]...[argN]",
+			  nrf_wifi_radio_test_otp_write_params,
+			  2,
+			  16),
+	SHELL_CMD_ARG(otp_write_retrim_version,
+			  NULL,
+			  "Write OTP Retrim Version\n"
+			  "otp_write_retrim_version <retrim version>",
+			  nrf_wifi_radio_test_otp_write_retrim_version,
+			  2,
+			  0),
+	SHELL_CMD_ARG(otp_write_retrim_params,
+			  NULL,
+			  "Write OTP Retrim Params\n"
+			  "otp_write_params <retrim index> [retrim data]",
+			  nrf_wifi_radio_test_otp_write_retrim_params,
+			  3,
+			  0),
+	SHELL_SUBCMD_SET_END);
+
+
+SHELL_CMD_REGISTER(wifi_radio_ficr_prog,
+		   &nrf_wifi_radio_otp_subcmds,
+		   "nRF Wi-Fi radio FICR commands",
+		   NULL);
+
+
+static int nrf_wifi_radio_otp_shell_init(void)
+{
+
+	return 0;
+}
+
+
+SYS_INIT(nrf_wifi_radio_otp_shell_init,
+	 APPLICATION,
+	 CONFIG_APPLICATION_INIT_PRIORITY);

--- a/drivers/wifi/nrf_wifi/src/radio_test_shell.c
+++ b/drivers/wifi/nrf_wifi/src/radio_test_shell.c
@@ -1,0 +1,2733 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* @file
+ * @brief nRF70 Wi-Fi radio test shell module
+ */
+
+#include <zephyr/kernel.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/init.h>
+#include <ctype.h>
+#include <host_rpu_sys_if.h>
+#include <radio_test/fmac_structs.h>
+#include <zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h>
+#include <radio_test_shell.h>
+#include <fmac_main.h>
+#include <util.h>
+#include <common/fmac_api_common.h>
+
+#if defined(CONFIG_NRF70_SR_COEX)
+#include <coex.h>
+#endif
+
+extern struct nrf_wifi_drv_priv_zep rpu_drv_priv_zep;
+struct nrf_wifi_ctx_zep *ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
+
+#define NRF_WIFI_RADIO_TEST_INIT_TIMEOUT_MS 5000
+#define rt_mem_alloc(size) nrf_wifi_osal_mem_zalloc(size)
+#define rt_mem_free(ptr) nrf_wifi_osal_mem_free(ptr)
+
+static bool check_test_in_prog(const struct shell *sh)
+{
+	if (ctx->conf_params.rx) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Disable RX\n");
+		return false;
+	}
+
+	if (ctx->conf_params.tx) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Disable TX\n");
+		return false;
+	}
+
+	if (ctx->rf_test_run) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Disable RF Test (%d)\n",
+			      ctx->rf_test);
+		return false;
+	}
+	return true;
+}
+
+
+static bool check_valid_data_rate(const struct shell *sh,
+				  unsigned char tput_mode,
+				  unsigned int nss,
+				  int dr)
+{
+	bool is_mcs = dr & 0x80;
+	bool ret = false;
+
+	if (dr == -1) {
+		return true;
+	}
+
+	if (is_mcs) {
+		dr = dr & 0x7F;
+
+		if (tput_mode & RPU_TPUT_MODE_HT) {
+			if (nss == 2) {
+				if ((dr >= 8) && (dr <= 15)) {
+					ret = true;
+				} else {
+					shell_fprintf(sh,
+						      SHELL_ERROR,
+						      "Invalid MIMO HT MCS: %d\n",
+						       dr);
+				}
+			}
+
+			if (nss == 1) {
+				if ((dr >= 0) && (dr <= 7)) {
+					ret = true;
+				} else {
+					shell_fprintf(sh,
+						      SHELL_ERROR,
+						      "Invalid SISO HT MCS: %d\n",
+						      dr);
+				}
+			}
+
+		} else if (tput_mode == RPU_TPUT_MODE_VHT) {
+			if ((dr >= 0 && dr <= 9)) {
+				ret = true;
+			} else {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "Invalid VHT MCS value: %d\n",
+					      dr);
+			}
+		} else if (tput_mode == RPU_TPUT_MODE_HE_SU) {
+			if ((dr >= 0 && dr <= 7)) {
+				ret = true;
+			} else {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "Invalid HE_SU MCS value: %d\n",
+					      dr);
+			}
+		} else if (tput_mode == RPU_TPUT_MODE_HE_ER_SU) {
+			if ((dr >= 0 && dr <= 2)) {
+				ret = true;
+			} else {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "Invalid HE_ER_SU MCS value: %d\n",
+					      dr);
+			}
+		} else {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "%s: Invalid throughput mode: %d\n", __func__,
+				      dr);
+		}
+	} else {
+		if (tput_mode != RPU_TPUT_MODE_LEGACY) {
+			ret = false;
+
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid rate_flags for legacy: %d\n",
+				      dr);
+		}
+
+		if ((dr == 1) ||
+		    (dr == 2) ||
+		    (dr == 55) ||
+		    (dr == 11) ||
+		    (dr == 6) ||
+		    (dr == 9) ||
+		    (dr == 12) ||
+		    (dr == 18) ||
+		    (dr == 24) ||
+		    (dr == 36) ||
+		    (dr == 48) ||
+		    (dr == 54) ||
+		    (dr == -1)) {
+			ret = true;
+		} else {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid Legacy Rate value: %d\n",
+				      dr);
+		}
+	}
+
+	return ret;
+}
+
+
+static bool check_valid_chan_2g(unsigned char chan_num)
+{
+	if ((chan_num >= 1) && (chan_num <= 14)) {
+		return true;
+	}
+
+	return false;
+}
+
+
+#ifndef CONFIG_NRF70_2_4G_ONLY
+static bool check_valid_chan_5g(unsigned char chan_num)
+{
+	if ((chan_num == 32) ||
+	    (chan_num == 36) ||
+	    (chan_num == 40) ||
+	    (chan_num == 44) ||
+	    (chan_num == 48) ||
+	    (chan_num == 52) ||
+	    (chan_num == 56) ||
+	    (chan_num == 60) ||
+	    (chan_num == 64) ||
+	    (chan_num == 68) ||
+	    (chan_num == 96) ||
+	    (chan_num == 100) ||
+	    (chan_num == 104) ||
+	    (chan_num == 108) ||
+	    (chan_num == 112) ||
+	    (chan_num == 116) ||
+	    (chan_num == 120) ||
+	    (chan_num == 124) ||
+	    (chan_num == 128) ||
+	    (chan_num == 132) ||
+	    (chan_num == 136) ||
+	    (chan_num == 140) ||
+	    (chan_num == 144) ||
+	    (chan_num == 149) ||
+	    (chan_num == 153) ||
+	    (chan_num == 157) ||
+	    (chan_num == 159) ||
+	    (chan_num == 161) ||
+	    (chan_num == 163) ||
+	    (chan_num == 165) ||
+	    (chan_num == 167) ||
+	    (chan_num == 169) ||
+	    (chan_num == 171) ||
+	    (chan_num == 173) ||
+	    (chan_num == 175) ||
+	    (chan_num == 177)) {
+		return true;
+	}
+
+	return false;
+}
+
+static bool check_valid_chan_6g(unsigned char chan_num)
+{
+	if ((chan_num == 1) ||
+	    (chan_num == 5) ||
+	    (chan_num == 9) ||
+	    (chan_num == 13) ||
+	    (chan_num == 17) ||
+	    (chan_num == 21) ||
+	    (chan_num == 25) ||
+	    (chan_num == 29) ||
+	    (chan_num == 33) ||
+	    (chan_num == 37) ||
+	    (chan_num == 41) ||
+	    (chan_num == 45) ||
+	    (chan_num == 49) ||
+	    (chan_num == 53) ||
+	    (chan_num == 57) ||
+	    (chan_num == 61) ||
+	    (chan_num == 65) ||
+	    (chan_num == 69) ||
+	    (chan_num == 73) ||
+	    (chan_num == 77) ||
+	    (chan_num == 81) ||
+	    (chan_num == 85) ||
+	    (chan_num == 89) ||
+	    (chan_num == 93)) {
+		return true;
+	}
+
+	return false;
+}
+#endif /* CONFIG_NRF70_2_4G_ONLY */
+
+static int check_channel_settings(const struct shell *sh,
+				  unsigned char tput_mode,
+				  struct chan_params *chan)
+{
+	if (tput_mode == RPU_TPUT_MODE_LEGACY) {
+		if (chan->bw != RPU_CH_BW_20) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid bandwidth setting for legacy channel = %d\n",
+				      chan->primary_num);
+			return -1;
+		}
+	} else if (tput_mode == RPU_TPUT_MODE_HT) {
+		if (chan->bw != RPU_CH_BW_20) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid bandwidth setting for HT channel = %d\n",
+				      chan->primary_num);
+			return -1;
+		}
+	} else if (tput_mode == RPU_TPUT_MODE_VHT) {
+		if ((chan->primary_num >= 1) &&
+		    (chan->primary_num <= 14)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "VHT setting not allowed in 2.4GHz band\n");
+			return -1;
+		}
+
+		if (chan->bw != RPU_CH_BW_20) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid bandwidth setting for VHT channel = %d\n",
+				      chan->primary_num);
+			return -1;
+		}
+	} else if ((tput_mode == RPU_TPUT_MODE_HE_SU) ||
+		   (tput_mode == RPU_TPUT_MODE_HE_TB) ||
+		   (tput_mode == RPU_TPUT_MODE_HE_ER_SU)) {
+		if (chan->bw != RPU_CH_BW_20) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid bandwidth setting for HE channel = %d\n",
+				      chan->primary_num);
+			return -1;
+		}
+	} else {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid throughput mode = %d\n",
+			      tput_mode);
+		return -1;
+	}
+
+	return 0;
+}
+
+
+enum nrf_wifi_status nrf_wifi_radio_test_conf_init(struct rpu_conf_params *conf_params)
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	unsigned char country_code[NRF_WIFI_COUNTRY_CODE_LEN] = {0};
+
+	/* Check and save regulatory country code currently set */
+	if (conf_params->country_code[0] != '\0') {
+		memcpy(country_code,
+		       conf_params->country_code,
+		       NRF_WIFI_COUNTRY_CODE_LEN);
+	}
+
+	memset(conf_params,
+	       0,
+	       sizeof(*conf_params));
+
+	/* Initialize values which are other than 0 */
+	conf_params->op_mode = RPU_OP_MODE_RADIO_TEST;
+
+	status = nrf_wifi_rt_fmac_rf_params_get(
+			ctx->rpu_ctx,
+			(struct nrf_wifi_phy_rf_params *)conf_params->rf_params);
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		goto out;
+	}
+
+	conf_params->tx_pkt_nss = 1;
+	conf_params->tx_pkt_gap_us = 0;
+
+	conf_params->tx_power = MAX_TX_PWR_SYS_TEST;
+
+	conf_params->chan.primary_num = 1;
+	conf_params->tx_mode = 1;
+	conf_params->tx_pkt_num = -1;
+	conf_params->tx_pkt_len = 1400;
+	conf_params->tx_pkt_preamble = 0;
+	conf_params->tx_pkt_rate = 6;
+	conf_params->he_ltf = 2;
+	conf_params->he_gi = 2;
+	conf_params->aux_adc_input_chain_id = 1;
+	conf_params->ru_tone = 26;
+	conf_params->ru_index = 1;
+	conf_params->tx_pkt_cw = 15;
+	conf_params->phy_calib = NRF_WIFI_DEF_PHY_CALIB;
+
+	/* Store back the currently set country code */
+	if (country_code[0] != '\0') {
+		memcpy(conf_params->country_code,
+		       country_code,
+		       NRF_WIFI_COUNTRY_CODE_LEN);
+	} else {
+		memcpy(conf_params->country_code,
+		       "00",
+		       NRF_WIFI_COUNTRY_CODE_LEN);
+	}
+out:
+	return status;
+}
+
+
+static int nrf_wifi_radio_test_set_defaults(const struct shell *sh,
+					    size_t argc,
+					    const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	status = nrf_wifi_radio_test_conf_init(&ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Configuration init failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_he_ltf(const struct shell *sh,
+					  size_t argc,
+					  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long he_ltf = 0;
+
+	he_ltf = strtoul(argv[1], &ptr, 10);
+
+	if (he_ltf > 2) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid HE LTF value(%lu).\n",
+			      he_ltf);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.he_ltf = he_ltf;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_he_gi(const struct shell *sh,
+					 size_t argc,
+					 const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long he_gi = 0;
+
+	he_gi = strtoul(argv[1], &ptr, 10);
+
+	if (he_gi > 2) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid HE GI value(%lu).\n",
+			      he_gi);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.he_gi = he_gi;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_tput_mode(const struct shell *sh,
+						    size_t argc,
+						    const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val >= RPU_TPUT_MODE_MAX) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_tput_mode = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_sgi(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_sgi = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_preamble(const struct shell *sh,
+						   size_t argc,
+						   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val >= RPU_PKT_PREAMBLE_MAX) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (ctx->conf_params.tx_pkt_tput_mode == 0) {
+		if ((val != RPU_PKT_PREAMBLE_SHORT) &&
+		    (val != RPU_PKT_PREAMBLE_LONG)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid value %lu for legacy mode\n",
+				      val);
+			return -ENOEXEC;
+		}
+	} else {
+		if (val != RPU_PKT_PREAMBLE_MIXED) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Only mixed preamble mode supported in HT, VHT and HE modes\n");
+			return -ENOEXEC;
+		}
+	}
+
+	ctx->conf_params.tx_pkt_preamble = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_mcs(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	long val = -1;
+
+	val = strtol(argv[1], &ptr, 10);
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (!(check_valid_data_rate(sh,
+				    ctx->conf_params.tx_pkt_tput_mode,
+				    ctx->conf_params.tx_pkt_nss,
+				    (val | 0x80)))) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_mcs = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_rate(const struct shell *sh,
+					       size_t argc,
+					       const char *argv[])
+{
+	char *ptr = NULL;
+	long val = -1;
+
+	val = strtol(argv[1], &ptr, 10);
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (!(check_valid_data_rate(sh,
+				    ctx->conf_params.tx_pkt_tput_mode,
+				    ctx->conf_params.tx_pkt_nss,
+				    val))) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_rate = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_gap(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 200000) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_gap_us = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_pkt_num(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	long val = 0;
+
+	val = strtol(argv[1], &ptr, 10);
+
+	if ((val < -1) || (val == 0)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_num = val;
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_tx_pkt_len(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val == 0) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_MAX) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Throughput mode not set\n");
+		return -ENOEXEC;
+	}
+
+	if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_LEGACY) {
+		if (val > 4000) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "max 'tx_pkt_len' size for legacy is 4000 bytes\n");
+			return -ENOEXEC;
+		}
+	} else if (ctx->conf_params.tx_pkt_tput_mode == RPU_TPUT_MODE_HE_TB) {
+		if (ctx->conf_params.ru_tone == 26) {
+			if (val >= 350) {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "'tx_pkt_len' has to be less than 350 bytes\n");
+				return -ENOEXEC;
+			}
+		} else if (ctx->conf_params.ru_tone == 52) {
+			if (val >= 800) {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "'tx_pkt_len' has to be less than 800 bytes\n");
+				return -ENOEXEC;
+			}
+		} else if (ctx->conf_params.ru_tone == 106) {
+			if (val >= 1800) {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "'tx_pkt_len' has to be less than 1800 bytes\n");
+				return -ENOEXEC;
+			}
+		} else if (ctx->conf_params.ru_tone == 242) {
+			if (val >= 4000) {
+				shell_fprintf(sh,
+					      SHELL_ERROR,
+					      "'tx_pkt_len' has to be less than 4000 bytes\n");
+				return -ENOEXEC;
+			}
+		} else {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "'ru_tone' not set\n");
+			return -ENOEXEC;
+		}
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_len = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_power(const struct shell *sh,
+					    size_t argc,
+					    const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (((val > MAX_TX_PWR_RADIO_TEST) && (val != MAX_TX_PWR_SYS_TEST))) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid TX power setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_power = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_tx_tone_freq(const struct shell *sh,
+						size_t argc,
+						const char *argv[])
+{
+	char *ptr = NULL;
+	signed char val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if ((val > 10) || (val < -10)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "'tx_tone_freq' has to be in between -10 to +10\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_tone_freq = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_rx_lna_gain(const struct shell *sh,
+					       size_t argc,
+					       const char *argv[])
+{
+	char *ptr = NULL;
+	signed char val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if ((val > 4) || (val < 0)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "'lna_gain' has to be in between 0 to 4\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.lna_gain = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_rx_bb_gain(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	signed char val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if ((val > 31) || (val < 0)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "'bb_gain' has to be in between 0 to 31\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.bb_gain = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_rx_capture_length(const struct shell *sh,
+						     size_t argc,
+						     const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned short int val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if ((val > MAX_CAPTURE_LEN)  || (val < MIN_CAPTURE_LEN)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "'capture_length' has to be non-zero and less than 16384\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.capture_length = val;
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_rx_capture_timeout(const struct shell *sh, size_t argc,
+						      const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned short int val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > CAPTURE_DURATION_IN_SEC) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "'capture_timeout' has to be less than 600 seconds\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.capture_timeout = val;
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_ru_tone(const struct shell *sh,
+					   size_t argc,
+					   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if ((val != 26) &&
+	    (val != 52) &&
+	    (val != 106) &&
+	    (val != 242)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.ru_tone = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_ru_index(const struct shell *sh,
+					    size_t argc,
+					    const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (ctx->conf_params.ru_tone == 26) {
+		if ((val < 1) || (val > 9)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid value %lu\n",
+				      val);
+			shell_help(sh);
+			return -ENOEXEC;
+		}
+	} else if (ctx->conf_params.ru_tone == 52) {
+		if ((val < 1) || (val > 4)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid value %lu\n",
+				      val);
+			shell_help(sh);
+			return -ENOEXEC;
+		}
+	} else if (ctx->conf_params.ru_tone == 106) {
+		if ((val < 1) || (val > 2)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid value %lu\n",
+				      val);
+			shell_help(sh);
+			return -ENOEXEC;
+		}
+	} else if (ctx->conf_params.ru_tone == 242) {
+		if ((val != 1)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid value %lu\n",
+				      val);
+			shell_help(sh);
+			return -ENOEXEC;
+		}
+	} else {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "RU tone not set\n");
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.ru_index = val;
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_init(const struct shell *sh,
+				    size_t argc,
+				    const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long band, chan_num = 0;
+
+	chan_num = strtoul(argv[1], &ptr, 10);
+	if (check_valid_chan_2g(chan_num)) {
+		band = NRF_WIFI_FREQ_BAND_2_4_GHZ;
+#ifndef CONFIG_NRF70_2_4G_ONLY
+	} else if (check_valid_chan_5g(chan_num)) {
+		band = NRF_WIFI_FREQ_BAND_5_GHZ;
+	} else if (check_valid_chan_6g(chan_num)) {
+		band = NRF_WIFI_FREQ_BAND_6_GHZ;
+#endif
+	} else {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid channel number %lu\n",
+			      chan_num);
+		return -ENOEXEC;
+	}
+
+	switch (band) {
+	case NRF_WIFI_FREQ_BAND_2_4_GHZ:
+		if (!check_valid_chan_2g(chan_num)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid channel number %lu on 2G band\n",
+				      chan_num);
+			return -ENOEXEC;
+		}
+	break;
+#ifndef CONFIG_NRF70_2_4G_ONLY
+	case NRF_WIFI_FREQ_BAND_5_GHZ:
+		if (!check_valid_chan_5g(chan_num)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid channel number %lu on 5G band\n",
+				      chan_num);
+			return -ENOEXEC;
+		}
+	break;
+	case NRF_WIFI_FREQ_BAND_6_GHZ:
+		if (!check_valid_chan_6g(chan_num)) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid channel number %lu on 6G band\n",
+				      chan_num);
+			return -ENOEXEC;
+		}
+	break;
+#endif /* CONFIG_NRF70_2_4G_ONLY */
+	default:
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid band %lu\n",
+			      band);
+		return -ENOEXEC;
+	}
+
+	if (ctx->conf_params.rx) {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "Disabling ongoing RX test\n");
+
+		ctx->conf_params.rx = 0;
+
+		status = nrf_wifi_rt_fmac_prog_rx(ctx->rpu_ctx,
+							  &ctx->conf_params);
+
+		if (status != NRF_WIFI_STATUS_SUCCESS) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Disabling RX failed\n");
+			return -ENOEXEC;
+		}
+	}
+
+	if (ctx->conf_params.tx) {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "Disabling ongoing TX test\n");
+
+		ctx->conf_params.tx = 0;
+
+		status = nrf_wifi_rt_fmac_prog_tx(ctx->rpu_ctx,
+							  &ctx->conf_params);
+
+		if (status != NRF_WIFI_STATUS_SUCCESS) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Disabling TX failed\n");
+			return -ENOEXEC;
+		}
+	}
+
+	if (ctx->rf_test_run) {
+		if (ctx->rf_test != NRF_WIFI_RF_TEST_TX_TONE) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Unexpected: RF Test (%d) running\n",
+				      ctx->rf_test);
+
+			return -ENOEXEC;
+		}
+
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "Disabling ongoing TX tone test\n");
+
+		status = nrf_wifi_rt_fmac_rf_test_tx_tone(ctx->rpu_ctx,
+						       0,
+						       ctx->conf_params.tx_tone_freq,
+						       ctx->conf_params.tx_power
+						       );
+
+		if (status != NRF_WIFI_STATUS_SUCCESS) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Disabling TX tone test failed\n");
+			return -ENOEXEC;
+		}
+
+		ctx->rf_test_run = false;
+		ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	}
+
+	status = nrf_wifi_radio_test_conf_init(&ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Configuration init failed\n");
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.chan.primary_num = chan_num;
+
+	status = nrf_wifi_rt_fmac_radio_test_init(ctx->rpu_ctx,
+					       &ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Programming init failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_tx_pkt_cw(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	long val = 0;
+
+	val = strtol(argv[1], &ptr, 10);
+
+	if (!((val == 0) ||
+		  (val == 3) ||
+		  (val == 7) ||
+		  (val == 15) ||
+		  (val == 31) ||
+		  (val == 63) ||
+		  (val == 127) ||
+		  (val == 255) ||
+		  (val == 511) ||
+		  (val == 1023))) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.tx_pkt_cw = val;
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_tx(const struct shell *sh,
+				      size_t argc,
+				      const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val != 0 && val != 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu (must be 0 or 1)\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (val == 1) {
+		if (!check_test_in_prog(sh)) {
+			return -ENOEXEC;
+		}
+
+		if (check_channel_settings(sh,
+					   ctx->conf_params.tx_pkt_tput_mode,
+					   &ctx->conf_params.chan) != 0) {
+			shell_fprintf(sh,
+				      SHELL_ERROR,
+				      "Invalid channel settings\n");
+			return -ENOEXEC;
+		}
+
+		/** Max TX power values differ based on the test being performed.
+		 * For TX EVM Vs Power, Max TX power required is
+		 * "MAX_TX_PWR_RADIO_TEST" (24dB) whereas for testing the
+		 * Max TX power for which both EVM and spectrum mask are passing
+		 * for specific band and MCS/rate, TX power values will be read from
+		 * RF params string.
+		 */
+		if (ctx->conf_params.tx_power != MAX_TX_PWR_SYS_TEST) {
+			/** Max TX power is represented in 0.25dB resolution
+			 * So,multiply 4 to MAX_TX_PWR_RADIO_TEST and
+			 * configure the RF params corresponding to Max TX power.
+			 */
+			memset(&ctx->conf_params.rf_params[NRF_WIFI_TX_PWR_CEIL_BYTE_OFFSET],
+			(MAX_TX_PWR_RADIO_TEST << 2),
+			sizeof(struct nrf_wifi_tx_pwr_ceil));
+		}
+	}
+
+	ctx->conf_params.tx = val;
+
+	status = nrf_wifi_rt_fmac_prog_tx(ctx->rpu_ctx,
+						  &ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Programming TX failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_set_rx(const struct shell *sh,
+				      size_t argc,
+				      const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val != 0 && val != 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu (must be 0 or 1)\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (val == 1) {
+		if (!check_test_in_prog(sh)) {
+			return -ENOEXEC;
+		}
+	}
+
+	ctx->conf_params.rx = val;
+
+	status = nrf_wifi_rt_fmac_prog_rx(ctx->rpu_ctx,
+						  &ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Programming RX failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+#if defined(CONFIG_NRF70_SR_COEX)
+static int nrf_wifi_radio_test_config_pta(const struct shell *sh,
+					  size_t argc,
+					  const char *argv[])
+{
+	bool wlan_band;
+	bool separate_antennas;
+	bool is_sr_protocol_ble;
+	int result_non_pta = 0;
+	int result_pta = 0;
+	int result = 0;
+
+	if (argc < 4) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "invalid # of args : %d\n", argc);
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Usage: config_pta wlan_band");
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      " separate_antennas is_sr_protocol_ble\n");
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "wlan_band: 0 for 2.4GHz, 1 for 5GHz\n");
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "is_sep_antennas: 0 for shared antenna,");
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      " 1 for separate antennas\n");
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "is_sr_ble: 0 for Thread, 1 for Bluetooth\n");
+		return -ENOEXEC;
+	}
+
+	wlan_band  = strtoul(argv[1], NULL, 0);
+	separate_antennas  = strtoul(argv[2], NULL, 0);
+	is_sr_protocol_ble  = strtoul(argv[3], NULL, 0);
+
+	if ((int)wlan_band > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid wlan_band(%d).\n",
+			      (int)wlan_band);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if ((int)separate_antennas > 1) {
+		shell_fprintf(sh,
+			     SHELL_ERROR,
+			    "Invalid separate_antennas(%d).\n",
+			    (int)separate_antennas);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if ((int)is_sr_protocol_ble > 1) {
+		shell_fprintf(sh,
+			     SHELL_ERROR,
+			    "Invalid is_sr_protocol_ble(%d).\n",
+			    (int)is_sr_protocol_ble);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	result_non_pta = nrf_wifi_coex_config_non_pta(separate_antennas, is_sr_protocol_ble);
+	result_pta = nrf_wifi_coex_config_pta(wlan_band, separate_antennas, is_sr_protocol_ble);
+	result = result_non_pta & result_pta;
+	return result;
+}
+#endif /* CONFIG_NRF70_SR_COEX */
+
+static void rx_cap_print_iq_sample(const struct shell *sh,
+				   const struct rx_cap_iq_sample *sample)
+{
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "%02X%02X%02X ",
+		      sample->bytes[2],
+		      sample->bytes[1],
+		      sample->bytes[0]);
+}
+
+
+static int nrf_wifi_radio_test_rx_cap(const struct shell *sh,
+				      size_t argc,
+				      const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	unsigned long rx_cap_type = 0;
+	unsigned char *rx_cap_buf = NULL;
+	unsigned char capture_status = 0;
+	char *ptr = NULL;
+	unsigned int i = 0;
+	int ret = -ENOEXEC;
+
+	rx_cap_type = strtoul(argv[1], &ptr, 10);
+
+	if ((rx_cap_type !=  NRF_WIFI_RF_TEST_RX_ADC_CAP) &&
+	    (rx_cap_type != NRF_WIFI_RF_TEST_RX_STAT_PKT_CAP) &&
+	    (rx_cap_type != NRF_WIFI_RF_TEST_RX_DYN_PKT_CAP)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      rx_cap_type);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!ctx->conf_params.capture_length) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "%s: Invalid rx_capture_length %d\n",
+			      __func__,
+			      ctx->conf_params.capture_length);
+		goto out;
+	}
+
+	if (rx_cap_type == NRF_WIFI_RF_TEST_RX_DYN_PKT_CAP) {
+		if (!ctx->conf_params.capture_timeout) {
+			shell_fprintf(sh,
+				SHELL_ERROR,
+				"%s: Invalid rx_capture_timeout %d\n",
+				__func__,
+				ctx->conf_params.capture_timeout);
+			goto out;
+		}
+	}
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	rx_cap_buf = rt_mem_alloc(ctx->conf_params.capture_length *
+				  RX_CAP_BYTES_PER_SAMPLE);
+
+	if (!rx_cap_buf) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "%s: Unable to allocate (%d) bytes for RX capture\n",
+			      __func__,
+			      (ctx->conf_params.capture_length *
+			       RX_CAP_BYTES_PER_SAMPLE));
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_RX_ADC_CAP;
+
+	status = nrf_wifi_rt_fmac_rf_test_rx_cap(ctx->rpu_ctx,
+					      rx_cap_type,
+					      rx_cap_buf,
+					      ctx->conf_params.capture_length,
+					      ctx->conf_params.capture_timeout,
+					      ctx->conf_params.lna_gain,
+					      ctx->conf_params.bb_gain,
+					      &capture_status);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "RX ADC capture programming failed\n");
+		goto out;
+	}
+
+	if (capture_status == 0) {
+		const struct rx_cap_iq_sample *samples =
+			(const struct rx_cap_iq_sample *)rx_cap_buf;
+		unsigned int num_samples = ctx->conf_params.capture_length;
+		unsigned int num_lines = (num_samples + SAMPLES_PER_LINE - 1) /
+					 SAMPLES_PER_LINE;
+
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "\n************* RX capture data ***********\n");
+
+		for (i = 0; i < num_lines; i++) {
+			unsigned int line_start = i * SAMPLES_PER_LINE;
+			unsigned int line_count = SAMPLES_PER_LINE;
+
+			if (line_start + line_count > num_samples) {
+				line_count = num_samples - line_start;
+			}
+
+			for (unsigned int j = 0; j < line_count; j++) {
+				rx_cap_print_iq_sample(sh, &samples[line_start + j]);
+			}
+
+			shell_fprintf(sh,
+				      SHELL_INFO,
+				      "\n");
+		}
+	} else if (capture_status == 1) {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "\n************* Capture failed ***********\n");
+	} else {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "\n************* Packet detection failed ***********\n");
+	}
+
+	ret = 0;
+out:
+	if (rx_cap_buf) {
+		rt_mem_free(rx_cap_buf);
+	}
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+
+static int nrf_wifi_radio_test_tx_tone(const struct shell *sh,
+				       size_t argc,
+				       const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long val = 0;
+	int ret = -ENOEXEC;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		goto out;
+
+	}
+
+	if (val == 1) {
+		if (!check_test_in_prog(sh)) {
+			goto out;
+		}
+
+	}
+
+	status = nrf_wifi_rt_fmac_rf_test_tx_tone(ctx->rpu_ctx,
+					       (unsigned char)val,
+					       ctx->conf_params.tx_tone_freq,
+					       ctx->conf_params.tx_power
+					       );
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "TX tone programming failed\n");
+		goto out;
+	}
+
+	if (val == 1) {
+		ctx->rf_test_run = true;
+		ctx->rf_test = NRF_WIFI_RF_TEST_TX_TONE;
+	} else {
+		ctx->rf_test_run = false;
+		ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+	}
+
+	ret = 0;
+out:
+	return ret;
+}
+
+
+static int nrf_wifi_radio_test_set_phy_calib_rxdc(const struct shell *sh,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_rxdc = 0;
+
+	phy_calib_rxdc = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_rxdc > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid PHY RX DC calibration value(%lu).\n",
+			      phy_calib_rxdc);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_rxdc) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_RXDC);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXDC));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txdc(const struct shell *sh,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txdc = 0;
+
+	phy_calib_txdc = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txdc > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid PHY TX DC calibration value(%lu).\n",
+			      phy_calib_txdc);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txdc) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXDC);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXDC));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txpow(const struct shell *sh,
+						   size_t argc,
+						   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txpow = 0;
+
+	phy_calib_txpow = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txpow > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid PHY TX power calibration value(%lu).\n",
+			      phy_calib_txpow);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txpow) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXPOW);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXPOW));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_rxiq(const struct shell *sh,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_rxiq = 0;
+
+	phy_calib_rxiq = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_rxiq > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid PHY RX IQ calibration value(%lu).\n",
+			      phy_calib_rxiq);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_rxiq) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_RXIQ);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_RXIQ));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_phy_calib_txiq(const struct shell *sh,
+						  size_t argc,
+						  const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long phy_calib_txiq = 0;
+
+	phy_calib_txiq = strtoul(argv[1], &ptr, 10);
+
+	if (phy_calib_txiq > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid PHY TX IQ calibration value(%lu).\n",
+			      phy_calib_txiq);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	if (phy_calib_txiq) {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib |
+					     NRF_WIFI_PHY_CALIB_FLAG_TXIQ);
+	} else {
+		ctx->conf_params.phy_calib = (ctx->conf_params.phy_calib &
+					     ~(NRF_WIFI_PHY_CALIB_FLAG_TXIQ));
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_set_dpd(const struct shell *sh,
+				  size_t argc,
+				  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long val = 0;
+	int ret = -ENOEXEC;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		goto out;
+	}
+
+	if (val == 1) {
+		if (!check_test_in_prog(sh)) {
+			goto out;
+		}
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_DPD;
+
+	status = nrf_wifi_rt_fmac_rf_test_dpd(ctx->rpu_ctx,
+					   val);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "DPD programming failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+static int nrf_wifi_radio_get_temperature(const struct shell *sh,
+					  size_t argc,
+					  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_GET_TEMPERATURE;
+
+	status = nrf_wifi_rt_fmac_rf_get_temp(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Temperature read failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+static int nrf_wifi_radio_get_bat_volt(const struct shell *sh,
+					  size_t argc,
+					  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_GET_BAT_VOLT;
+
+	status = nrf_wifi_rt_fmac_rf_get_bat_volt(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Voltage read failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+
+static int nrf_wifi_radio_get_rf_rssi(const struct shell *sh,
+				      size_t argc,
+				      const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_RF_RSSI;
+
+	status = nrf_wifi_rt_fmac_rf_get_rf_rssi(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "RF RSSI get failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+
+static int nrf_wifi_radio_set_xo_val(const struct shell *sh,
+				     size_t argc,
+				     const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	unsigned long val = 0;
+	int ret = -ENOEXEC;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 0x7f) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value XO value should be <= 0x7f\n");
+		shell_help(sh);
+		goto out;
+	}
+
+	if (val < 0) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value XO value should be >= 0\n");
+		shell_help(sh);
+		goto out;
+	}
+
+	if (val == 1) {
+		if (!check_test_in_prog(sh)) {
+			goto out;
+		}
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_XO_CALIB;
+
+	status = nrf_wifi_rt_fmac_set_xo_val(ctx->rpu_ctx,
+					       (unsigned char)val);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "XO value programming failed\n");
+		goto out;
+	}
+
+	ctx->conf_params.rf_params[NRF_WIFI_XO_FREQ_BYTE_OFFSET] = val;
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+static int nrf_wifi_radio_test_set_ant_gain(const struct shell *sh,
+					    size_t argc,
+					    const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long ant_gain = 0;
+
+	ant_gain = strtoul(argv[1], &ptr, 10);
+
+	if ((ant_gain < 0) || (ant_gain > 6)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid antenna gain setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	memset(&ctx->conf_params.rf_params[ANT_GAIN_2G_OFST],
+	       ant_gain,
+	       NUM_ANT_GAIN);
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_edge_bo(const struct shell *sh,
+					   size_t argc,
+					   const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long edge_bo = 0;
+
+	edge_bo = strtoul(argv[1], &ptr, 10);
+
+	if ((edge_bo < 0) || (edge_bo > 10)) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid edge backoff setting\n");
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	memset(&ctx->conf_params.rf_params[BAND_2G_LW_ED_BKF_DSSS_OFST],
+	       edge_bo,
+	       NUM_EDGE_BACKOFF);
+
+	return 0;
+}
+
+/* See enum CD2CM_MSG_ID_T in RPU Coexistence Manager API */
+#define CD2CM_UPDATE_SWITCH_CONFIG 0x7
+static int nrf_wifi_radio_test_wlan_switch_ctrl(const struct shell *sh,
+						size_t argc,
+						const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	char *ptr = NULL;
+	struct coex_wlan_switch_ctrl params = { 0 };
+
+	if (argc < 2) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid number of parameters\n");
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	params.rpu_msg_id = CD2CM_UPDATE_SWITCH_CONFIG;
+	params.switch_A = strtoul(argv[1], &ptr, 10);
+
+	if (params.switch_A > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid WLAN switch config (%d)\n",
+			      params.switch_A);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.wlan_ant_switch_ctrl = params.switch_A;
+
+	status = nrf_wifi_fmac_conf_srcoex(ctx->rpu_ctx,
+					   &params, sizeof(params));
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "WLAN switch configuration failed\n");
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int nrf_wifi_radio_comp_opt_xo_val(const struct shell *sh,
+					  size_t argc,
+					  const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+
+	int ret = -ENOEXEC;
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	ctx->rf_test_run = true;
+	ctx->rf_test = NRF_WIFI_RF_TEST_XO_TUNE;
+
+	status = nrf_wifi_rt_fmac_rf_test_compute_xo(ctx->rpu_ctx);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "XO value computation failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	ctx->rf_test_run = false;
+	ctx->rf_test = NRF_WIFI_RF_TEST_MAX;
+
+	return ret;
+}
+
+
+static int nrf_wifi_radio_test_show_cfg(const struct shell *sh,
+					size_t argc,
+					const char *argv[])
+{
+	struct rpu_conf_params *conf_params = NULL;
+
+	conf_params = &ctx->conf_params;
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "************* Configured Parameters ***********\n");
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "\n");
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_tput_mode = %d\n",
+		      conf_params->tx_pkt_tput_mode);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_sgi = %d\n",
+		      conf_params->tx_pkt_sgi);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_preamble = %d\n",
+		      conf_params->tx_pkt_preamble);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_mcs = %d\n",
+		      conf_params->tx_pkt_mcs);
+
+	if (conf_params->tx_pkt_rate == 5) {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "tx_pkt_rate = 5.5\n");
+	} else {
+		shell_fprintf(sh,
+			      SHELL_INFO,
+			      "tx_pkt_rate = %d\n",
+			      conf_params->tx_pkt_rate);
+	}
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_gap = %d\n",
+		      conf_params->tx_pkt_gap_us);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_num = %d\n",
+		      conf_params->tx_pkt_num);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_len = %d\n",
+		      conf_params->tx_pkt_len);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_power = %d\n",
+		      conf_params->tx_power);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "he_ltf = %d\n",
+		      conf_params->he_ltf);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "he_gi = %d\n",
+		      conf_params->he_gi);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "phy_calib_rxdc = %d\n",
+		      (conf_params->phy_calib &
+		       NRF_WIFI_PHY_CALIB_FLAG_RXDC) ? 1:0);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "phy_calib_txdc = %d\n",
+		      (conf_params->phy_calib &
+		       NRF_WIFI_PHY_CALIB_FLAG_TXDC) ? 1:0);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "phy_calib_txpow = %d\n",
+		      (conf_params->phy_calib &
+		       NRF_WIFI_PHY_CALIB_FLAG_TXPOW) ? 1:0);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "phy_calib_rxiq = %d\n",
+		      (conf_params->phy_calib &
+		       NRF_WIFI_PHY_CALIB_FLAG_RXIQ) ? 1:0);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "phy_calib_txiq = %d\n",
+		      (conf_params->phy_calib &
+		       NRF_WIFI_PHY_CALIB_FLAG_TXIQ) ? 1:0);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "xo_val = %d\n",
+		      conf_params->rf_params[NRF_WIFI_XO_FREQ_BYTE_OFFSET]);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "wlan_ant_switch_ctrl = %d\n",
+		      conf_params->wlan_ant_switch_ctrl);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "init = %d\n",
+		      conf_params->chan.primary_num);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx = %d\n",
+		      conf_params->tx);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rx = %d\n",
+		      conf_params->rx);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_tone_freq = %d\n",
+		      conf_params->tx_tone_freq);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rx_lna_gain = %d\n",
+		      conf_params->lna_gain);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rx_bb_gain = %d\n",
+		      conf_params->bb_gain);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rx_capture_length = %d\n",
+		      conf_params->capture_length);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rx_capture_timeout = %d\n",
+		      conf_params->capture_timeout);
+
+#if defined(CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP_NRF7001) || \
+	defined(CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP)
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "sr_ant_switch_ctrl = %d\n",
+		      conf_params->sr_ant_switch_ctrl);
+#endif /* CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP_NRF7001 || CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP */
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "tx_pkt_cw = %d\n",
+		      conf_params->tx_pkt_cw);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "reg_domain = %c%c\n",
+		      conf_params->country_code[0],
+		      conf_params->country_code[1]);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "bypass_reg_domain = %d\n",
+		      conf_params->bypass_regulatory);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "ru_tone = %d\n",
+		      conf_params->ru_tone);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "ru_index = %d\n",
+		      conf_params->ru_index);
+
+	return 0;
+}
+
+
+static int nrf_wifi_radio_test_get_stats(const struct shell *sh,
+					 size_t argc,
+					 const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	struct rpu_rt_op_stats stats;
+
+	memset(&stats,
+	       0,
+	       sizeof(stats));
+
+	status = nrf_wifi_rt_fmac_stats_get(ctx->rpu_ctx,
+					 ctx->conf_params.op_mode,
+					 &stats);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "nrf_wifi_rt_fmac_stats_get failed\n");
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "************* PHY STATS ***********\n");
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "rssi_avg = %d dBm\n",
+		      stats.fw.phy.rssi_avg);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "ofdm_crc32_pass_cnt=%d\n",
+		      stats.fw.phy.ofdm_crc32_pass_cnt);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "ofdm_crc32_fail_cnt=%d\n",
+		      stats.fw.phy.ofdm_crc32_fail_cnt);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "dsss_crc32_pass_cnt=%d\n",
+		      stats.fw.phy.dsss_crc32_pass_cnt);
+
+	shell_fprintf(sh,
+		      SHELL_INFO,
+		      "dsss_crc32_fail_cnt=%d\n",
+		      stats.fw.phy.dsss_crc32_fail_cnt);
+
+	return 0;
+}
+
+static int nrf_wifi_radio_test_set_reg_domain(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	int ret = -ENOEXEC;
+	struct nrf_wifi_fmac_reg_info reg_domain_info = {0};
+
+	if (strlen(argv[1]) != 2) {
+		shell_fprintf(sh, SHELL_WARNING,
+			"Invalid reg domain: Length should be two letters/digits\n");
+			goto out;
+	}
+
+	/* Two letter country code with special case of 00 for WORLD */
+	if (((argv[1][0] < 'A' || argv[1][0] > 'Z') ||
+	     (argv[1][1] < 'A' || argv[1][1] > 'Z')) &&
+	     (argv[1][0] != '0' || argv[1][1] != '0')) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid reg domain %c%c\n", argv[1][0],
+			      argv[1][1]);
+		goto out;
+	}
+
+	ctx->conf_params.country_code[0] = argv[1][0];
+	ctx->conf_params.country_code[1] = argv[1][1];
+
+	if (!check_test_in_prog(sh)) {
+		goto out;
+	}
+
+	memcpy(reg_domain_info.alpha2, ctx->conf_params.country_code,
+			NRF_WIFI_COUNTRY_CODE_LEN);
+
+	status = nrf_wifi_fmac_set_reg(ctx->rpu_ctx, &reg_domain_info);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Regulatory programming failed\n");
+		goto out;
+	}
+
+	ret = 0;
+out:
+	return ret;
+}
+
+
+static int nrf_wifi_radio_test_set_bypass_reg(const struct shell *sh,
+					      size_t argc,
+					      const char *argv[])
+{
+	char *ptr = NULL;
+	unsigned long val = 0;
+
+	val = strtoul(argv[1], &ptr, 10);
+
+	if (val > 1) {
+		shell_fprintf(sh,
+			      SHELL_ERROR,
+			      "Invalid value %lu\n",
+			      val);
+		shell_help(sh);
+		return -ENOEXEC;
+	}
+
+	if (!check_test_in_prog(sh)) {
+		return -ENOEXEC;
+	}
+
+	ctx->conf_params.bypass_regulatory = val;
+
+	return 0;
+}
+
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	nrf_wifi_radio_test_subcmds,
+	SHELL_CMD_ARG(set_defaults,
+		      NULL,
+		      "Reset configuration parameter to their default values",
+		      nrf_wifi_radio_test_set_defaults,
+		      1,
+		      0),
+	SHELL_CMD_ARG(he_ltf,
+		      NULL,
+		      "0 - 1x HE LTF\n"
+		      "1 - 2x HE LTF\n"
+		      "2 - 4x HE LTF                                        ",
+		      nrf_wifi_radio_test_set_he_ltf,
+		      2,
+		      0),
+	SHELL_CMD_ARG(he_gi,
+		      NULL,
+		      "0 - 0.8 us\n"
+		      "1 - 1.6 us\n"
+		      "2 - 3.2 us                                           ",
+		      nrf_wifi_radio_test_set_he_gi,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_tput_mode,
+		      NULL,
+		      "0 - Legacy mode\n"
+		      "1 - HT mode\n"
+		      "2 - VHT mode\n"
+		      "3 - HE(SU) mode\n"
+		      "4 - HE(ER SU) mode\n"
+		      "5 - HE (TB) mode                                   ",
+		      nrf_wifi_radio_test_set_tx_pkt_tput_mode,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_sgi,
+		      NULL,
+		      "0 - Disable\n"
+		      "1 - Enable",
+		      nrf_wifi_radio_test_set_tx_pkt_sgi,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_preamble,
+		      NULL,
+		      "0 - Long preamble\n"
+		      "1 - Short preamble\n"
+		      "2 - Mixed preamble                                   ",
+		      nrf_wifi_radio_test_set_tx_pkt_preamble,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_mcs,
+		      NULL,
+		      "-1    - Not being used\n"
+		      "<val> - MCS index to be used",
+		      nrf_wifi_radio_test_set_tx_pkt_mcs,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_rate,
+		      NULL,
+		      "-1    - Not being used\n"
+		      "<val> - Legacy rate to be used in Mbps (1, 2, 5.5, 11, 6, 9, 12, 18, 24, 36, 48, 54)",
+		      nrf_wifi_radio_test_set_tx_pkt_rate,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_gap,
+		      NULL,
+		      "<val> - Interval between TX packets in us (Min: 200, Max: 200000, Default: 200)",
+		      nrf_wifi_radio_test_set_tx_pkt_gap,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_num,
+		      NULL,
+		      "-1    - Transmit infinite packets\n"
+		      "<val> - Number of packets to transmit",
+		      nrf_wifi_radio_test_set_tx_pkt_num,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_len,
+		      NULL,
+		      "<val> - Length of the packet (in bytes) to be transmitted (Default: 1400)",
+		      nrf_wifi_radio_test_set_tx_pkt_len,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_power,
+		      NULL,
+		      "<val> - Value in dBm",
+		      nrf_wifi_radio_test_set_tx_power,
+		      2,
+		      0),
+	SHELL_CMD_ARG(ru_tone,
+		      NULL,
+		      "<val> - Resource unit (RU) size (26,52,106 or 242)",
+		      nrf_wifi_radio_test_set_ru_tone,
+		      2,
+		      0),
+	SHELL_CMD_ARG(ru_index,
+		      NULL,
+		      "<val> - Location of resource unit (RU) in 20 MHz spectrum\n"
+		      "        Valid Values:\n"
+		      "           For 26 ru_tone: 1 to 9\n"
+		      "           For 52 ru_tone:  1 to 4\n"
+		      "           For 106 ru_tone:  1 to 2\n"
+		      "           For 242 ru_tone:  1",
+		      nrf_wifi_radio_test_set_ru_index,
+		      2,
+		      0),
+	SHELL_CMD_ARG(init,
+		      NULL,
+		      "<val> - Primary channel number",
+		      nrf_wifi_radio_test_init,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx,
+		      NULL,
+		      "0 - Disable TX\n"
+		      "1 - Enable TX",
+		      nrf_wifi_radio_test_set_tx,
+		      2,
+		      0),
+	SHELL_CMD_ARG(rx,
+		      NULL,
+		      "0 - Disable RX\n"
+		      "1 - Enable RX",
+		      nrf_wifi_radio_test_set_rx,
+		      2,
+		      0),
+
+#if defined(CONFIG_NRF70_SR_COEX)
+	SHELL_CMD_ARG(config_pta,
+		      NULL,
+		      " - <val> - Wi-Fi operating band 0: 2.4GHz, 1: 5GHz\n"
+		      " - <val> - Antenna mode 0: Shared, 1: Separate\n"
+		      " - <val> - SR protocol  0: Thread, 1: Bluetooth LE\n",
+		      nrf_wifi_radio_test_config_pta,
+		      4,
+		      0),
+#endif /* CONFIG_NRF70_SR_COEX */
+
+	SHELL_CMD_ARG(rx_lna_gain,
+		      NULL,
+		      "<val> - LNA gain to be configured.\n"
+			  "0 = 24 dB\n"
+			  "1 = 18 dB\n"
+			  "2 = 12 dB\n"
+			  "3 = 0 dB\n"
+			  "4 = -12 dB                         ",
+		      nrf_wifi_radio_test_set_rx_lna_gain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(rx_bb_gain,
+		      NULL,
+		      "<val> - Baseband gain to be configured\n"
+			  "It is a 5 bit value. Supports 64dB range in steps of 2dB",
+		      nrf_wifi_radio_test_set_rx_bb_gain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(rx_capture_length,
+		      NULL,
+		      "<val> - Number of RX samples to be captured\n"
+		      "Max allowed length is 16384 complex samples",
+		      nrf_wifi_radio_test_set_rx_capture_length,
+		      2,
+		      0),
+	SHELL_CMD_ARG(rx_capture_timeout,
+		      NULL,
+		      "<val> - Wait time allowed in seconds\n"
+		      "Max timeout allowed is 600 seconds",
+		      nrf_wifi_radio_test_set_rx_capture_timeout,
+		      2,
+		      0),
+	SHELL_CMD_ARG(rx_cap,
+		      NULL,
+		      "0 = ADC capture\n"
+		      "1 = Filtered ADC capture\n"
+		      "2 = Dynamic packet capture              ",
+		      nrf_wifi_radio_test_rx_cap,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_tone_freq,
+		      NULL,
+		      "<val> - Frequency offset with respect to center frequency in the range of -10MHz to 10MHz (resolution 1MHz)",
+		      nrf_wifi_radio_test_set_tx_tone_freq,
+		      2,
+		      0),
+	SHELL_CMD_ARG(tx_tone,
+		      NULL,
+		      "<TONE CONTROL>\n"
+		      "0: Disable tone\n"
+		      "1: Enable tone                                       ",
+		      nrf_wifi_radio_test_tx_tone,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_rxdc,
+		      NULL,
+		      "0 - Disable RX DC calibration\n"
+		      "1 - Enable RX DC calibration",
+		      nrf_wifi_radio_test_set_phy_calib_rxdc,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txdc,
+		      NULL,
+		      "0 - Disable TX DC calibration\n"
+		      "1 - Enable TX DC calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txdc,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txpow,
+		      NULL,
+		      "0 - Disable TX power calibration\n"
+		      "1 - Enable TX power calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txpow,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_rxiq,
+		      NULL,
+		      "0 - Disable RX IQ calibration\n"
+		      "1 - Enable RX IQ calibration",
+		      nrf_wifi_radio_test_set_phy_calib_rxiq,
+		      2,
+		      0),
+	SHELL_CMD_ARG(phy_calib_txiq,
+		      NULL,
+		      "0 - Disable TX IQ calibration\n"
+		      "1 - Enable TX IQ calibration",
+		      nrf_wifi_radio_test_set_phy_calib_txiq,
+		      2,
+		      0),
+	SHELL_CMD_ARG(dpd,
+		      NULL,
+		      "0 - Bypass DPD\n"
+		      "1 - Enable DPD",
+		      nrf_wifi_radio_set_dpd,
+		      2,
+		      0),
+	SHELL_CMD_ARG(get_temperature,
+		      NULL,
+		      "No arguments required",
+		      nrf_wifi_radio_get_temperature,
+		      1,
+		      0),
+	SHELL_CMD_ARG(get_voltage,
+		      NULL,
+		      "No arguments required",
+		      nrf_wifi_radio_get_bat_volt,
+		      1,
+		      0),
+	SHELL_CMD_ARG(get_rf_rssi,
+		      NULL,
+		      "No arguments required",
+		      nrf_wifi_radio_get_rf_rssi,
+		      1,
+		      0),
+	SHELL_CMD_ARG(set_xo_val,
+		      NULL,
+		      "<val> - XO value in the range 0 to 127",
+		      nrf_wifi_radio_set_xo_val,
+		      2,
+		      0),
+	SHELL_CMD_ARG(set_ant_gain,
+		      NULL,
+		      "<val> - Antenna gain in dB (Min: 0, Max: 6)",
+		      nrf_wifi_radio_test_set_ant_gain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(set_edge_bo,
+		      NULL,
+		      "<val> - Edge backoff in dB (Min: 0, Max: 10)",
+		      nrf_wifi_radio_test_set_edge_bo,
+		      2,
+		      0),
+	SHELL_CMD_ARG(wlan_ant_switch_ctrl,
+		      NULL,
+		      "Configure WLAN antenna switch (0-separate/1-shared)",
+		      nrf_wifi_radio_test_wlan_switch_ctrl,
+		      2,
+		      0),
+	SHELL_CMD_ARG(compute_optimal_xo_val,
+		      NULL,
+		      "Compute optimal XO trim value",
+		      nrf_wifi_radio_comp_opt_xo_val,
+		      1,
+		      0),
+	SHELL_CMD_ARG(show_config,
+		      NULL,
+		      "Display the current configuration values",
+		      nrf_wifi_radio_test_show_cfg,
+		      1,
+		      0),
+	SHELL_CMD_ARG(get_stats,
+		      NULL,
+		      "Display statistics",
+		      nrf_wifi_radio_test_get_stats,
+		      1,
+		      0),
+	SHELL_CMD_ARG(tx_pkt_cw,
+		      NULL,
+		      "<val> - Contention window value to be configured (0, 3, 7, 15, 31, 63, 127, 255, 511, 1023)",
+		      nrf_wifi_radio_test_set_tx_pkt_cw,
+		      2,
+		      0),
+	SHELL_CMD_ARG(reg_domain,
+		      NULL,
+		      "Configure WLAN regulatory domain country code",
+		      nrf_wifi_radio_test_set_reg_domain,
+		      2,
+		      0),
+	SHELL_CMD_ARG(bypass_reg_domain,
+		      NULL,
+		      "Configure WLAN to bypass regulatory\n"
+		      "0 - TX power of the channel will be set to "
+			   "minimum between user configured TX power & "
+			   "maximum TX power of channel in the configured regulatory domain.\n"
+		      "1 - Configured TX power value will be used for the channel.				",
+		      nrf_wifi_radio_test_set_bypass_reg,
+		      2,
+		      0),
+	SHELL_SUBCMD_SET_END);
+
+
+SHELL_CMD_REGISTER(wifi_radio_test,
+		   &nrf_wifi_radio_test_subcmds,
+		   "nRF Wi-Fi radio test commands",
+		   NULL);
+
+
+static int nrf_wifi_radio_test_shell_init(void)
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	unsigned int timeout = 0;
+
+	while (!ctx->rpu_ctx && timeout < NRF_WIFI_RADIO_TEST_INIT_TIMEOUT_MS) {
+		k_sleep(K_MSEC(100));
+		timeout += 100;
+	}
+
+	if (!ctx->rpu_ctx) {
+		printf("nRF Wi-Fi radio test shell init timedout waiting for driver: %d\n",
+		       NRF_WIFI_RADIO_TEST_INIT_TIMEOUT_MS);
+		return -ENOEXEC;
+	}
+
+	status = nrf_wifi_radio_test_conf_init(&ctx->conf_params);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+
+SYS_INIT(nrf_wifi_radio_test_shell_init,
+	 APPLICATION,
+	 CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Move radio test and FICR programming shell commands into the nRF70 Wi-Fi driver. Register the command sets behind NRF70_RADIO_TEST_SHELL and NRF70_RADIO_TEST_FICR_SHELL Kconfig options so radio test builds can use the built-in shell or provide a custom integration.