### PR TITLE
modem: cellular: silence the implicit switch fallthroughs

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1103,6 +1103,7 @@ static void modem_cellular_await_power_on_event_handler(struct modem_cellular_da
 	case MODEM_CELLULAR_EVENT_MODEM_READY:
 		/* disable the timer and fall through, as we are ready to proceed */
 		modem_cellular_stop_timer(data);
+		__fallthrough;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		if (config->vendor->scripts.set_baudrate != NULL) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_SET_BAUDRATE);
@@ -2017,6 +2018,7 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 	case MODEM_CELLULAR_EVENT_RING:
 		LOG_DBG("RING received!");
 		modem_pipe_open_async(data->uart_pipe);
+		break;
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
 		/* Wait for the channel to return to AT mode after PPP termination */
 		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));


### PR DESCRIPTION
A `CONFIG_CODING_GUIDELINE_CHECK` build compiles this driver with `-Wimplicit-fallthrough=2`, which flags two case reaches.

The await power on handler means its one, as the comment there already says, so it just wants the marker. The RING case in the await ppp dead handler does not: it is the only RING case in the driver that does not end, and nothing marks the reach as deliberate.
Ending it is a deliberate behaviour change on one path. Three of the four entries into that state arm the timeout at the call site, so the `start_timer` the fallthrough reached was a no-op there. The fourth, the deregistered case, arms none, and leaving the registered state cancels any pending one, so a RING arriving there used to arm the settling timeout and now does not. 

In practice the state's own `net_if_dormant_on` provokes the PPP_DEAD that arms it in the same millisecond, so the window is sub-millisecond and recovery is unaffected either way.