### PR TITLE
doc: api: Overview: Add requirement to reset minor/patch versions

### DIFF
--- a/doc/develop/api/overview.rst
+++ b/doc/develop/api/overview.rst
@@ -39,6 +39,7 @@ following expectations:
 
  * Major version X (x.Y.z | x > 0) MUST be incremented if a compatibility
    breaking change was made to the API.
+   Patch and minor versions MUST be reset to 0 when major version is incremented.
 
 .. note::
    Version for existing APIs are initially set based on the current state of the


### PR DESCRIPTION
The referenced website (https://semver.org/) has this requirement, but it has been omitted in our documentation. It only exists for patch versions when minor versions are updated.

Add the requirement from https://semver.org/ that the minor and patch versions are also reset to 0 when the major version is incremented.