### PR TITLE
soc: nordic: nrf71: extract early init into nordicsemi_nrf71_init

### DIFF
--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -176,7 +176,11 @@ static void wifi_setup(void)
 #endif
 #endif
 
-void soc_early_init_hook(void)
+/**
+ * This function is used by TF-M (see target_cfg_71.c, nrf71_init.c). You must align the TF-M
+ * implementation if you want to change this function.
+ */
+int nordicsemi_nrf71_init(void)
 {
 #if defined(CONFIG_HAS_NORDIC_RAM_CTRL) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	nrfx_ram_ctrl_retention_enable_all_set(false);
@@ -201,6 +205,7 @@ void soc_early_init_hook(void)
 
 	if (ret != 0) {
 		LOG_ERR("WICR programming failed: %d", ret);
+		return ret;
 	}
 #endif
 
@@ -224,6 +229,12 @@ void soc_early_init_hook(void)
 #elif defined(NRF_ICACHE)
 	nrf_cache_enable(NRF_ICACHE);
 #endif
+	return 0;
+}
+
+void soc_early_init_hook(void)
+{
+	(void)nordicsemi_nrf71_init();
 }
 
 void arch_busy_wait(uint32_t time_us)


### PR DESCRIPTION
soc_early_init_hook() is a generic Zephyr SoC API, called automatically by the kernel during a normal Zephyr boot. TF-M's
platform/ext/target/nordic_nrf/common/core/target_cfg_71.c also needs this same hardware bring-up to run during the Secure boot, which never goes through Zephyr's kernel init and so never calls the hook automatically and has to call the function by name instead.

Because target_cfg_71.c declared its own prototype for soc_early_init_hook() rather than sharing a header with this file, and TF-M's standalone fallback in nrf71_init.c happened to reuse the same name with a different (int) signature, the two independent declarations of the same symbol silently disagreed. The compiler cannot catch this across translation units, so it went undetected until it caused TF-M to read an uninitialized register as a bogus error code and panic on every boot, before any log output was even possible.

Extract the actual init logic into a new, TF-M-specific function nordicsemi_nrf71_init(), matching the pattern already used by nRF54L (nordicsemi_nrf54l_init()). soc_early_init_hook() becomes a thin wrapper that just calls it, so Zephyr's normal boot is unaffected, while TF-M can now call nordicsemi_nrf71_init() by a name that isn't also a generic Zephyr API with its own, unrelated contract.

Assisted-by: Claude:claude-opus-4.8