### PR TITLE
boards: antmicro: stm32h7_renode_reference_board: repl fixes

### DIFF
--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
@@ -34,6 +34,8 @@ sw4: Miscellaneous.Button @ gpioPortG 10
 
 veml7700: Sensors.VEML7700 @ i2c1 0x10
 
+iis2mdc: Sensors.IIS2MDC @ i2c1 0x1E
+
 tmp108: Sensors.TMP108 @ i2c1 0x48
 
 lps25hb: Sensors.LPS25HB @ i2c1 0x5D

--- a/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
+++ b/boards/antmicro/stm32h7_renode_reference_board/support/stm32h7_renode_reference_board.repl
@@ -55,9 +55,6 @@ qspiFlash: SPI.ISSI_IS25WP @ qspi
 flashMem: Memory.MappedMemory @ sysbus 0x90000000
     size: 0x8000000
 
-dwt: Miscellaneous.DWT @ sysbus 0xE0001000
-    frequency: 72000000
-
 phy: Network.EthernetPhysicalLayer @ ethernet 0
     BasicControl: 0x3100
     BasicStatus: 0x782D


### PR DESCRIPTION
This PR adds missing iis2mdc sensor and removes duplicate dwt definition from Antmicro's STM32H7 Renode Reference Platform board repl file.