### PR TITLE
samples: net: ptp: remove integration_platforms

### DIFF
--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -11,8 +11,6 @@ tests:
     depends_on:
       - eth
       - ptp_clock
-    integration_platforms:
-      - nucleo_h563zi
 
   sample.net.ptp.multicast:
     extra_configs:


### PR DESCRIPTION
remove integration_platforms from sample.net.ptp,
as it is restricting the platforms that this is build for, so that we have a build test for the ptp clock drivers.