### PR TITLE
dts: bindings: haptics: drv2605: default to the device's own voltages

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -659,6 +659,10 @@ Haptics
   and :dtcompatible:`cirrus,cs40l53`. Applications using the old compatible must update their
   devicetree nodes accordingly.
 
+* The ``vib-rated-mv`` and ``vib-overdrive-mv`` properties of :dtcompatible:`ti,drv2605` now
+  default to the device reset values, 1362 mV and 3075 mV, instead of 3200 mV. Boards that need
+  the previous drive level must set them explicitly.
+
 HWSPINLOCK
 ==========
 

--- a/dts/bindings/haptics/ti,drv2605.yaml
+++ b/dts/bindings/haptics/ti,drv2605.yaml
@@ -45,16 +45,20 @@ properties:
       a value of 2 ("HIGH") is valid for most actuators.
   vib-rated-mv:
     type: int
-    default: 3200
+    default: 1362
+    min: 0
+    max: 5600
     description: |
       Sets the reference voltage for full-scale output during closed-loop
-      operation. The default value is inherited from ti,drv260x.yaml in Linux.
+      operation. Defaults to the device reset value.
   vib-overdrive-mv:
     type: int
-    default: 3200
+    default: 3075
+    min: 0
+    max: 5600
     description: |
-      Sets a clamp so that the automatic overdrive is bounded. The default
-      value is inherited from ti,drv260x.yaml in Linux.
+      Sets a clamp so that the automatic overdrive is bounded. Defaults to the
+      device reset value.
   en-gpios:
     type: phandle-array
     description: GPIO to enable and disable the device.


### PR DESCRIPTION
The `vib-rated-mv` and `vib-overdrive-mv` defaults of 3200 mV were inherited from Linux rather than taken from the part, and drive an actuator harder than the DRV2605L's own reset values of 0x3E and 0x8C. On a LilyGO T-Watch S3 that is enough to make the device latch `OC_DETECT`, shut its output down and stop answering on I2C until the board is power cycled, so I think it would make sense to have defaults that are more conservative...

Default to the power-on values instead, 1362 mV and 3075 mV. Document the change in migration guide.