### PR TITLE
secure storage: its: fix spelling of chosen node

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -549,6 +549,8 @@ device.
        set the system time when :kconfig:option:`CONFIG_NET_CONFIG_CLOCK_SNTP_SET_RTC` is enabled)
    * - zephyr,rtk-serial
      - Selects the :ref:`uart_api` device used by the Serial GNSS RTK client.
+   * - zephyr,secure-storage-its-partition
+     - Fixed partition node. This selects the partition used by the Secure Storage ZMS backend.
    * - zephyr,sensor-clock
      - Selects the :ref:`counter_api` device used as sensor time source.
    * - zephyr,settings-partition

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -2297,6 +2297,9 @@ Secure Storage
   * ``zephyr/secure_storage/its/transform/aead_get.h`` ->
     ``zephyr/secure_storage/its/transform/aead.h``
 
+* The ZMS backend partition chosen name has been updated from
+  ``secure_storage_its_partition`` to ``zephyr,secure-storage-its-partition`` (:github:`118501`).
+
 Shell
 =====
 

--- a/subsys/secure_storage/Kconfig.its_store
+++ b/subsys/secure_storage/Kconfig.its_store
@@ -4,7 +4,8 @@
 choice SECURE_STORAGE_ITS_STORE_IMPLEMENTATION
 	prompt "ITS store module implementation"
 
-DT_ITS_PARTITION := $(dt_chosen_path,secure_storage_its_partition)
+DT_CHOSEN_Z_SECURE_STORAGE_ITS_PARTITION := zephyr,secure-storage-its-partition
+DT_ITS_PARTITION := $(dt_chosen_path,$(DT_CHOSEN_Z_SECURE_STORAGE_ITS_PARTITION))
 DT_CHOSEN_Z_SETTINGS_PARTITION := zephyr,settings-partition
 DT_SETTINGS_PARTITIION := $(dt_chosen_path,$(DT_CHOSEN_Z_SETTINGS_PARTITION))
 DT_STORAGE_PARTITION := $(dt_nodelabel_path,storage_partition)
@@ -18,7 +19,7 @@ config SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS
 	depends on ZMS
 	help
 	  This implementation of the ITS store module makes direct use of ZMS for storage.
-	  It needs a secure_storage_its_partition devicetree chosen property that points
+	  It needs a zephyr,secure-storage-its-partition devicetree chosen property that points
 	  to a fixed storage partition that will be dedicated to the ITS. It has lower
 	  overhead compared to the settings-based implementation, both in terms of runtime
 	  execution and storage space, and also ROM footprint if the settings subsystem is disabled.

--- a/subsys/secure_storage/src/its/store/zms.c
+++ b/subsys/secure_storage/src/its/store/zms.c
@@ -11,7 +11,7 @@ LOG_MODULE_DECLARE(secure_storage, CONFIG_SECURE_STORAGE_LOG_LEVEL);
 BUILD_ASSERT(CONFIG_SECURE_STORAGE_ITS_STORE_ZMS_SECTOR_SIZE
 	     > 2 * CONFIG_SECURE_STORAGE_ITS_MAX_DATA_SIZE);
 
-#define PARTITION_DT_NODE DT_CHOSEN(secure_storage_its_partition)
+#define PARTITION_DT_NODE DT_CHOSEN(zephyr_secure_storage_its_partition)
 
 static struct zms_fs s_zms = {
 	.flash_device = PARTITION_NODE_DEVICE(PARTITION_DT_NODE),

--- a/tests/subsys/secure_storage/psa/its/zms.overlay
+++ b/tests/subsys/secure_storage/psa/its/zms.overlay
@@ -1,5 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 / {
 	chosen {
-		secure_storage_its_partition = &storage_partition;
+		zephyr,secure-storage-its-partition = &storage_partition;
 	};
 };


### PR DESCRIPTION
The name of the chosen partition doesn't follow standard zephyr convention. Fixing the spelling so that the name is now "zephyr,secure-storage-its-partition".