### PR TITLE
bluetooth: mesh: fix dfu applying step

### DIFF
--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -836,14 +836,20 @@ static int handle_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 			return 0;
 		}
 
-		/* MshDFUv1.0 Section 7.1.2.6: a target that responds with
-		 * status Success and phase Applying Update has accepted the
-		 * Firmware Update Apply message. A target that remains
-		 * provisioned may also respond with phase Idle once the apply
-		 * has already completed. Both responses are terminal for the
-		 * Apply step, and the Firmware Update Apply message is
-		 * idempotent, so further retries cannot change the response.
-		 * Acknowledge the target on the first such response.
+		if (phase == BT_MESH_DFU_PHASE_APPLYING &&
+		    !bt_mesh_has_addr(target->blob.addr)) {
+			/* MshDFUv1.0 Section 6.2.2.4 requires the Confirm step to
+			 * wait until the targets have applied. Keep repeating
+			 * Firmware Update Apply (Section 7.1.2.6) until the
+			 * target leaves Applying Update, otherwise the Confirm
+			 * step reads the old Firmware ID.
+			 */
+			LOG_DBG("Target 0x%04x still applying", target->blob.addr);
+			return 0;
+		}
+
+		/* The self-target defers its apply until the Confirm step
+		 * completes, so it never leaves Applying Update on its own.
 		 */
 		LOG_DBG("Target 0x%04x accepted apply (phase %u)",
 			target->blob.addr, phase);

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -95,27 +95,10 @@ static void apply_rsp_sent(int err, void *cb_params)
 {
 	struct bt_mesh_dfu_srv *srv = cb_params;
 
-	if (err == -ETIMEDOUT) {
-		/* The response was transmitted N times without receiving a
-		 * segment ack. A spec-compliant client that received any
-		 * complete copy of the Firmware Update Status message
-		 * containing status Success and phase Applying Update has
-		 * accepted it as terminal for the Apply step (MshDFUv1.0
-		 * Section 7.1.2.6) and will not retry Update Apply. Proceed
-		 * with the apply so our state matches what the client
-		 * believes; if the client did miss the response, its retry
-		 * hits handle_apply's idempotent APPLYING branch.
-		 */
-		LOG_WRN("Apply response ack timeout, applying anyway");
-	} else if (err) {
-		/* Any other end-of-send error (buffer exhaustion, cancellation,
-		 * etc.) means the response was not successfully placed on air.
-		 * Revert the phase so a client retry of Update Apply is
-		 * accepted as a fresh apply request.
-		 */
+	if (err) {
+		/* return phase back to give client one more chance. */
 		srv->update.phase = BT_MESH_DFU_PHASE_VERIFY_OK;
-		LOG_WRN("Apply response send failed (err %d), wait for retry",
-			err);
+		LOG_WRN("Apply response failed, wait for retry (err %d)", err);
 		return;
 	}
 
@@ -146,9 +129,6 @@ static void apply_rsp_sent(int err, void *cb_params)
 static void apply_rsp_sending(uint16_t duration, int err, void *cb_params)
 {
 	if (err) {
-		/* Start-of-send errors are never -ETIMEDOUT, so this falls
-		 * into apply_rsp_sent's revert-to-VERIFY_OK branch.
-		 */
 		apply_rsp_sent(err, cb_params);
 	}
 }

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1640,15 +1640,10 @@ static void test_cli_stop(void)
 		}
 
 		bt_mesh_dfu_cli_apply(&dfu_cli);
-		/* Per MshDFUv1.0 Section 7.1.2.6, SUCCESS + APPLYING is a terminal
-		 * response to Update Apply. The target sends this response before
-		 * its (test-injected) apply callback stalls, so the client MUST
-		 * accept it and complete the Apply step successfully.
-		 */
-		if (k_sem_take(&dfu_cli_applied_sem, K_SECONDS(SEMAPHORE_TIMEOUT))) {
-			FAIL("DFU Apply step did not complete");
+		if (!k_sem_take(&dfu_cli_applied_sem, K_SECONDS(SEMAPHORE_TIMEOUT))) {
+			FAIL("Apply should not complete: target stops while applying");
 		}
-		ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfu_cli_xfer.targets[0].status);
+		ASSERT_EQUAL(BT_MESH_DFU_ERR_INTERNAL, dfu_cli_xfer.targets[0].status);
 		ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_cli_xfer.targets[0].phase);
 		break;
 	case BT_MESH_DFU_PHASE_APPLY_SUCCESS:


### PR DESCRIPTION
Commit 1de08e0b6e08 ("bluetooth: mesh: dfu_cli, dfu_srv: accept SUCCESS
and APPLYING as terminal") made the Firmware Update Client acknowledge any
target that answers a Firmware Update Apply message with status Success
and phase Applying Update, ending the Apply step on the first response.

MshDFUv1.0 Section 6.2.2.4 requires the Confirm step of the Distribute
Firmware procedure to wait until the Target nodes have applied the new
firmware update before starting the Retrieve Firmware Information
procedure. The Apply step retry loop was the only thing implementing
that wait. Without it the client reads the Current Firmware ID while the
target is still installing, the Table 7.3 comparison in Section 7.1.2.9
fails, and the target is marked Apply Failed. A PTS test caught this.

Keep repeating Firmware Update Apply to a target reporting Applying
Update, as Section 7.1.2.6 permits, until it reports Idle. Once the
install completes the target answers Wrong Phase with phase Idle, which
the branch above already accepts as the end of the Apply step.

Keep acknowledging the self-target, which is why 1de08e0b6e08 touched
this branch in the first place: a Distributor that is also a Target
defers its own apply until the Confirm step completes, so it never
leaves Applying Update on its own and would otherwise stall the Apply
step until the retry budget is exhausted.

Revert the accompanying dfu_srv change as well. Its -ETIMEDOUT branch
applied the firmware although the Firmware Update Status response was
never acknowledged, assuming a client treats Success + Applying Update
as terminal and does not retry. That assumption no longer holds.
Reverting the phase to Verification Succeeded on any send error is
correct for a retrying client: the retry is accepted as a fresh apply
per Section 6.1.3.6.