### PR TITLE
usb: host: fail device init when the device has no configurations

### DIFF
--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -581,6 +581,7 @@ int usbh_device_init(struct usb_device *const udev)
 	if (!udev->dev_desc.bNumConfigurations) {
 		LOG_ERR("Device has no configurations, bNumConfigurations %d",
 			udev->dev_desc.bNumConfigurations);
+		err = -EINVAL;
 		goto error;
 	}
 


### PR DESCRIPTION
The error was logged but the device initialization returned success, so the device was probed against the class instances without a configuration descriptor and the stack dereferenced a NULL pointer.

Fixes: #119107