### PR TITLE
dts: vendor: nordic: nrf7120: Increase MRAM allocation to full

### DIFF
--- a/dts/vendor/nordic/nrf7120_7120e_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf7120_7120e_cpuapp_partition.dtsi
@@ -22,19 +22,19 @@
 		slot0_partition: partition@10000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-0";
-			reg = <0x00010000 DT_SIZE_K(1440)>;
+			reg = <0x00010000 DT_SIZE_K(1988)>;
 		};
 
-		slot1_partition: partition@178000 {
+		slot1_partition: partition@201000 {
 			compatible = "zephyr,mapped-partition";
 			label = "image-1";
-			reg = <0x00178000 DT_SIZE_K(1440)>;
+			reg = <0x00201000 DT_SIZE_K(1988)>;
 		};
 
-		storage_partition: partition@300000 {
+		storage_partition: partition@3f2000 {
 			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x00300000 DT_SIZE_K(36)>;
+			reg = <0x003f2000 DT_SIZE_K(36)>;
 		};
 	};
 };


### PR DESCRIPTION
Expand image slots and storage partitions to utilize the full MRAM address space on nRF7120.