### PR TITLE
drivers: serial: reclaim empty completed async RX buffers

### DIFF
--- a/drivers/serial/uart_async_rx.c
+++ b/drivers/serial/uart_async_rx.c
@@ -83,7 +83,7 @@ size_t uart_async_rx_data_claim(struct uart_async_rx *rx_data, uint8_t **data, s
 	struct uart_async_rx_buf *buf;
 	int rem;
 
-	if ((rx_data->pending_bytes == 0) || (length == 0)) {
+	if (length == 0) {
 		return 0;
 	}
 
@@ -98,6 +98,10 @@ size_t uart_async_rx_data_claim(struct uart_async_rx *rx_data, uint8_t **data, s
 			break;
 		}
 	} while (1);
+
+	if (rx_data->pending_bytes == 0) {
+		return 0;
+	}
 
 	*data = &buf->buffer[rx_data->rd_idx];
 	rem = buf->wr_idx - rx_data->rd_idx;

--- a/tests/drivers/uart/uart_async_rx/src/main.c
+++ b/tests/drivers/uart/uart_async_rx/src/main.c
@@ -144,6 +144,44 @@ ZTEST(uart_async_rx, test_rx_late_consume)
 	zassert_equal(claim_len, 0);
 }
 
+ZTEST(uart_async_rx, test_rx_reclaim_empty_completed_buffers)
+{
+	uint8_t storage[40];
+	uint8_t *allocated[4];
+	uint8_t *claim_buf;
+	struct uart_async_rx async_rx;
+	const struct uart_async_rx_config config = {
+		.buffer = storage,
+		.length = sizeof(storage),
+		.buf_cnt = ARRAY_SIZE(allocated),
+	};
+	int err;
+
+	err = uart_async_rx_init(&async_rx, &config);
+	zassert_ok(err);
+
+	for (size_t i = 0; i < ARRAY_SIZE(allocated); i++) {
+		allocated[i] = uart_async_rx_buf_req(&async_rx);
+		zassert_not_null(allocated[i]);
+	}
+	zassert_is_null(uart_async_rx_buf_req(&async_rx));
+
+	for (size_t i = 0; i < ARRAY_SIZE(allocated); i++) {
+		uart_async_rx_on_buf_rel(&async_rx, allocated[i]);
+	}
+
+	claim_buf = allocated[0];
+	zassert_equal(uart_async_rx_data_claim(&async_rx, &claim_buf, 0), 0);
+	zassert_equal(claim_buf, allocated[0]);
+	zassert_is_null(uart_async_rx_buf_req(&async_rx));
+
+	zassert_equal(uart_async_rx_data_claim(&async_rx, &claim_buf, 1), 0);
+
+	for (size_t i = 0; i < ARRAY_SIZE(allocated); i++) {
+		zassert_equal(uart_async_rx_buf_req(&async_rx), allocated[i]);
+	}
+}
+
 struct test_async_rx {
 	struct uart_async_rx async_rx;
 	atomic_t pending_req;


### PR DESCRIPTION
## Problem

The asynchronous RX helper can keep empty completed buffers outside the free
pool indefinitely.

Buffers are returned to the pool lazily from the consumer. However,
`uart_async_rx_data_claim()` returned immediately when `pending_bytes` was zero,
before walking over completed buffers. If a driver released buffers without
reporting data, every buffer could be `completed=1, wr_idx=0` while
`free_buf_cnt` remained zero.

This invariant failure was captured while reproducing an asynchronous UART
shell stall on `nrf54l15dk/nrf54l15/cpuapp`:

```
free=0 pbytes=0
[0] completed=1 wr_idx=0
[1] completed=1 wr_idx=0
[2] completed=1 wr_idx=0
[3] completed=1 wr_idx=0
```

## Fix

Run the existing ordered empty-buffer reclaim loop before checking
`pending_bytes`. A nonzero consumer poll can now return completed empty buffers
to the pool even when there is no payload to claim.

Zero-length claims remain side-effect free. The output pointer remains
untouched and no buffers are reclaimed.

## Regression test

The new test:

- allocates the complete four-buffer pool
- releases all four buffers without reporting data
- verifies a zero-length claim has no side effects
- performs one nonzero consumer poll with no pending bytes
- verifies all four buffers are reusable in FIFO order

The test commit was applied independently to the unmodified base to verify the
failure mode. That run passed 4 of 5 cases and failed only
`test_rx_reclaim_empty_completed_buffers` at the first FIFO buffer-reuse
assertion. With the implementation commit present, all 5 cases pass.

The same RED/GREEN check was repeated with Twister device testing on
`nrf54l15dk/nrf54l15/cpuapp`. The test-only branch passed 4 of 5 cases and
failed only the new reclaim test. The MR tip passed all 5 cases on the DK.