### PR TITLE
app_version: fix custom app version handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,6 +693,10 @@ elseif(NOT ZEPHYR_GIT_INDEX)
   endif()
 endif()
 
+if(DEFINED APP_BUILD_VERSION)
+  set(app_build_version_argument "-DAPP_BUILD_VERSION=${APP_BUILD_VERSION}")
+endif()
+
 if(ZEPHYR_GIT_INDEX)
   set(git_dependency ${ZEPHYR_GIT_INDEX})
 endif()
@@ -725,7 +729,7 @@ if(EXISTS ${APPLICATION_SOURCE_DIR}/VERSION)
       -DVERSION_TYPE=APP
       -DVERSION_FILE=${APPLICATION_SOURCE_DIR}/VERSION
       -DAPP_VERSION_CUSTOMIZATION="$<TARGET_PROPERTY:app_version_h,APP_VERSION_CUSTOMIZATION>"
-      ${build_version_argument}
+      ${app_build_version_argument}
       -P ${ZEPHYR_BASE}/cmake/gen_version_h.cmake
     DEPENDS ${APPLICATION_SOURCE_DIR}/VERSION ${git_dependency}
       $<TARGET_PROPERTY:app_version_h,APP_VERSION_DEPENDS>

--- a/doc/build/cmake-ref/variable/APP_BUILD_VERSION.rst
+++ b/doc/build/cmake-ref/variable/APP_BUILD_VERSION.rst
@@ -1,0 +1,26 @@
+APP_BUILD_VERSION
+#################
+
+This variable is used in all contexts as the build version of the application.
+
+By default, if the application is in a Git repository, its contents are generated from the output of
+the command ``git describe --abbrev=12 --always`` run in the application folder. This results in a
+string which contains the most recent tag, the number of commits since that tag, and the abbreviated
+commit hash.
+
+This default behavior can also be overridden by setting the CMake variable ``APP_BUILD_VERSION`` to
+the desired string value. This can either be done in the ``CMakeLists.txt`` file, or on the command
+line when invoking CMake, e.g. via ``cmake -DAPP_BUILD_VERSION="v3.3.0-18-g2c85d92" ..``.
+
+Input to :cmake:module:`version`
+********************************
+
+Custom application build version to use for this build, if set externally.
+
+Output from :cmake:module:`version`
+***********************************
+
+Final value of the build version of the application: either the value of ``APP_BUILD_VERSION``, if
+set, or the value generated from the Git repository.
+
+See :ref:`app-version-details` for details; see also :cmake:variable:`BUILD_VERSION`.

--- a/doc/build/cmake-ref/variable/BUILD_VERSION.rst
+++ b/doc/build/cmake-ref/variable/BUILD_VERSION.rst
@@ -1,0 +1,26 @@
+BUILD_VERSION
+#############
+
+This variable is used in all contexts as the build version of the Zephyr kernel.
+
+By default, if the Zephyr project is in a Git repository and the ``git`` tool is available, its
+contents are generated from the output of the command ``git describe --abbrev=12 --always`` run in
+the Zephyr folder. This results in a string which contains the most recent tag, the number of
+commits since that tag, and the abbreviated commit hash.
+
+This default behavior can also be overridden by setting the CMake variable ``BUILD_VERSION`` to
+the desired string value. This can either be done in the ``CMakeLists.txt`` file, or on the command
+line when invoking CMake, e.g. via ``cmake -DBUILD_VERSION="v3.3.0-18-g2c85d92" ..``.
+
+Input to :cmake:module:`version`
+********************************
+
+Custom Zephyr build version to use for this build, if set externally.
+
+Output from :cmake:module:`version`
+***********************************
+
+Final value of the build version of the Zephyr project: either the value of ``BUILD_VERSION``, if
+already set, or the value generated from the Git repository.
+
+See also :cmake:variable:`APP_BUILD_VERSION`.

--- a/doc/build/version/index.rst
+++ b/doc/build/version/index.rst
@@ -68,6 +68,22 @@ For the sections below, examples are provided for the following :file:`VERSION` 
    VERSION_TWEAK = 4
    EXTRAVERSION = unstable.5
 
+Application build version
+=========================
+
+The *application build version* is a separate, more dynamic concept from the one described in the
+``VERSION`` file: it is intended to represent the current state of the application source code at
+the time of build, and is extracted from source versioning metadata.
+
+By default, if the application is in a Git repository, its contents are generated from the output of
+the command ``git describe --abbrev=12 --always`` run in the application folder. This results in a
+string which contains the most recent tag, the number of commits since that tag, and the abbreviated
+commit hash.
+
+Setting :cmake:variable:`APP_BUILD_VERSION` to the desired string value directly overrides this
+default behavior. This can either be done from the application ``CMakeLists.txt`` file or on the
+command line when invoking CMake, e.g. via ``cmake -DAPP_BUILD_VERSION="v3.3.0-18-g2c85d92" ..``.
+
 Use in code
 ===========
 
@@ -113,8 +129,7 @@ following defines are available:
 |                             |                   | ``PATCHLEVEL``, |br|                                 |                           |
 |                             |                   | ``VERSION_TWEAK`` |br|                               |                           |
 +-----------------------------+-------------------+------------------------------------------------------+---------------------------+
-| APP_BUILD_VERSION           | String (unquoted) | None (value of ``git describe --abbrev=12 --always`` | v3.3.0-18-g2c85d9224fca   |
-|                             |                   | from application repository)                         |                           |
+| APP_BUILD_VERSION           | String (unquoted) | None (see `Application build version`_ above)        | v3.3.0-18-g2c85d92        |
 +-----------------------------+-------------------+------------------------------------------------------+---------------------------+
 
 Use in Kconfig
@@ -195,6 +210,8 @@ The following variable are available for usage in CMake files:
 |                             |                 | ``PATCHLEVEL``, |br|                              |                    |
 |                             |                 | ``VERSION_TWEAK``                                 |                    |
 +-----------------------------+-----------------+---------------------------------------------------+--------------------+
+| APP_BUILD_VERSION           | String          | None (see `Application build version`_ above)     | v3.3.0-18-g2c85d92 |
++-----------------------------+-----------------+---------------------------------------------------+--------------------+
 
 Use in MCUboot-supported applications
 =====================================
@@ -215,5 +232,5 @@ When a shell interface is configured, the following commands are available to re
 +----------------------+-----------------------------+-------------------------+
 | app version-extended | APP_VERSION_EXTENDED_STRING | 1.2.3-unstable.5+4      |
 +----------------------+-----------------------------+-------------------------+
-| app build-version    | APP_BUILD_VERSION           | v3.3.0-18-g2c85d9224fca |
+| app build-version    | APP_BUILD_VERSION           | v3.3.0-18-g2c85d92      |
 +----------------------+-----------------------------+-------------------------+

--- a/tests/cmake/app_version/src/main.c
+++ b/tests/cmake/app_version/src/main.c
@@ -34,6 +34,7 @@ ZTEST(app_version, test_basic_strings)
 	zassert_equal(0, strcmp("5.6.7-development", APP_VERSION_STRING));
 	zassert_equal(0, strcmp("5.6.7-development+89", APP_VERSION_EXTENDED_STRING));
 	zassert_equal(0, strcmp("5.6.7+89", APP_VERSION_TWEAK_STRING));
+	zassert_equal(0, strcmp("user app version", STRINGIFY(APP_BUILD_VERSION)));
 }
 
 ZTEST_SUITE(app_version, NULL, NULL, NULL, NULL, NULL);

--- a/tests/cmake/app_version/tests.yaml
+++ b/tests/cmake/app_version/tests.yaml
@@ -3,3 +3,5 @@ tests:
     tags: version
     integration_platforms:
       - native_sim
+    extra_args:
+      - 'APP_BUILD_VERSION=user app version'


### PR DESCRIPTION
According to the code comments, `APP_BUILD_VERSION` can be overridden externally to set a custom version for the application. However, when generating `app_version.h` the Zephyr version (`BUILD_VERSION`) is passed instead. This results in `app_version.h` always containing the Git hash as a fallback, regardless of the user value.

Fix the issue by passing the correct `APP_BUILD_VERSION` to the `gen_version_h.cmake` script when generating `app_version.h`.