### PR TITLE
ci: twister: upload test results with codecov-action

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -362,8 +362,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && (github.event_name == 'push') }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish Unit Test Results


### PR DESCRIPTION
`codecov/test-results-action` is [deprecated by Codecov](https://github.com/codecov/test-results-action#deprecation-warning) in favor of `codecov-action` with `report_type: test_results`. It is also one of the last actions in the tree still running on Node 20, whose removal from GitHub Actions is scheduled for September 23rd, 2026, and upstream has no Node 24 release: the latest tag (v1.2.1, December 2025) and the repository's `main` branch are both still `node20`.

This switches the step to `codecov/codecov-action`, which is already pinned at the same v7.0.0 SHA twice in `codecov.yaml`, so Dependabot's `actions-deps` group will keep all three call sites in lockstep.

Only `token` is passed, exactly as before, so the CLI's file search behavior is unchanged.