### PR TITLE
drivers: led_strip: ws2812_gpio: remove undeclared variable

### DIFF
--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -136,7 +136,7 @@ static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
 	rc = onoff_release(mgr);
 #else
-	rc = nrf_clock_control_release(drv_data->clk_dev, NULL);
+	rc = nrf_clock_control_release(clk_dev, NULL);
 #endif
 	/* Returns non-negative value on success. Cap to 0 as API states. */
 	rc = MIN(rc, 0);


### PR DESCRIPTION
The expression `drv_data->clk_dev` is invalid because the pointer `drv_data` is not declared anywhere. Since `nrf_clock_control_release()` is the counterpart to `nrf_clock_control_request()`, the pointer part `drv_data->` can be safely removed.

Fixes: #118481

Related to: #104658

Follow up for @mif1-nordic in [#104658 (comment)](https://github.com/zephyrproject-rtos/zephyr/pull/104658#discussion_r3951010391)