### PR TITLE
MAINTAINERS: add label to Arduino platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -472,6 +472,8 @@ Arduino Platforms:
     - boards/shields/arduino_*/
     - drivers/*/*modulino*
     - dts/vendor/arduino/
+  labels:
+    - "platform: Arduino"
 
 Authentication:
   status: maintained


### PR DESCRIPTION
Add missing label to area.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
