### PR TITLE
Imx8 a core supports pwm

### DIFF
--- a/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk-pinctrl.dtsi
@@ -64,6 +64,14 @@
 		};
 	};
 
+	pwm3_default: pwm3_default {
+		group0 {
+			pinmux = <&iomuxc_spdif_tx_pwm_out_pwm3_out>;
+			slew-rate = "fast";
+			drive-strength = "x1";
+		};
+	};
+
 	pinmux_i2c3: pinmux_i2c3 {
 		group0 {
 			pinmux = <&iomuxc_i2c3_scl_i2c_scl_i2c3_scl>,

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.dts
@@ -101,3 +101,10 @@
 &wdog1 {
 	status = "okay";
 };
+
+&pwm3 {
+	pinctrl-0 = <&pwm3_default>;
+	pinctrl-names = "default";
+	prescaler = <9>;
+	status = "okay";
+};

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - i2c
   - watchdog
+  - pwm
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk-pinctrl.dtsi
@@ -64,6 +64,14 @@
 		};
 	};
 
+	pwm3_default: pwm3_default {
+		group0 {
+			pinmux = <&iomuxc_spdif_tx_pwm_out_pwm3_out>;
+			slew-rate = "fast";
+			drive-strength = "x1";
+		};
+	};
+
 	pinmux_i2c3: pinmux_i2c3 {
 		group0 {
 			pinmux = <&iomuxc_i2c3_scl_i2c_scl_i2c3_scl>,

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.dts
@@ -101,3 +101,10 @@
 &wdog1 {
 	status = "okay";
 };
+
+&pwm3 {
+	pinctrl-0 = <&pwm3_default>;
+	pinctrl-names = "default";
+	prescaler = <9>;
+	status = "okay";
+};

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
@@ -18,6 +18,7 @@ supported:
   - gpio
   - i2c
   - watchdog
+  - pwm
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/nxp/imx8mp_evk/imx8mp_evk-pinctrl.dtsi
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk-pinctrl.dtsi
@@ -115,6 +115,15 @@
 		};
 	};
 
+	pwm4_default: pwm4_default {
+		group0 {
+			pinmux = <&iomuxc_sai5_rxfs_pwm_out_pwm4_out>;
+			bias-pull-up;
+			slew-rate = "fast";
+			drive-strength = "x1";
+		};
+	};
+
 	pinmux_i2c3: pinmux_i2c3 {
 		group0 {
 			pinmux = <&iomuxc_i2c3_scl_i2c_scl_i2c3_scl>,

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.dts
@@ -139,3 +139,10 @@
 &wdog1 {
 	status = "okay";
 };
+
+&pwm4 {
+	pinctrl-0 = <&pwm4_default>;
+	pinctrl-names = "default";
+	prescaler = <9>;
+	status = "okay";
+};

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
@@ -17,6 +17,7 @@ supported:
   - gpio
   - i2c
   - net
+  - pwm
   - uart
   - watchdog
 testing:

--- a/drivers/pwm/Kconfig.imx
+++ b/drivers/pwm/Kconfig.imx
@@ -11,6 +11,18 @@ menuconfig PWM_IMX
 	help
 	  Enable support for i.MX pwm driver.
 
+config PWM_IMX_MCUX
+	bool
+	default y
+	depends on PWM_IMX
+	depends on SOC_MIMX8ML8_A53
+	help
+	  Use the MCUXpresso SDK register layout and clock API for the i.MX
+	  PWM driver. This is required on i.MX8M family Cortex-A cores, which
+	  provide the classic i.MX PWM IP through the MCUXpresso SDK device
+	  headers (fsl_device_registers.h / fsl_clock.h) instead of the legacy
+	  device_imx.h HAL used by the i.MX6/i.MX7 Cortex-M ports.
+
 config PWM_PWMSWR_LOOP
 	int "Loop count for PWM Software Reset"
 	default 5

--- a/drivers/pwm/Kconfig.imx
+++ b/drivers/pwm/Kconfig.imx
@@ -15,7 +15,7 @@ config PWM_IMX_MCUX
 	bool
 	default y
 	depends on PWM_IMX
-	depends on SOC_MIMX8ML8_A53
+	depends on SOC_MIMX8ML8_A53 || SOC_MIMX8MM6_A53 || SOC_MIMX8MN6_A53
 	help
 	  Use the MCUXpresso SDK register layout and clock API for the i.MX
 	  PWM driver. This is required on i.MX8M family Cortex-A cores, which

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -7,9 +7,15 @@
 #include <errno.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/kernel.h>
+#if defined(CONFIG_PWM_IMX_MCUX)
+#include <fsl_device_registers.h>
+#include <fsl_clock.h>
+#else
 #include <soc.h>
 #include <device_imx.h>
+#endif
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/sys/device_mmio.h>
 
 #include <zephyr/logging/log.h>
 
@@ -17,19 +23,101 @@ LOG_MODULE_REGISTER(pwm_imx, CONFIG_PWM_LOG_LEVEL);
 
 #define PWM_PWMSR_FIFOAV_4WORDS	0x4
 
+#if defined(CONFIG_PWM_IMX_MCUX)
+/*
+ * The MCUXpresso SDK exposes the classic i.MX PWM registers as C struct
+ * members (base->PWMCR, base->PWMSR, ...) instead of the legacy
+ * PWM_*_REG(base) accessor macros used by the device_imx.h HAL. Provide the
+ * accessor macros the driver body relies on so the same code path works with
+ * either HAL. The register bitfield macros (PWM_PWMCR_*_MASK/SHIFT,
+ * PWM_PWMCR_PRESCALER(), PWM_PWMCR_CLKSRC(), PWM_PWMSR_FIFOAV_MASK/SHIFT) are
+ * already provided by the MCUXpresso device header.
+ */
+#define PWM_PWMCR_REG(base)	((base)->PWMCR)
+#define PWM_PWMSR_REG(base)	((base)->PWMSR)
+#define PWM_PWMSAR_REG(base)	((base)->PWMSAR)
+#define PWM_PWMPR_REG(base)	((base)->PWMPR)
+
+/* Extract the FIFOAV field value from a PWMSR register read. */
+#define PWM_PWMSR_FIFOAV_GET(sr) \
+	(((uint32_t)(sr) & PWM_PWMSR_FIFOAV_MASK) >> PWM_PWMSR_FIFOAV_SHIFT)
+
+/*
+ * Return the PWM peripheral input clock frequency in Hz. The clock root is
+ * selected by the peripheral physical base address, which is kept in the
+ * device MMIO ROM data because the register accesses use the mapped virtual
+ * address instead.
+ */
+static uint32_t imx_pwm_clock_freq(uintptr_t phys_base)
+{
+	switch (phys_base) {
+	case PWM1_BASE:
+		return CLOCK_GetClockRootFreq(kCLOCK_Pwm1ClkRoot);
+	case PWM2_BASE:
+		return CLOCK_GetClockRootFreq(kCLOCK_Pwm2ClkRoot);
+	case PWM3_BASE:
+		return CLOCK_GetClockRootFreq(kCLOCK_Pwm3ClkRoot);
+	case PWM4_BASE:
+		return CLOCK_GetClockRootFreq(kCLOCK_Pwm4ClkRoot);
+	default:
+		return 0;
+	}
+}
+#else
+/*
+ * The legacy device_imx.h HAL provides a PWM_PWMSR_FIFOAV(sr) macro that
+ * extracts the FIFOAV field. Map the common accessor onto it.
+ */
+#define PWM_PWMSR_FIFOAV_GET(sr)	PWM_PWMSR_FIFOAV(sr)
+
+/*
+ * The MCUXpresso device header (fsl_device_registers.h) already defines the
+ * function-like PWM_PWMCR_SWR(x) macro. The legacy device_imx.h HAL only
+ * provides PWM_PWMCR_SWR_MASK/SHIFT, so define the accessor here for that path
+ * to avoid a redefinition warning when building against MCUXpresso.
+ */
 #define PWM_PWMCR_SWR(x) (((uint32_t)(((uint32_t)(x)) \
 				<<PWM_PWMCR_SWR_SHIFT))&PWM_PWMCR_SWR_MASK)
 
+/*
+ * The legacy device_imx.h HAL identifies the clock by the peripheral base
+ * address directly. On the Cortex-M ports that use this path there is no MMU,
+ * so the mapped address equals the physical base and can be used as-is.
+ */
+static uint32_t imx_pwm_clock_freq(uintptr_t phys_base)
+{
+	return get_pwm_clock_freq((PWM_Type *)phys_base);
+}
+#endif /* CONFIG_PWM_IMX_MCUX */
+
 struct imx_pwm_config {
-	PWM_Type *base;
+	DEVICE_MMIO_ROM;
 	uint16_t prescaler;
 	const struct pinctrl_dev_config *pincfg;
 };
 
 struct imx_pwm_data {
+	DEVICE_MMIO_RAM;
 	uint32_t period_cycles;
 };
 
+/* Return the mapped register block base for the given device. */
+static inline PWM_Type *imx_pwm_base(const struct device *dev)
+{
+	return (PWM_Type *)DEVICE_MMIO_GET(dev);
+}
+
+/* Return the peripheral physical base address, used to select the clock. */
+static inline uintptr_t imx_pwm_phys_base(const struct device *dev)
+{
+#ifdef DEVICE_MMIO_IS_IN_RAM
+	/* MMU platforms keep the physical base separate from the mapped one. */
+	return DEVICE_MMIO_ROM_PTR(dev)->phys_addr;
+#else
+	/* No MMU: the mapped address is the physical base. */
+	return DEVICE_MMIO_GET(dev);
+#endif
+}
 
 static bool imx_pwm_is_enabled(PWM_Type *base)
 {
@@ -41,7 +129,7 @@ static int imx_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 {
 	const struct imx_pwm_config *config = dev->config;
 
-	*cycles = get_pwm_clock_freq(config->base) >> config->prescaler;
+	*cycles = imx_pwm_clock_freq(imx_pwm_phys_base(dev)) >> config->prescaler;
 
 	return 0;
 }
@@ -52,8 +140,9 @@ static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
 {
 	const struct imx_pwm_config *config = dev->config;
 	struct imx_pwm_data *data = dev->data;
+	PWM_Type *base = imx_pwm_base(dev);
 	unsigned int period_ms;
-	bool enabled = imx_pwm_is_enabled(config->base);
+	bool enabled = imx_pwm_is_enabled(base);
 	int wait_count = 0, fifoav;
 	uint32_t cr, sr;
 
@@ -80,23 +169,23 @@ static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
 	 * when the controller is enabled and the FIFO is fully loaded.
 	 */
 	if (enabled) {
-		sr = PWM_PWMSR_REG(config->base);
-		fifoav = PWM_PWMSR_FIFOAV(sr);
+		sr = PWM_PWMSR_REG(base);
+		fifoav = PWM_PWMSR_FIFOAV_GET(sr);
 		if (fifoav == PWM_PWMSR_FIFOAV_4WORDS) {
-			period_ms = (get_pwm_clock_freq(config->base) >>
+			period_ms = (imx_pwm_clock_freq(imx_pwm_phys_base(dev)) >>
 					config->prescaler) * MSEC_PER_SEC;
 			k_sleep(K_MSEC(period_ms));
 
-			sr = PWM_PWMSR_REG(config->base);
-			if (fifoav == PWM_PWMSR_FIFOAV(sr)) {
+			sr = PWM_PWMSR_REG(base);
+			if (fifoav == PWM_PWMSR_FIFOAV_GET(sr)) {
 				LOG_WRN("there is no free FIFO slot\n");
 			}
 		}
 	} else {
-		PWM_PWMCR_REG(config->base) = PWM_PWMCR_SWR(1);
+		PWM_PWMCR_REG(base) = PWM_PWMCR_SWR(1);
 		do {
 			k_sleep(K_MSEC(1));
-			cr = PWM_PWMCR_REG(config->base);
+			cr = PWM_PWMCR_REG(base);
 		} while ((PWM_PWMCR_SWR(cr)) &&
 			 (++wait_count < CONFIG_PWM_PWMSWR_LOOP));
 
@@ -116,7 +205,7 @@ static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	PWM_PWMSAR_REG(config->base) = pulse_cycles;
+	PWM_PWMSAR_REG(base) = pulse_cycles;
 
 	if (data->period_cycles != period_cycles) {
 		LOG_WRN("Changing period cycles from %d to %d in %s",
@@ -124,14 +213,14 @@ static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
 			    dev->name);
 
 		data->period_cycles = period_cycles;
-		PWM_PWMPR_REG(config->base) = period_cycles;
+		PWM_PWMPR_REG(base) = period_cycles;
 	}
 
 	cr = PWM_PWMCR_EN_MASK | PWM_PWMCR_PRESCALER(config->prescaler) |
 		PWM_PWMCR_DOZEN_MASK | PWM_PWMCR_WAITEN_MASK |
 		PWM_PWMCR_DBGEN_MASK | PWM_PWMCR_CLKSRC(2);
 
-	PWM_PWMCR_REG(config->base) = cr;
+	PWM_PWMCR_REG(base) = cr;
 
 	return 0;
 }
@@ -142,12 +231,19 @@ static int imx_pwm_init(const struct device *dev)
 	struct imx_pwm_data *data = dev->data;
 	int err;
 
+	/*
+	 * Map the peripheral MMIO region through the device MMIO API instead of
+	 * relying on a static mmu_regions.c entry. On the Cortex-M ports without
+	 * an MMU this resolves to the physical address at build time.
+	 */
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
 		return err;
 	}
 
-	PWM_PWMPR_REG(config->base) = data->period_cycles;
+	PWM_PWMPR_REG(imx_pwm_base(dev)) = data->period_cycles;
 
 	return 0;
 }
@@ -160,7 +256,7 @@ static DEVICE_API(pwm, imx_pwm_driver_api) = {
 #define PWM_IMX_INIT(n)							\
 	PINCTRL_DT_INST_DEFINE(n);					\
 	static const struct imx_pwm_config imx_pwm_config_##n = {	\
-		.base = (PWM_Type *)DT_INST_REG_ADDR(n),		\
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),			\
 		.prescaler = DT_INST_PROP(n, prescaler),		\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 	};								\

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -286,6 +286,58 @@
 		reg = <0x303d0000 DT_SIZE_K(64)>;
 	};
 
+	pwm1: pwm@30660000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30660000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 81 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm2: pwm@30670000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30670000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm3: pwm@30680000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30680000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm4: pwm@30690000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30690000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 84 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M4_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
 	enet: enet@30be0000 {
 		compatible = "nxp,enet";
 		reg = <0x30be0000 DT_SIZE_K(64)>;

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -275,6 +275,58 @@
 		reg = <0x303d0000 DT_SIZE_K(64)>;
 	};
 
+	pwm1: pwm@30660000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30660000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 81 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm2: pwm@30670000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30670000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm3: pwm@30680000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30680000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
+	pwm4: pwm@30690000 {
+		compatible = "fsl,imx27-pwm";
+		reg = <0x30690000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 84 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+		prescaler = <0>;
+		rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+			RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+		#pwm-cells = <2>;
+		status = "disabled";
+	};
+
 	enet: enet@30be0000 {
 		compatible = "nxp,enet";
 		reg = <0x30be0000 DT_SIZE_K(64)>;

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -353,6 +353,58 @@
 			compatible = "nxp,rdc";
 			reg = <0x303d0000 DT_SIZE_K(64)>;
 		};
+
+		pwm1: pwm@30660000 {
+			compatible = "fsl,imx27-pwm";
+			reg = <0x30660000 DT_SIZE_K(64)>;
+			interrupts = <GIC_SPI 81 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-parent = <&gic>;
+			clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
+
+		pwm2: pwm@30670000 {
+			compatible = "fsl,imx27-pwm";
+			reg = <0x30670000 DT_SIZE_K(64)>;
+			interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-parent = <&gic>;
+			clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
+
+		pwm3: pwm@30680000 {
+			compatible = "fsl,imx27-pwm";
+			reg = <0x30680000 DT_SIZE_K(64)>;
+			interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-parent = <&gic>;
+			clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
+
+		pwm4: pwm@30690000 {
+			compatible = "fsl,imx27-pwm";
+			reg = <0x30690000 DT_SIZE_K(64)>;
+			interrupts = <GIC_SPI 84 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-parent = <&gic>;
+			clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
+			prescaler = <0>;
+			rdc = <(RDC_DOMAIN_PERM(A53_DOMAIN_ID, RDC_DOMAIN_PERM_RW) |
+				RDC_DOMAIN_PERM(M7_DOMAIN_ID, RDC_DOMAIN_PERM_RW))>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -63,6 +63,8 @@ In these other cases, however, manual wiring is necessary:
      - connect PWM6 (J47-6) to an LED
    * - :zephyr:board:`imx95_evk`
      - connect PWM2 (R881) to an LED
+   * - :zephyr:board:`imx8mp_evk`
+     - connect PWM4 (J21-32) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -65,6 +65,8 @@ In these other cases, however, manual wiring is necessary:
      - connect PWM2 (R881) to an LED
    * - :zephyr:board:`imx8mp_evk`
      - connect PWM4 (J21-32) to an LED
+   * - :zephyr:board:`imx8mm_evk`
+     - connect PWM3 (J1001-47) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -67,6 +67,8 @@ In these other cases, however, manual wiring is necessary:
      - connect PWM4 (J21-32) to an LED
    * - :zephyr:board:`imx8mm_evk`
      - connect PWM3 (J1001-47) to an LED
+   * - :zephyr:board:`imx8mn_evk`
+     - connect PWM3 (J1001-47) to an LED
 
 Building and Running
 ********************

--- a/samples/basic/blinky_pwm/boards/imx8mm_evk_mimx8mm6_a53.overlay
+++ b/samples/basic/blinky_pwm/boards/imx8mm_evk_mimx8mm6_a53.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Connect PWM3 (J1001-47) to an LED */
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm3 0 PWM_MSEC(20)>;
+		};
+	};
+};

--- a/samples/basic/blinky_pwm/boards/imx8mn_evk_mimx8mn6_a53.overlay
+++ b/samples/basic/blinky_pwm/boards/imx8mn_evk_mimx8mn6_a53.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Connect PWM3 (J1001-47) to an LED */
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm3 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};

--- a/samples/basic/blinky_pwm/boards/imx8mp_evk_mimx8ml8_a53.overlay
+++ b/samples/basic/blinky_pwm/boards/imx8mp_evk_mimx8ml8_a53.overlay
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Connect PWM4 (J21-32) to an LED */
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm4 0 PWM_MSEC(20)>;
+		};
+	};
+};

--- a/soc/nxp/imx/imx8m/a53/soc.c
+++ b/soc/nxp/imx/imx8m/a53/soc.c
@@ -91,6 +91,34 @@ __weak void soc_clock_init(void)
 	/* Set root clock to 800MHZ / 10 = 80MHZ */
 	CLOCK_SetRootDivider(kCLOCK_RootFlexCan2, 2U, 5U);
 #endif
+	/*
+	 * Configure and ungate the PWM peripheral clocks. The i.MX PWM driver
+	 * accesses the PWM register block at init time but does not manage the
+	 * peripheral clock itself. Without ungating the clock here the very
+	 * first register access stalls the SoC bus and hangs the core before
+	 * the boot banner is printed, so set the root mux/divider to OSC 24MHz
+	 * and enable the gate for every enabled PWM instance.
+	 */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pwm1))
+	CLOCK_SetRootMux(kCLOCK_RootPwm1, kCLOCK_PwmRootmuxOsc24M);
+	CLOCK_SetRootDivider(kCLOCK_RootPwm1, 1U, 1U);
+	CLOCK_EnableClock(kCLOCK_Pwm1);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pwm2))
+	CLOCK_SetRootMux(kCLOCK_RootPwm2, kCLOCK_PwmRootmuxOsc24M);
+	CLOCK_SetRootDivider(kCLOCK_RootPwm2, 1U, 1U);
+	CLOCK_EnableClock(kCLOCK_Pwm2);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pwm3))
+	CLOCK_SetRootMux(kCLOCK_RootPwm3, kCLOCK_PwmRootmuxOsc24M);
+	CLOCK_SetRootDivider(kCLOCK_RootPwm3, 1U, 1U);
+	CLOCK_EnableClock(kCLOCK_Pwm3);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pwm4))
+	CLOCK_SetRootMux(kCLOCK_RootPwm4, kCLOCK_PwmRootmuxOsc24M);
+	CLOCK_SetRootDivider(kCLOCK_RootPwm4, 1U, 1U);
+	CLOCK_EnableClock(kCLOCK_Pwm4);
+#endif
 }
 
 void soc_prep_hook(void)


### PR DESCRIPTION
Add PWM sample support for the A53 core on imx8mp_evk, imx8mm_evk, and imx8mn_evk.
The PWM functionality has been verified on the boards.