### PR TITLE
samples: sensor: mcux_lpcmp: do not fail on deprecated Kconfig

### DIFF
--- a/samples/sensor/mcux_lpcmp/README.rst
+++ b/samples/sensor/mcux_lpcmp/README.rst
@@ -9,6 +9,12 @@ Overview
 
 This sample show how to use the NXP MCUX Low-power Analog Comparator (LPCMP) driver.
 
+.. note::
+   This sample demonstrates the deprecated ``mcux_lpcmp`` sensor driver. New
+   applications should use the :ref:`comparator API <comparator_api>` with
+   :kconfig:option:`CONFIG_COMPARATOR_NXP_LPCMP` instead. The driver and this
+   sample are scheduled for removal in Zephyr 4.6.
+
 In this application, the negative input port of the LPCMP is set with
 :kconfig:option:`CONFIG_LPCMP_NEGATIVE_PORT` which means the input voltage comes
 from the LPCMP internal DAC. The reference voltage of the DAC is set to 0 (check

--- a/samples/sensor/mcux_lpcmp/prj.conf
+++ b/samples/sensor/mcux_lpcmp/prj.conf
@@ -2,3 +2,8 @@ CONFIG_SENSOR=y
 CONFIG_MCUX_LPCMP_TRIGGER=y
 CONFIG_MCUX_LPCMP=y
 CONFIG_COMPARATOR_NXP_LPCMP=n
+
+# The mcux_lpcmp sensor driver is deprecated in favor of the comparator API
+# (CONFIG_COMPARATOR_NXP_LPCMP). Both the driver and this sample are scheduled
+# for removal in Zephyr 4.6, keep this sample buildable until then.
+CONFIG_WARN_DEPRECATED=n


### PR DESCRIPTION
add CONFIG_WARN_DEPRECATED=n for `samples/sensor/mcux_lpcmp/README.rst`

The 4.4 release notes state that this sample will be removed in version 4.6, so it is being retained for the time being.

https://github.com/zephyrproject-rtos/zephyr/blob/main/doc/releases/release-notes-4.4.rst?plain=1#L370