### PR TITLE
soc: atmel: sam0: samc21: add PM support with IDLE0 and IDLE2

### DIFF
--- a/dts/arm/atmel/samc2x.dtsi
+++ b/dts/arm/atmel/samc2x.dtsi
@@ -48,6 +48,28 @@
 			reg = <0>;
 
 			device_type = "cpu";
+			cpu-power-states = <&idle0 &idle2>;
+		};
+
+		power-states {
+			idle0: state0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <20>;
+			};
+
+			idle2: state1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <500>;
+			};
+
+			standby: state2 {
+				compatible = "zephyr,power-state";
+				power-state-name = "standby";
+				min-residency-us = <5000>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/soc/atmel/sam0/common/CMakeLists.txt
+++ b/soc/atmel/sam0/common/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 zephyr_sources(soc_port.c)
 
+zephyr_sources_ifdef(CONFIG_PM power.c)
+
 zephyr_sources_ifdef(CONFIG_BOOTLOADER_BOSSA bossa.c)
 
 zephyr_sources_ifdef(CONFIG_SOC_SERIES_SAMC20 soc_samc2x.c)

--- a/soc/atmel/sam0/common/power.c
+++ b/soc/atmel/sam0/common/power.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+#include <soc.h>
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		k_cpu_idle();
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		PM->SLEEPCFG.bit.SLEEPMODE = 0x2;
+		while (PM->SLEEPCFG.bit.SLEEPMODE != 0x2) {
+		}
+		__DSB();
+		__ISB();
+		__WFI();
+		PM->SLEEPCFG.bit.SLEEPMODE = 0x0;
+		break;
+	default:
+		break;
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+}

--- a/soc/atmel/sam0/samc21/Kconfig
+++ b/soc/atmel/sam0/samc21/Kconfig
@@ -11,3 +11,4 @@ config SOC_SERIES_SAMC21
 	select CPU_CORTEX_M_HAS_VTOR
 	select CPU_HAS_ARM_MPU
 	select SOC_RESET_HOOK
+	select HAS_PM


### PR DESCRIPTION
Add Power Management support for the SAMC21 series (SAM0 Gen 2).

- Select HAS_PM in SOC_SERIES_SAMC21 Kconfig
- Add cpu-power-states and power-states DT node to samc2x.dtsi with runtime-idle (IDLE0) and suspend-to-idle (IDLE2) states. Standby is declared but disabled pending implementation.
- Add pm_state_set() and pm_state_exit_post_ops() in soc/atmel/sam0/common/power.c:
  * PM_STATE_RUNTIME_IDLE: WFI only
  * PM_STATE_SUSPEND_TO_IDLE: configure SLEEPCFG for IDLE2 with read-back per datasheet requirement, then WFI
- Build power.c conditionally on CONFIG_PM in CMakeLists.txt

Verified on samc21n_xpro with CONFIG_TICKLESS_KERNEL=y: PM policy selects IDLE2 correctly, system wakes on systick and GPIO events without issue.