### PR TITLE
ci: workflows: delete stale queued runs with github-script

### DIFF
--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -24,11 +24,23 @@ jobs:
 
     steps:
     - name: Delete stale queued workflow runs
-      uses: MajorScruffy/delete-old-workflow-runs@78b5af714fefaefdf74862181c467b061782719e # v0.3.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
-        repository: ${{ github.repository }}
-        # Remove any workflow runs in "queued" state for more than 1 day
-        older-than-seconds: 86400
-        status: queued
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        retries: 3
+        script: |
+          // Remove any workflow runs in "queued" state for more than 1 day
+          const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+
+          const runs = await github.paginate(
+            github.rest.actions.listWorkflowRunsForRepo,
+            { ...context.repo, status: "queued", per_page: 100 },
+          );
+
+          for (const run of runs.filter((r) => Date.parse(r.created_at) < cutoff)) {
+            core.info(`Deleting workflow run ${run.id}`);
+            try {
+              await github.rest.actions.deleteWorkflowRun({ ...context.repo, run_id: run.id });
+            } catch (err) {
+              core.warning(`Failed to delete workflow run ${run.id}: ${err.message}`);
+            }
+          }


### PR DESCRIPTION
`MajorScruffy/delete-old-workflow-runs` runs on Node 12 — its `main` branch only ever reached Node 16 — and has been unmaintained since January 2024. With the removal of Node 20 from GitHub Actions scheduled for September 23rd, 2026, the action has no supported runtime left and no upgrade path.

Replace it with an `actions/github-script` step reproducing the same configuration the action was given (`status: queued`, `older-than-seconds: 86400`): list queued workflow runs, keep those created more than a day ago, delete them.

`actions/github-script` is already pinned at v9.0.0 (Node 24) in `doc-publish-pr.yml`, so this adds no new dependency and Dependabot's `actions-deps` group keeps it current.

No permission changes are required. The job already declares `actions: write`, which covers both listing (`actions: read`) and deleting runs, and the default `github-token` carries it.

### Testing

The underlying REST query (`actions/runs?status=queued`) and the one-day cutoff filter were checked against this repository and select 6 queued runs currently older than a day, two of them several weeks old.