### PR TITLE
drivers: serial: stm32: lock IRQs when setting interrupt callback

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1232,6 +1232,7 @@ static void uart_stm32_irq_callback_set(const struct device *dev,
 					void *cb_data)
 {
 	struct uart_stm32_data *data = dev->data;
+	unsigned int key = irq_lock();
 
 	data->user_cb = cb;
 	data->user_data = cb_data;
@@ -1240,6 +1241,8 @@ static void uart_stm32_irq_callback_set(const struct device *dev,
 	data->async_cb = NULL;
 	data->async_user_data = NULL;
 #endif
+
+	irq_unlock(key);
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -1573,6 +1576,7 @@ static int uart_stm32_async_callback_set(const struct device *dev,
 					 void *user_data)
 {
 	struct uart_stm32_data *data = dev->data;
+	unsigned int key = irq_lock();
 
 	data->async_cb = callback;
 	data->async_user_data = user_data;
@@ -1581,6 +1585,8 @@ static int uart_stm32_async_callback_set(const struct device *dev,
 	data->user_cb = NULL;
 	data->user_data = NULL;
 #endif
+
+	irq_unlock(key);
 
 	return 0;
 }


### PR DESCRIPTION
Protect the assignment of user_cb and user_data in uart_stm32_irq_callback_set() using irq_lock() and irq_unlock() to prevent a race condition where an incoming UART interrupt executes the new callback with stale user_data.

Fixes #118457