### PR TITLE
samples: shields: Update iks4a1 shield to new code-sample extension

### DIFF
--- a/boards/shields/x_nucleo_iks4a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks4a1/doc/index.rst
@@ -156,11 +156,11 @@ Examples
 Three samples are provided as examples for ``x-nucleo-iks4a1`` shield, each one associated
 with one of the overlays described above:
 
-- :ref:`x-nucleo-iks4a1-std-sample` application, to be used when the shield is configured
+- ::zephyr:code-sample:`x-nucleo-iks4a1-std` application, to be used when the shield is configured
   in Standard Mode (Mode 1)
-- :ref:`x-nucleo-iks4a1-shub1-sample` application, to be used when the shield is configured
+- ::zephyr:code-sample:`x-nucleo-iks4a1-shub1` application, to be used when the shield is configured
   in SHUB1 Mode (Mode 3)
-- :ref:`x-nucleo-iks4a1-shub2-sample` application, to be used when the shield is configured
+- ::zephyr:code-sample:`x-nucleo-iks4a1-shub2` application, to be used when the shield is configured
   in SHUB2 Mode (Mode 2)
 
 See also :ref:`shields` for more details.

--- a/samples/shields/x_nucleo_iks4a1/sensorhub1/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub1/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks4a1-shub1-sample:
+.. zephyr:code-sample:: x-nucleo-iks4a1-shub1
+   :name: X-NUCLEO-IKS4A1 shield - SensorHub (Mode 3)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS4A1 shield SHUB1 (Mode 3) sample
-############################################
+   Interact with all the sensors of an X-NUCLEO-IKS4A1 shield using SHUB1 (mode 3).
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks4a1/sensorhub2/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/sensorhub2/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks4a1-shub2-sample:
+.. zephyr:code-sample:: x-nucleo-iks4a1-shub2
+   :name: X-NUCLEO-IKS4A1 shield - SensorHub (Mode 2)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS4A1: shield SHUB2 (Mode 2) sample
-#############################################
+   Interact with all the sensors of an X-NUCLEO-IKS4A1 shield using SHUB2 (mode 2).
 
 Overview
 ********

--- a/samples/shields/x_nucleo_iks4a1/standard/README.rst
+++ b/samples/shields/x_nucleo_iks4a1/standard/README.rst
@@ -1,7 +1,8 @@
-.. _x-nucleo-iks4a1-std-sample:
+.. zephyr:code-sample:: x-nucleo-iks4a1-std
+   :name: X-NUCLEO-IKS4A1 shield - Standard (Mode 1)
+   :relevant-api: sensor_interface
 
-X-NUCLEO-IKS4A1 shield Standard (Mode 1) sample
-###############################################
+   Interact with all the sensors of an X-NUCLEO-IKS4A1 shield using Standard mode.
 
 Overview
 ********


### PR DESCRIPTION
Fix all x-nucleo-iks4a1 shield samples and references to them so that they use the new zephyr:code-sample extension.
(The current iks4a1 shield sample documentation is broken)