### PR TITLE
tests: bsim: use unique temp result file

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -60,7 +60,7 @@ fi
 set -u
 
 RESULTS_FILE="${RESULTS_FILE:-`pwd`/../RunResults.xml}"
-tmp_res_file=tmp.xml
+tmp_res_file=$(mktemp --tmpdir run_parallel.XXXXXX.xml)
 
 if [[ -v BOARD ]]; then
 	export FAILURE_EXTRA_INFO=" on ${BOARD}"


### PR DESCRIPTION
The parallel test runner used a fixed temporary result file name. When multiple runs execute in the same working directory, they can overwrite or race on each other's result files.

Use mktemp to create a unique file per invocation, avoiding collisions between parallel bsim runs.