### PR TITLE
boards: add missing Twister metadata so CI can build skipped boards

### DIFF
--- a/boards/amd/acp_6_0_adsp/acp_6_0_adsp.yaml
+++ b/boards/amd/acp_6_0_adsp/acp_6_0_adsp.yaml
@@ -12,3 +12,4 @@ toolchain:
   - zephyr
   - xcc
 vendor: amd
+twister: false

--- a/boards/amd/acp_7_0_adsp/acp_7_0_adsp.yaml
+++ b/boards/amd/acp_7_0_adsp/acp_7_0_adsp.yaml
@@ -3,9 +3,10 @@
 
 identifier: acp_7_0_adsp/acp_7_0
 name: AMD ACP7.0 Audio DSP
-type: mpu
+type: mcu
 arch: xtensa
 toolchain:
   - zephyr
   - xcc
 vendor: amd
+twister: false

--- a/boards/amd/acp_7_x_adsp/acp_7_x_adsp.yaml
+++ b/boards/amd/acp_7_x_adsp/acp_7_x_adsp.yaml
@@ -3,9 +3,10 @@
 
 identifier: acp_7_x_adsp/acp_7_x
 name: AMD ACP7.X Audio DSP
-type: mpu
+type: mcu
 arch: xtensa
 toolchain:
   - zephyr
   - xcc
 vendor: amd
+twister: false

--- a/boards/others/stm32_debug_probe/stm32_debug_probe.yaml
+++ b/boards/others/stm32_debug_probe/stm32_debug_probe.yaml
@@ -1,0 +1,14 @@
+identifier: stm32_debug_probe/stm32f103xb
+name: STM32 Debug Probe
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 20
+flash: 128
+supported:
+  - gpio
+  - uart
+  - usb_device
+vendor: others

--- a/boards/others/stm32_min_dev/twister.yaml
+++ b/boards/others/stm32_min_dev/twister.yaml
@@ -10,3 +10,6 @@ supported:
   - spi
   - adc
   - gpio
+variants:
+  stm32_min_dev/stm32f103x8:
+    twister: true

--- a/boards/shakti/nexys_ganga/nexys_ganga.yaml
+++ b/boards/shakti/nexys_ganga/nexys_ganga.yaml
@@ -1,0 +1,10 @@
+identifier: nexys_ganga/ganga
+name: Nexys Video (Ganga SoC)
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+ram: 262144
+supported:
+  - uart
+vendor: shakti

--- a/boards/st/stm32mp135f_dk/twister.yaml
+++ b/boards/st/stm32mp135f_dk/twister.yaml
@@ -1,4 +1,3 @@
-identifier: stm32mp135f_dk
 name: ST STM32MP135F-DK Discovery
 type: mcu
 arch: arm
@@ -14,3 +13,6 @@ supported:
 ram: 262144
 flash: 262144
 vendor: st
+variants:
+  stm32mp135f_dk/stm32mp135fxx:
+    twister: true

--- a/boards/viewe/uedx24240013_md50e/uedx24240013_md50e.yaml
+++ b/boards/viewe/uedx24240013_md50e/uedx24240013_md50e.yaml
@@ -1,0 +1,15 @@
+identifier: uedx24240013_md50e/esp32c3
+name: VIEWE UEDX24240013-MD50E
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+supported:
+  - gpio
+  - uart
+  - spi
+  - watchdog
+  - entropy
+  - input
+  - display
+vendor: viewe


### PR DESCRIPTION
CI `BoardStrategy` skipped several boards with "No targets found" because it only reads `*.yaml` files with an `identifier:` and `twister.yaml` `variants:` keys. Twister itself has the same `*.yaml` glob, so some of these boards were also missing from the platform inventory.

This PR adds or fixes that metadata so a board-directory change at least selects `tests/integration/kernel` for the board.
