### PR TITLE
boards: lilygo: twatch_s3: init the PMIC before its consumers

### DIFF
--- a/boards/lilygo/twatch_s3/Kconfig.defconfig
+++ b/boards/lilygo/twatch_s3/Kconfig.defconfig
@@ -11,3 +11,11 @@ config LV_COLOR_16_SWAP
 endif # LVGL
 
 endif # DISPLAY
+
+# The AXP2101 gates the supply of most of the board, so bring the PMIC and its
+# regulators up before the drivers that sit behind them.
+config MFD_INIT_PRIORITY
+	default 70
+
+config REGULATOR_AXP192_AXP2101_INIT_PRIORITY
+	default 71


### PR DESCRIPTION
The AXP2101 supplies most of the T-Watch S3, including the DRV2605 haptic driver on BLDO2, but its regulators come up at the default init priority, after the drivers that depend on them.

The DRV2605 is therefore probed while its rail is still off. This moves the PMIC and its regulators ahead of those drivers, the same way e.g. `m5stack_core2` already does for the AXP192.

### Testing

On a `twatch_s3/esp32s3/procpu` with `samples/drivers/haptics/drv2605` built with `CONFIG_MFD=y` and `CONFIG_REGULATOR=y`:

| | Result |
|---|---|
| Without this change | `DRV2605 device drv2605@5a is not ready` |
| With this change | `Found DRV2605 device drv2605@5a`, effect plays, 3/3 boots |
