### PR TITLE
drivers: serial: microchip: sercom g1: Reset a UART left enabled

### DIFF
--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -1122,6 +1122,7 @@ static int uart_mchp_init(const struct device *dev)
 	uart_mchp_dev_data_t *const dev_data = dev->data;
 	sercom_registers_t *regs = cfg->regs;
 	bool is_clock_external = cfg->is_clock_external;
+	sercom_usart_registers_t *usart_regs = UART_GET_BASE_ADDR(regs, is_clock_external);
 	int retval = UART_SUCCESS;
 
 	/* Enable the GCLK and MCLK*/
@@ -1133,6 +1134,14 @@ static int uart_mchp_init(const struct device *dev)
 	retval = clock_control_on(cfg->uart_clock.clock_dev, cfg->uart_clock.mclk_sys);
 	if ((retval != UART_SUCCESS) && (retval != -EALREADY)) {
 		return retval;
+	}
+
+	if ((usart_regs->SERCOM_CTRLA & SERCOM_USART_CTRLA_ENABLE_Msk) != 0) {
+		usart_regs->SERCOM_CTRLA &= ~SERCOM_USART_CTRLA_ENABLE_Msk;
+		uart_wait_sync(regs, is_clock_external);
+
+		usart_regs->SERCOM_CTRLA = SERCOM_USART_CTRLA_SWRST_Msk;
+		uart_wait_sync(regs, is_clock_external);
 	}
 
 	uart_disable_interrupts(regs, is_clock_external);


### PR DESCRIPTION
`uart_mchp_init()` assumes the SERCOM it is handed has never been used: it issues no software reset, then writes character size, parity, stop bits, clock source and baud rate into registers the SERCOM write-protects while `CTRLA.ENABLE` is set.

That holds from a cold reset. Under a bootloader it does not: MCUboot drives its own console on the same SERCOM and hands it over still enabled, so none of those writes take effect. On a PIC32CM5112GC00100 the chainloaded image faults during this device's init - the console is the one entry in `device_states` that never reaches initialized.

The fix clears `ENABLE` and asserts `CTRLA.SWRST` per the data sheet, only when the peripheral is already enabled; a cold boot does not take that branch.

The first commit bumps the `hal_microchip` manifest: `SERCOM_USART_CTRLA_SWRST_Msk` reaches the four INT/EXT-register-pair packs through an alias header that was missing this bit until 27c17f4. Without the bump this driver change fails to compile on `pic32cm_jh01_cpro` and `sam_e54_xpro`.

`samples/hello_world` builds for `pic32cm_gc00_cpro`, `sam_e54_xpro` and `pic32cm_jh01_cpro`.

Both the failure and the fix were observed on a PIC32CM GC00 Curiosity Pro running MCUboot and a signed application on SERCOM4: without the fix the chainloaded console never comes up; with it, the shell prompt and counter line appear after handover.
