### PR TITLE
Fix uart nrfx irq cb race

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -921,6 +921,8 @@ static void uart_nrfx_irq_callback_set(const struct device *dev,
 				       void *cb_data)
 {
 	(void)dev;
+	unsigned int key = irq_lock();
+
 	irq_callback = cb;
 	irq_cb_data = cb_data;
 
@@ -928,6 +930,8 @@ static void uart_nrfx_irq_callback_set(const struct device *dev,
 	uart0_cb.callback = NULL;
 	uart0_cb.user_data = NULL;
 #endif
+
+	irq_unlock(key);
 }
 
 /**

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1232,6 +1232,7 @@ static void uart_stm32_irq_callback_set(const struct device *dev,
 					void *cb_data)
 {
 	struct uart_stm32_data *data = dev->data;
+	unsigned int key = irq_lock();
 
 	data->user_cb = cb;
 	data->user_data = cb_data;
@@ -1240,6 +1241,8 @@ static void uart_stm32_irq_callback_set(const struct device *dev,
 	data->async_cb = NULL;
 	data->async_user_data = NULL;
 #endif
+
+	irq_unlock(key);
 }
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */


### PR DESCRIPTION
In drivers/serial/uart_nrfx_uart.c, uart_nrfx_irq_callback_set() updates irq_callback and irq_cb_data without disabling interrupts. If a UART IRQ triggers between the two assignments, uart_nrfx_isr() executes the newly assigned callback with the old context argument (irq_cb_data).

This PR wraps the callback assignments in an irq_lock() / irq_unlock() critical section to prevent the race condition.

Fixes #118456