### PR TITLE
tracing: ctf: guard socket address arguments against NULL

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -978,11 +978,15 @@ void sys_trace_socket_shutdown_exit(int sock, int ret)
 void sys_trace_socket_bind_enter(int sock, const struct net_sockaddr *addr, size_t addrlen)
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};
+	uint16_t port = 0U;
 
-	(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
-			    sizeof(addr_str.buf));
+	if (addr != NULL) {
+		(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
+				    sizeof(addr_str.buf));
+		port = net_ntohs(net_sin(addr)->sin_port);
+	}
 
-	ctf_top_socket_bind_enter(sock, addr_str, addrlen, net_ntohs(net_sin(addr)->sin_port));
+	ctf_top_socket_bind_enter(sock, addr_str, addrlen, port);
 }
 
 void sys_trace_socket_bind_exit(int sock, int ret)
@@ -994,8 +998,10 @@ void sys_trace_socket_connect_enter(int sock, const struct net_sockaddr *addr, s
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};
 
-	(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
-			    sizeof(addr_str.buf));
+	if (addr != NULL) {
+		(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
+				    sizeof(addr_str.buf));
+	}
 
 	ctf_top_socket_connect_enter(sock, addr_str, addrlen);
 }
@@ -1213,11 +1219,18 @@ void sys_trace_socket_getpeername_exit(int sock,  struct net_sockaddr *addr,
 				       const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};
+	uint32_t addr_len = 0U;
 
-	(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
-			    sizeof(addr_str.buf));
+	if (addr != NULL) {
+		(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
+				    sizeof(addr_str.buf));
+	}
 
-	ctf_top_socket_getpeername_exit(sock, addr_str, *addrlen, ret);
+	if (addrlen != NULL) {
+		addr_len = *addrlen;
+	}
+
+	ctf_top_socket_getpeername_exit(sock, addr_str, addr_len, ret);
 }
 
 void sys_trace_socket_getsockname_enter(int sock)
@@ -1229,11 +1242,18 @@ void sys_trace_socket_getsockname_exit(int sock, const struct net_sockaddr *addr
 				       const uint32_t *addrlen, int ret)
 {
 	ctf_net_bounded_string_t addr_str = {"unknown"};
+	uint32_t addr_len = 0U;
 
-	(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
-			    sizeof(addr_str.buf));
+	if (addr != NULL) {
+		(void)net_addr_ntop(addr->sa_family, &net_sin(addr)->sin_addr, addr_str.buf,
+				    sizeof(addr_str.buf));
+	}
 
-	ctf_top_socket_getsockname_exit(sock, addr_str, *addrlen, ret);
+	if (addrlen != NULL) {
+		addr_len = *addrlen;
+	}
+
+	ctf_top_socket_getsockname_exit(sock, addr_str, addr_len, ret);
 }
 
 void sys_trace_socket_socketpair_enter(int family, int type, int proto, int *sv)


### PR DESCRIPTION
Check sockaddr and addrlen for NULL in four CTF socket hooks, matching accept_exit and recvfrom_exit.

Fixes #117635