### PR TITLE
dts: arm: st: f4: add DFSDM peripheral support

### DIFF
--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -253,6 +253,37 @@
 			master-can-reg = <0x40006400>;
 			status = "disabled";
 		};
+
+		dfsdm1: dfsdm@40016000 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>;
+			clock-names = "pclk";
+			resets = <&rctl STM32_RESET(APB2, 24)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm0: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <61 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm1: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <62 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -108,5 +108,56 @@
 				status = "disabled";
 			};
 		};
+
+		dfsdm2: dfsdm@40016400 {
+			compatible = "st,stm32-dfsdm";
+			reg = <0x40016400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 25)>;
+			clock-names = "pclk";
+			resets = <&rctl STM32_RESET(APB2, 25)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+
+			pdm2: filter@0 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <0>;
+				interrupts = <98 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm3: filter@1 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <1>;
+				interrupts = <99 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm4: filter@2 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <2>;
+				interrupts = <100 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			pdm5: filter@3 {
+				compatible = "st,stm32-dfsdm-dmic";
+				reg = <3>;
+				interrupts = <101 0>;
+				filter-order = <5>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+		};
 	};
 };


### PR DESCRIPTION
Add the DFSDM peripheral to STM32F4xx series.

Depending on the hardware, there is one or two instances of DFSDM, with a total of 2 or 6 filters respectively:

$ rg -c DFSDM._FLT._IRQn\\s stm32cube/stm32f4xx/soc/ | sort stm32cube/stm32f4xx/soc/stm32f412cx.h:2
stm32cube/stm32f4xx/soc/stm32f412rx.h:2
stm32cube/stm32f4xx/soc/stm32f412vx.h:2
stm32cube/stm32f4xx/soc/stm32f412zx.h:2
stm32cube/stm32f4xx/soc/stm32f413xx.h:6
stm32cube/stm32f4xx/soc/stm32f423xx.h:6

Audio clock 'aclk' has not been instanciated since it depends on board configuration.

I don't own any STM32F4 that allows to test DFSDM support. So this has only been compile tested.