### PR TITLE
subsys: pm: refine pm device runtime put related functions

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -413,10 +413,6 @@ static int put_sync_locked(const struct device *dev)
 	struct pm_device_isr *pm = dev->pm_isr;
 	uint32_t flags = pm->base.flags;
 
-	if (!(flags & BIT(PM_DEVICE_FLAG_RUNTIME_ENABLED))) {
-		return 0;
-	}
-
 	if (pm->base.usage == 0U) {
 		return -EALREADY;
 	}
@@ -434,7 +430,7 @@ static int put_sync_locked(const struct device *dev)
 			const struct device *domain = PM_DOMAIN(&pm->base);
 
 			if (domain->pm_base->flags & BIT(PM_DEVICE_FLAG_ISR_SAFE)) {
-				ret = put_sync_locked(domain);
+				ret = pm_device_runtime_put(domain);
 				pm->base.flags &= ~BIT(PM_DEVICE_FLAG_PD_CLAIMED);
 			} else {
 				ret = -EWOULDBLOCK;

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -141,13 +141,6 @@ static int runtime_suspend(const struct device *dev, bool async,
 	int ret = 0;
 	struct pm_device *pm = dev->pm;
 
-	/*
-	 * Early return if device runtime is not enabled.
-	 */
-	if (!atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
-		return 0;
-	}
-
 	/* If we are not the last user, return. */
 	if (runtime_usage_put_fast(pm)) {
 		return 0;
@@ -464,7 +457,12 @@ int pm_device_runtime_put(const struct device *dev)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put, dev);
 
-	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+	/*
+	 * Early return if device runtime is not enabled.
+	 */
+	if (!atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+		ret = 0;
+	} else if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
 		struct pm_device_isr *pm_sync = dev->pm_isr;
 		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
 
@@ -489,7 +487,13 @@ int pm_device_runtime_put_async(const struct device *dev, k_timeout_t delay)
 	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put_async, dev, delay);
-	if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
+
+	/*
+	 * Early return if device runtime is not enabled.
+	 */
+	if (!atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED)) {
+		ret = 0;
+	} else if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_ISR_SAFE)) {
 		struct pm_device_isr *pm_sync = dev->pm_isr;
 		k_spinlock_key_t k = k_spin_lock(&pm_sync->lock);
 


### PR DESCRIPTION
see commit message.

test pass:

- `pm.device_runtime.stress` — `qemu_x86`, `qemu_cortex_a53/smp`
- `pm.power_domain`, `pm.power_domain.isr_safe` — `qemu_x86`, `qemu_cortex_a53/smp`
- the same two suites with `CONFIG_SPIN_VALIDATE=y CONFIG_ASSERT=y`, no lock assert
- `pm.device_runtime.api`, 4 configs — no per-case status change vs. unmodified `main`

`pm.power_domain.isr_safe` on `qemu_cortex_a53/smp` is the relevant coverage for 2/2: it is the only suite exercising `put_sync_locked()` releasing an ISR-safe power domain on SMP.