### PR TITLE
Make clock control API use more consistent

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -371,6 +371,13 @@ Clock Control
   RT11xx overlays should be updated using the mapping
   ``loop-div = clock-mult * 2`` and ``post-div = clock-div``.
 
+* Drivers had been returning inconsistent result codes for :c:func:`clock_control_on()` and
+  :c:func:`clock_control_off()` for clocks that aren't stoppable. In addition, some drivers had
+  implemented only the former function. Both has been marked as mandatory, with new helper handlers
+  added to :file:`drivers/clock_control/common_helpers.h`. Drivers are expected to use them instead
+  of writing their own, whenever feasible. See :github:`118560` for examples of how in-tree drivers
+  have been updated.
+
 Clock control nrf deprecation
 -----------------------------
 

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_sources(common_helpers.c)
 
 if(CONFIG_CLOCK_CONTROL_RENESAS_RZA2M_CPG)
   zephyr_library_sources(clock_control_renesas_rza2m_cpg.c)

--- a/drivers/clock_control/clock_control_adsp.c
+++ b/drivers/clock_control/clock_control_adsp.c
@@ -17,20 +17,11 @@ static int cavs_clock_ctrl_set_rate(const struct device *clk,
 	return adsp_clock_set_cpu_freq(freq_idx);
 }
 
-static int cavs_clock_ctrl_init(const struct device *dev)
-{
-	/* Nothing to do. All initialisation should've been handled
-	 * by SOC level driver.
-	 */
-	return 0;
-}
-
 static DEVICE_API(clock_control, cavs_clock_api) = {
 	.on = clock_control_always_running_clk_on,
 	.off = clock_control_always_running_clk_off,
 	.set_rate = cavs_clock_ctrl_set_rate,
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(clkctl), cavs_clock_ctrl_init, NULL,
-		 NULL, NULL, POST_KERNEL,
+DEVICE_DT_DEFINE(DT_NODELABEL(clkctl), NULL, NULL, NULL, NULL, POST_KERNEL,
 		 CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &cavs_clock_api);

--- a/drivers/clock_control/clock_control_adsp.c
+++ b/drivers/clock_control/clock_control_adsp.c
@@ -6,6 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control/clock_control_adsp.h>
 #include <zephyr/drivers/clock_control.h>
+#include "common_helpers.h"
 
 static int cavs_clock_ctrl_set_rate(const struct device *clk,
 				    clock_control_subsys_t sys,
@@ -25,7 +26,9 @@ static int cavs_clock_ctrl_init(const struct device *dev)
 }
 
 static DEVICE_API(clock_control, cavs_clock_api) = {
-	.set_rate = cavs_clock_ctrl_set_rate
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
+	.set_rate = cavs_clock_ctrl_set_rate,
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(clkctl), cavs_clock_ctrl_init, NULL,

--- a/drivers/clock_control/clock_control_agilex5.c
+++ b/drivers/clock_control/clock_control_agilex5.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
 #include <zephyr/logging/log.h>
+#include "common_helpers.h"
 
 #include "clock_control_agilex5_ll.h"
 
@@ -78,6 +79,8 @@ static int clock_get_rate(const struct device *dev, clock_control_subsys_t sub_s
 }
 
 static DEVICE_API(clock_control, clock_api) = {
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_ambiq.c
+++ b/drivers/clock_control/clock_control_ambiq.c
@@ -112,14 +112,6 @@ static inline int ambiq_clock_configure(const struct device *dev, clock_control_
 	return ret;
 }
 
-static int ambiq_clock_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	/* Nothing to do.*/
-	return 0;
-}
-
 static DEVICE_API(clock_control, ambiq_clock_driver_api) = {
 	.on = ambiq_clock_on,
 	.off = ambiq_clock_off,
@@ -132,8 +124,7 @@ static DEVICE_API(clock_control, ambiq_clock_driver_api) = {
 	static const struct ambiq_clock_config ambiq_clock_config##n = {                           \
 		.clock_freq = DT_INST_PROP(n, clock_frequency),                                    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n)};                                        \
-	DEVICE_DT_INST_DEFINE(n, ambiq_clock_init, NULL, NULL, &ambiq_clock_config##n,             \
-			      POST_KERNEL, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,                     \
-			      &ambiq_clock_driver_api);
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &ambiq_clock_config##n, POST_KERNEL,            \
+			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &ambiq_clock_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(AMBIQ_CLOCK_INIT)

--- a/drivers/clock_control/clock_control_ameba.c
+++ b/drivers/clock_control/clock_control_ameba.c
@@ -143,24 +143,11 @@ static enum clock_control_status ameba_clock_get_status(const struct device *dev
 	return CLOCK_CONTROL_STATUS_OFF;
 }
 
-/**
- * @brief Initialize Ameba RCC Driver
- *
- * @param dev Device structure whose driver controls the clock
- *
- * @return 0 on success
- */
-static int ameba_clock_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 static DEVICE_API(clock_control, ameba_clock_driver_api) = {
 	.on = ameba_clock_on,
 	.off = ameba_clock_off,
 	.get_status = ameba_clock_get_status,
 };
 
-DEVICE_DT_INST_DEFINE(0, &ameba_clock_init, NULL, NULL, NULL, PRE_KERNEL_1,
-		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &ameba_clock_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &ameba_clock_driver_api);

--- a/drivers/clock_control/clock_control_fixed_rate.c
+++ b/drivers/clock_control/clock_control_fixed_rate.c
@@ -33,23 +33,11 @@ static DEVICE_API(clock_control, fixed_rate_clk_api) = {
 	.get_rate = fixed_rate_clk_get_rate,
 };
 
-static int fixed_rate_clk_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
+#define FIXED_CLK_INIT(idx)                                                                        \
+	static const struct fixed_rate_clock_config fixed_rate_clock_config_##idx = {              \
+		.rate = DT_INST_PROP(idx, clock_frequency),                                        \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(idx, NULL, NULL, NULL, &fixed_rate_clock_config_##idx, PRE_KERNEL_1, \
+			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &fixed_rate_clk_api);
 
-	return 0;
-}
-
-#define FIXED_CLK_INIT(idx) \
-	static const struct fixed_rate_clock_config fixed_rate_clock_config_##idx = { \
-		.rate = DT_INST_PROP(idx, clock_frequency),                           \
-	};                                                                            \
-	DEVICE_DT_INST_DEFINE(idx,                                                    \
-		fixed_rate_clk_init,                                                  \
-		NULL, NULL,                                                           \
-		&fixed_rate_clock_config_##idx,                                       \
-		PRE_KERNEL_1,                                                         \
-		CONFIG_CLOCK_CONTROL_INIT_PRIORITY,                                   \
-		&fixed_rate_clk_api                                                   \
-	);
 DT_INST_FOREACH_STATUS_OKAY(FIXED_CLK_INIT)

--- a/drivers/clock_control/clock_control_fixed_rate.c
+++ b/drivers/clock_control/clock_control_fixed_rate.c
@@ -6,36 +6,13 @@
  */
 
 #include <zephyr/drivers/clock_control.h>
+#include "common_helpers.h"
 
 #define DT_DRV_COMPAT fixed_clock
 
 struct fixed_rate_clock_config {
 	uint32_t rate;
 };
-
-static int fixed_rate_clk_on(const struct device *dev,
-			     clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return 0;
-}
-
-static int fixed_rate_clk_off(const struct device *dev,
-			      clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return 0;
-}
-
-static enum clock_control_status fixed_rate_clk_get_status(const struct device *dev,
-							   clock_control_subsys_t sys)
-{
-	return CLOCK_CONTROL_STATUS_ON;
-}
 
 static int fixed_rate_clk_get_rate(const struct device *dev,
 				   clock_control_subsys_t sys,
@@ -50,10 +27,10 @@ static int fixed_rate_clk_get_rate(const struct device *dev,
 }
 
 static DEVICE_API(clock_control, fixed_rate_clk_api) = {
-	.on = fixed_rate_clk_on,
-	.off = fixed_rate_clk_off,
-	.get_status = fixed_rate_clk_get_status,
-	.get_rate = fixed_rate_clk_get_rate
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
+	.get_status = clock_control_always_running_clk_get_status,
+	.get_rate = fixed_rate_clk_get_rate,
 };
 
 static int fixed_rate_clk_init(const struct device *dev)

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -10,6 +10,8 @@
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #include <zephyr/sys/util.h>
 #include <fsl_clock.h>
+#include "common_helpers.h"
+
 #if defined(CONFIG_SOC_MIMX9352)
 #include <soc.h>
 #endif
@@ -130,12 +132,6 @@ static int mcux_ccm_on(const struct device *dev,
 		(void)instance;
 		return 0;
 	}
-}
-
-static int mcux_ccm_off(const struct device *dev,
-				   clock_control_subsys_t sub_system)
-{
-	return 0;
 }
 
 static int mcux_ccm_get_subsys_rate(const struct device *dev,
@@ -604,7 +600,7 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 
 static DEVICE_API(clock_control, mcux_ccm_driver_api) = {
 	.on = mcux_ccm_on,
-	.off = mcux_ccm_off,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = mcux_ccm_get_subsys_rate,
 	.set_rate = mcux_ccm_set_subsys_rate,
 };

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -13,22 +13,11 @@
 #include <zephyr/dt-bindings/clock/kinetis_mcg.h>
 #include <soc.h>
 #include <fsl_clock.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control_mcg);
-
-static int mcux_mcg_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
-{
-	return 0;
-}
-
-static int mcux_mcg_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
-{
-	return 0;
-}
 
 static int mcux_mcg_get_rate(const struct device *dev,
 			     clock_control_subsys_t sub_system,
@@ -56,8 +45,8 @@ static int mcux_mcg_get_rate(const struct device *dev,
 }
 
 static DEVICE_API(clock_control, mcux_mcg_driver_api) = {
-	.on = mcux_mcg_on,
-	.off = mcux_mcg_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = mcux_mcg_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -14,24 +14,13 @@
 #include <zephyr/dt-bindings/clock/kinetis_scg.h>
 #include <soc.h>
 #include <fsl_clock.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control_scg);
 
 #define MCUX_SCG_CLOCK_NODE(name) DT_INST_CHILD(0, name)
-
-static int mcux_scg_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
-{
-	return 0;
-}
-
-static int mcux_scg_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
-{
-	return 0;
-}
 
 static int mcux_scg_get_rate(const struct device *dev,
 			     clock_control_subsys_t sub_system,
@@ -149,8 +138,8 @@ static int mcux_scg_init(const struct device *dev)
 }
 
 static DEVICE_API(clock_control, mcux_scg_driver_api) = {
-	.on = mcux_scg_on,
-	.off = mcux_scg_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = mcux_scg_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_mcux_scg_k4.c
+++ b/drivers/clock_control/clock_control_mcux_scg_k4.c
@@ -14,22 +14,13 @@
 #include <zephyr/dt-bindings/clock/scg_k4.h>
 #include <soc.h>
 #include <fsl_clock.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control_scg);
 
 #define MCUX_SCG_CLOCK_NODE(name) DT_INST_CHILD(0, name)
-
-static int mcux_scg_k4_on(const struct device *dev, clock_control_subsys_t sub_system)
-{
-	return 0;
-}
-
-static int mcux_scg_k4_off(const struct device *dev, clock_control_subsys_t sub_system)
-{
-	return 0;
-}
 
 static int mcux_scg_k4_get_rate(const struct device *dev, clock_control_subsys_t sub_system,
 				uint32_t *rate)
@@ -80,8 +71,8 @@ static int mcux_scg_k4_get_rate(const struct device *dev, clock_control_subsys_t
 }
 
 static DEVICE_API(clock_control, mcux_scg_driver_api) = {
-	.on = mcux_scg_k4_on,
-	.off = mcux_scg_k4_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = mcux_scg_k4_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_mspm0.c
+++ b/drivers/clock_control/clock_control_mspm0.c
@@ -127,12 +127,12 @@ static DL_SYSCTL_SYSPLLConfig clock_mspm0_cfg_syspll = {
 
 static int clock_mspm0_on(const struct device *dev, clock_control_subsys_t sys)
 {
-	return 0;
+	return -ENOSYS;
 }
 
 static int clock_mspm0_off(const struct device *dev, clock_control_subsys_t sys)
 {
-	return 0;
+	return -ENOSYS;
 }
 
 static int clock_mspm0_get_rate(const struct device *dev,

--- a/drivers/clock_control/clock_control_pwm.c
+++ b/drivers/clock_control/clock_control_pwm.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/kernel.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL CONFIG_CLOCK_CONTROL_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -131,6 +132,7 @@ static int clock_control_pwm_init(const struct device *dev)
 
 static DEVICE_API(clock_control, clock_control_pwm_api) = {
 	.on = clock_control_pwm_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_pwm_get_rate,
 	.set_rate = clock_control_pwm_set_rate,
 };

--- a/drivers/clock_control/clock_control_renesas_ra_cgc_subclk.c
+++ b/drivers/clock_control/clock_control_renesas_ra_cgc_subclk.c
@@ -10,26 +10,11 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
+#include "common_helpers.h"
 
 struct clock_control_ra_subclk_cfg {
 	uint32_t rate;
 };
-
-static int clock_control_renesas_ra_subclk_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return -ENOTSUP;
-}
-
-static int clock_control_renesas_ra_subclk_off(const struct device *dev, clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return -ENOTSUP;
-}
 
 static int clock_control_renesas_ra_subclk_get_rate(const struct device *dev,
 						    clock_control_subsys_t sys, uint32_t *rate)
@@ -44,8 +29,8 @@ static int clock_control_renesas_ra_subclk_get_rate(const struct device *dev,
 }
 
 static DEVICE_API(clock_control, clock_control_renesas_ra_subclk_api) = {
-	.on = clock_control_renesas_ra_subclk_on,
-	.off = clock_control_renesas_ra_subclk_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_renesas_ra_subclk_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_renesas_rx_pll_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_rx_pll_cgc.c
@@ -12,22 +12,7 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control/renesas_rx_cgc.h>
 #include <zephyr/dt-bindings/clock/rx_clock.h>
-
-static int clock_control_renesas_rx_pll_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
-
-static int clock_control_renesas_rx_pll_off(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
-
-static enum clock_control_status clock_control_renesas_rx_pll_get_status(const struct device *dev,
-									 clock_control_subsys_t sys)
-{
-	return CLOCK_CONTROL_STATUS_ON;
-}
+#include "common_helpers.h"
 
 static int clock_control_renesas_rx_pll_get_rate(const struct device *dev,
 						 clock_control_subsys_t sys, uint32_t *rate)
@@ -62,9 +47,9 @@ static int clock_control_renesas_rx_pll_get_rate(const struct device *dev,
 }
 
 static DEVICE_API(clock_control, clock_control_renesas_rx_pll_api) = {
-	.on = clock_control_renesas_rx_pll_on,
-	.off = clock_control_renesas_rx_pll_off,
-	.get_status = clock_control_renesas_rx_pll_get_status,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
+	.get_status = clock_control_always_running_clk_get_status,
 	.get_rate = clock_control_renesas_rx_pll_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_renesas_rx_root_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_rx_root_cgc.c
@@ -11,16 +11,7 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/drivers/clock_control/renesas_rx_cgc.h>
-
-static int clock_control_renesas_rx_root_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
-
-static int clock_control_renesas_rx_root_off(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
+#include "common_helpers.h"
 
 static int clock_control_renesas_rx_root_get_rate(const struct device *dev,
 						  clock_control_subsys_t sys, uint32_t *rate)
@@ -38,8 +29,8 @@ static int clock_control_renesas_rx_root_get_rate(const struct device *dev,
 }
 
 static DEVICE_API(clock_control, clock_control_renesas_rx_root_api) = {
-	.on = clock_control_renesas_rx_root_on,
-	.off = clock_control_renesas_rx_root_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_renesas_rx_root_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_renesas_rz_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_rz_cgc.c
@@ -161,12 +161,5 @@ static DEVICE_API(clock_control, rz_clock_control_driver_api) = {
 	.get_rate = clock_control_renesas_rz_get_rate,
 };
 
-static int clock_control_rz_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-DEVICE_DT_INST_DEFINE(0, clock_control_rz_init, NULL, NULL, NULL, PRE_KERNEL_1,
-		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &rz_clock_control_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &rz_clock_control_driver_api);

--- a/drivers/clock_control/clock_control_renesas_rz_cpg.c
+++ b/drivers/clock_control/clock_control_renesas_rz_cpg.c
@@ -167,11 +167,5 @@ static DEVICE_API(clock_control, rz_clock_control_driver_api) = {
 	.get_rate = clock_control_renesas_rz_get_rate,
 };
 
-static int clock_control_rz_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
-DEVICE_DT_INST_DEFINE(0, clock_control_rz_init, NULL, NULL, NULL, PRE_KERNEL_1,
-		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &rz_clock_control_driver_api);
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &rz_clock_control_driver_api);

--- a/drivers/clock_control/clock_control_sama7g5_sckc.c
+++ b/drivers/clock_control/clock_control_sama7g5_sckc.c
@@ -82,15 +82,6 @@ static int sckc_get_rate(const struct device *dev,
 	return ret;
 }
 
-static enum clock_control_status sckc_get_status(const struct device *dev,
-						 clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return CLOCK_CONTROL_STATUS_ON;
-}
-
 static int sckc_driver_init(const struct device *dev)
 {
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
@@ -99,9 +90,11 @@ static int sckc_driver_init(const struct device *dev)
 }
 
 static DEVICE_API(clock_control, sckc_api) = {
+	/* Clock is always running, on() is used to choose its source */
 	.on = sckc_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = sckc_get_rate,
-	.get_status = sckc_get_status,
+	.get_status = clock_control_always_running_clk_get_status,
 };
 
 DEVICE_DT_INST_DEFINE(0, sckc_driver_init, NULL, &mchp_sckc_data, &mchp_sckc_cfg, PRE_KERNEL_1,

--- a/drivers/clock_control/clock_control_si32_ahb.c
+++ b/drivers/clock_control/clock_control_si32_ahb.c
@@ -15,6 +15,7 @@
 #include <SI32_CLKCTRL_A_Type.h>
 #include <SI32_FLASHCTRL_A_Type.h>
 #include <si32_device.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 #include <zephyr/logging/log.h>
@@ -25,17 +26,6 @@ struct clock_control_si32_ahb_config {
 	uint32_t freq;
 };
 
-static int clock_control_si32_ahb_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
-
-static int clock_control_si32_ahb_off(const struct device *dev, clock_control_subsys_t sys)
-{
-
-	return -ENOTSUP;
-}
-
 static int clock_control_si32_ahb_get_rate(const struct device *dev, clock_control_subsys_t sys,
 					   uint32_t *rate)
 {
@@ -45,8 +35,8 @@ static int clock_control_si32_ahb_get_rate(const struct device *dev, clock_contr
 }
 
 static DEVICE_API(clock_control, clock_control_si32_ahb_api) = {
-	.on = clock_control_si32_ahb_on,
-	.off = clock_control_si32_ahb_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_si32_ahb_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_si32_apb.c
+++ b/drivers/clock_control/clock_control_si32_apb.c
@@ -14,22 +14,12 @@
 
 #include <SI32_CLKCTRL_A_Type.h>
 #include <si32_device.h>
+#include "common_helpers.h"
 
 struct clock_control_si32_apb_config {
 	const struct device *clock_dev;
 	uint32_t divider;
 };
-
-static int clock_control_si32_apb_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	return -ENOTSUP;
-}
-
-static int clock_control_si32_apb_off(const struct device *dev, clock_control_subsys_t sys)
-{
-
-	return -ENOTSUP;
-}
 
 static int clock_control_si32_apb_get_rate(const struct device *dev, clock_control_subsys_t sys,
 					   uint32_t *rate)
@@ -47,8 +37,8 @@ static int clock_control_si32_apb_get_rate(const struct device *dev, clock_contr
 }
 
 static DEVICE_API(clock_control, clock_control_si32_apb_api) = {
-	.on = clock_control_si32_apb_on,
-	.off = clock_control_si32_apb_off,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_si32_apb_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_si32_pll.c
+++ b/drivers/clock_control/clock_control_si32_pll.c
@@ -15,6 +15,7 @@
 #include <SI32_CLKCTRL_A_Type.h>
 #include <SI32_PLL_A_Type.h>
 #include <si32_device.h>
+#include "common_helpers.h"
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 #include <zephyr/logging/log.h>
@@ -86,12 +87,6 @@ static int clock_control_si32_pll_on(const struct device *dev, clock_control_sub
 	return 0;
 }
 
-static int clock_control_si32_pll_off(const struct device *dev, clock_control_subsys_t sys)
-{
-
-	return -ENOTSUP;
-}
-
 static int clock_control_si32_pll_get_rate(const struct device *dev, clock_control_subsys_t sys,
 					   uint32_t *rate)
 {
@@ -115,7 +110,7 @@ static int clock_control_si32_pll_set_rate(const struct device *dev, clock_contr
 
 static DEVICE_API(clock_control, clock_control_si32_pll_api) = {
 	.on = clock_control_si32_pll_on,
-	.off = clock_control_si32_pll_off,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_si32_pll_get_rate,
 	.set_rate = clock_control_si32_pll_set_rate,
 };

--- a/drivers/clock_control/clock_control_smartfusion2.c
+++ b/drivers/clock_control/clock_control_smartfusion2.c
@@ -10,36 +10,12 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util.h>
+#include "common_helpers.h"
 
 struct smartfusion2_clock_config {
 	const uint32_t *rates;
 	uint32_t rate_count;
 };
-
-static int smartfusion2_clock_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return 0;
-}
-
-static int smartfusion2_clock_off(const struct device *dev, clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return 0;
-}
-
-static enum clock_control_status smartfusion2_clock_get_status(const struct device *dev,
-						       clock_control_subsys_t sys)
-{
-	ARG_UNUSED(dev);
-	ARG_UNUSED(sys);
-
-	return CLOCK_CONTROL_STATUS_ON;
-}
 
 static int smartfusion2_clock_get_rate(const struct device *dev, clock_control_subsys_t sys,
 					       uint32_t *rate)
@@ -56,9 +32,9 @@ static int smartfusion2_clock_get_rate(const struct device *dev, clock_control_s
 }
 
 static DEVICE_API(clock_control, smartfusion2_clock_api) = {
-	.on = smartfusion2_clock_on,
-	.off = smartfusion2_clock_off,
-	.get_status = smartfusion2_clock_get_status,
+	.on = clock_control_always_running_clk_on,
+	.off = clock_control_always_running_clk_off,
+	.get_status = clock_control_always_running_clk_get_status,
 	.get_rate = smartfusion2_clock_get_rate,
 };
 

--- a/drivers/clock_control/clock_control_smartfusion2.c
+++ b/drivers/clock_control/clock_control_smartfusion2.c
@@ -38,24 +38,17 @@ static DEVICE_API(clock_control, smartfusion2_clock_api) = {
 	.get_rate = smartfusion2_clock_get_rate,
 };
 
-static int smartfusion2_clock_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-
-	return 0;
-}
-
-#define SMARTFUSION2_CLOCK_INIT(inst)                                                       \
-	static const uint32_t smartfusion2_clock_rates_##inst[] =                            \
-		DT_INST_PROP(inst, clock_frequencies);                                          \
-	                                                                                       \
-	static const struct smartfusion2_clock_config smartfusion2_clock_config_##inst = {    \
-		.rates = smartfusion2_clock_rates_##inst,                                      \
-		.rate_count = ARRAY_SIZE(smartfusion2_clock_rates_##inst),                     \
-	};                                                                                     \
-	                                                                                       \
-	DEVICE_DT_INST_DEFINE(inst, smartfusion2_clock_init, NULL, NULL,                      \
-			      &smartfusion2_clock_config_##inst, PRE_KERNEL_1,              \
-			      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &smartfusion2_clock_api);
+#define SMARTFUSION2_CLOCK_INIT(inst)                                                              \
+	static const uint32_t smartfusion2_clock_rates_##inst[] =                                  \
+		DT_INST_PROP(inst, clock_frequencies);                                             \
+                                                                                                   \
+	static const struct smartfusion2_clock_config smartfusion2_clock_config_##inst = {         \
+		.rates = smartfusion2_clock_rates_##inst,                                          \
+		.rate_count = ARRAY_SIZE(smartfusion2_clock_rates_##inst),                         \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &smartfusion2_clock_config_##inst,           \
+			      PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,                    \
+			      &smartfusion2_clock_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SMARTFUSION2_CLOCK_INIT)

--- a/drivers/clock_control/clock_control_tisci.c
+++ b/drivers/clock_control/clock_control_tisci.c
@@ -87,10 +87,20 @@ static enum clock_control_status tisci_get_status(const struct device *dev,
 	return CLOCK_CONTROL_STATUS_UNKNOWN;
 }
 
+static int tisci_nosys_on_off(const struct device *dev, clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sys);
+
+	return -ENOSYS;
+}
+
 static DEVICE_API(clock_control, tisci_clock_driver_api) = {
+	.on = tisci_nosys_on_off,
+	.off = tisci_nosys_on_off,
 	.get_rate = tisci_get_rate,
 	.set_rate = tisci_set_rate,
-	.get_status = tisci_get_status
+	.get_status = tisci_get_status,
 };
 
 #define TI_K2G_SCI_CLK_INIT(_n)                                                                    \

--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -14,6 +14,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/util_macro.h>
+#include "common_helpers.h"
 
 #include <hal_ch32fun.h>
 
@@ -235,6 +236,7 @@ static void clock_control_wch_h41x_init_480m(void)
 
 static DEVICE_API(clock_control, clock_control_wch_rcc_api) = {
 	.on = clock_control_wch_rcc_on,
+	.off = clock_control_always_running_clk_off,
 	.get_rate = clock_control_wch_rcc_get_rate,
 };
 

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -402,20 +402,9 @@ static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.get_rate = stm32_clock_control_get_subsys_rate,
 };
 
-static int stm32_clock_control_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 /**
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init
  */
-DEVICE_DT_DEFINE(DT_NODELABEL(rcc),
-		    stm32_clock_control_init,
-		    NULL,
-		    NULL, NULL,
-		    PRE_KERNEL_1,
-		    CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-		    &stm32_clock_control_api);
+DEVICE_DT_DEFINE(DT_NODELABEL(rcc), NULL, NULL, NULL, NULL, PRE_KERNEL_1,
+		 CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &stm32_clock_control_api);

--- a/drivers/clock_control/clock_stm32_ll_mp2.c
+++ b/drivers/clock_control/clock_stm32_ll_mp2.c
@@ -177,15 +177,9 @@ static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.get_rate = stm32_clock_control_get_subsys_rate,
 };
 
-static int stm32_clock_control_init(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-	return 0;
-}
-
 /**
  * @brief RCC device, note that priority is intentionally set to 1 so
  * that the device init runs just after SOC init
  */
-DEVICE_DT_DEFINE(DT_NODELABEL(rcc), stm32_clock_control_init, NULL, NULL, NULL, PRE_KERNEL_1,
+DEVICE_DT_DEFINE(DT_NODELABEL(rcc), NULL, NULL, NULL, NULL, PRE_KERNEL_1,
 		 CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &stm32_clock_control_api);

--- a/drivers/clock_control/common_helpers.c
+++ b/drivers/clock_control/common_helpers.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Antmicro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common_helpers.h"
+
+int clock_control_always_running_clk_on(const struct device *dev, clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sys);
+
+	return 0;
+}
+
+int clock_control_always_running_clk_off(const struct device *dev, clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sys);
+
+	return -ENOTSUP;
+}
+
+enum clock_control_status clock_control_always_running_clk_get_status(const struct device *dev,
+								      clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sys);
+
+	return CLOCK_CONTROL_STATUS_ON;
+}

--- a/drivers/clock_control/common_helpers.h
+++ b/drivers/clock_control/common_helpers.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Antmicro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_CLOCK_CONTROL_COMMON_HELPERS_H_
+#define ZEPHYR_DRIVERS_CLOCK_CONTROL_COMMON_HELPERS_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+
+int clock_control_always_running_clk_on(const struct device *dev, clock_control_subsys_t sys);
+
+int clock_control_always_running_clk_off(const struct device *dev, clock_control_subsys_t sys);
+
+enum clock_control_status clock_control_always_running_clk_get_status(const struct device *dev,
+								      clock_control_subsys_t sys);
+
+#endif /* ZEPHYR_DRIVERS_CLOCK_CONTROL_COMMON_HELPERS_H_ */

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -145,9 +145,9 @@ typedef int (*clock_control_configure_fn)(const struct device *dev,
  * @driver_ops{Clock Control}
  */
 __subsystem struct clock_control_driver_api {
-	/** @driver_ops_optional @copybrief clock_control_on */
+	/** @driver_ops_mandatory @copybrief clock_control_on */
 	clock_control on;
-	/** @driver_ops_optional @copybrief clock_control_off */
+	/** @driver_ops_mandatory @copybrief clock_control_off */
 	clock_control off;
 	/** @driver_ops_optional @copybrief clock_control_async_on */
 	clock_control_async_on_fn async_on;
@@ -174,7 +174,7 @@ __subsystem struct clock_control_driver_api {
  *
  * @param dev Device structure whose driver controls the clock.
  * @param sys Opaque data representing the clock.
- * @return 0 on success, negative errno on failure.
+ * @return 0 on success (including always-running clocks), negative errno on failure.
  */
 static inline int clock_control_on(const struct device *dev,
 				   clock_control_subsys_t sys)
@@ -196,7 +196,9 @@ static inline int clock_control_on(const struct device *dev,
  *
  * @param dev Device structure whose driver controls the clock
  * @param sys Opaque data representing the clock
- * @return 0 on success, negative errno on failure.
+ * @retval 0 on success.
+ * @retval -ENOTSUP when the clock can't be turned off (e.g. is always running).
+ * @retval <0 other negative errno on failure.
  */
 static inline int clock_control_off(const struct device *dev,
 				    clock_control_subsys_t sys)

--- a/tests/drivers/clock_control/fixed_clock/src/test_clock_control.c
+++ b/tests/drivers/clock_control/fixed_clock/src/test_clock_control.c
@@ -34,8 +34,7 @@ ZTEST(fixed_clk, test_fixed_rate_clk_on_off_status_rate)
 		      "%s: Unexpected status (%d)", dev->name, status);
 
 	err = clock_control_off(dev, 0);
-	zassert_equal(0, err, "%s: Expected 0, got (%d)",
-		      dev->name, err);
+	zassert_equal(-ENOTSUP, err, "%s: Expected -ENOTSUP, got (%d)", dev->name, err);
 
 	status = clock_control_get_status(dev, 0);
 	zassert_equal(status, CLOCK_CONTROL_STATUS_ON,


### PR DESCRIPTION
# Summary

Existing clock control drivers use different sets of return values for always-running clocks. In most common case, both `on()` and `off()` returns the same value, but the specific value differs between the drivers (usually it is either `-ENOTSUP` or 0).
This PR attempts to standardize the API by providing dummy implementations of `on()`, `off()` and `get_status()`. It also marks `on()`/`off()` as mandatory.

# Changes

## New helper functions

Three new helper functions have been added to a new `common_helpers.h` file:

* `clock_control_always_running_clk_on()` - returns 0 (success)
* `clock_control_always_running_clk_off()` - returns `-ENOTSUP`
* `clock_control_always_running_clk_get_status()` - returns `CLOCK_CONTROL_STATUS_ON`

The main motivations for adding those, as opposed to simply describing the expectations in documentation, is to reduce code duplication.

`clock_control_always_running_clk_on()` returns success. The other considered value was `-EALREADY`, as would be returned by `clock_control_async_on()`, however, in that context it is used to mark that the callback will not be called.
`clock_control_on()` doesn't have a callback, so such distinction isn't needed, and returning 0 (success) passes the information that the clock is now in the requested state. That way the caller doesn't have to test for `-EALREADY` specifically, which saves few bytes of code.

Return values of the two remaining functions should be self-explanatory.

## Tests

The expected return value for `clock_control_off()` have been updated in `tests/drivers/clock_control/fixed_clock/src/test_clock_control.c`.

## Functions marked as mandatory

`on()`/`off()` are marked as mandatory in order to avoid drivers implementing `on()` without implementing `off()`. Currently, there are 3 drivers that do so (`pwm`, `sama_7g5_sckc` and `wch_rcc`), with another 3 that don't implement either (`adsp`, `agilex5`, `tisci`).

To the best of my knowledge, all of them behave like always-running clocks, with the exception of `tisci` - it uses `tisci_set_clock_state()` which prototype makes it incompatible with clock control API, although perhaps the additional information (`dev_id` and `clk_id`) could be encoded through `subsys` parameter. Since I'm not familiar with this code, I opted to return `-ENOSYS` for this driver, which is the same error code that was returned before. For the remaining clocks, `clock_control_always_running_clk_*()` helpers were used.

## Documentation

The expected return values for always-running clocks have been explicitly listed. The change has been added to the migration guide.

## Removed empty `init()` functions

A number of drivers uses `init()` functions that simply return success. The end result of such implementation is identical to passing `NULL` as second argument of `DEVICE_DT_INST_DEFINE()` macro. To slightly reduce ROM usage and improve boot time, all such functions have been removed.

# Modified drivers

## Drivers with `on()` that returned success, switched to use common helpers (no functional change)

* `fixed_rate`
* `mcux_mcg`
* `mcux_scg`
* `mcux_scg_k4`
* `mspm0`
* `smartfusion2`

## Drivers with `off()` that returned `-ENOTSUP`, switched to use common helpers (no functional change)

* `renesas_ra_cgc_subclk`
* `renesas_rx_pll_cgc`
* `renesas_rx_root_cgc`
* `si32_ahb`
* `si32_apb`
* `si32_pll`

## Drivers with `get_status()` that returned `CLOCK_CONTROL_STATUS_ON`, switched to use common helpers (no functional change)

* `renesas_rx_pll_cgc`
* `sama_7g5_sckc`
* `smartfusion2`

## Drivers with removed empty `init()` (no functional change)

* `adsp`
* `ambiq`
* `ameba`
* `fixed_rate`
* `renesas_rz_cgc`
* `renesas_rz_cpg`
* `smartfusion2`
* `stm32_ll_mp1`
* `stm32_ll_mp2`

## Drivers with changed `on()` return code

* `adsp` (previously not implemented)
* `agilex5` (previously not implemented)
* `renesas_ra_cgc_subclk`
* `renesas_rx_pll_cgc`
* `renesas_rx_root_cgc`
* `si32_ahb`
* `si32_apb`
* `tisci` (previously not implemented)

## Drivers with changed `off()` return code

* `adsp` (previously not implemented)
* `agilex5` (previously not implemented)
* `fixed_rate`
* `mcux_ccm_rev2`
* `mcux_mcg`
* `mcux_scg`
* `mcux_scg_k4`
* `mcux_syscon`
* `mspm0`
* `pwm` (previously not implemented)
* `sama_7g5_sckc` (previously not implemented)
* `smartfusion2`
* `tisci` (previously not implemented)
* `wch_rcc` (previously not implemented)

# Remaining issues

`infineon` and a number of `nrf*` drivers return `-ENOSYS` for `on()`/`off()` and don't implement any other clock control API functions. `infineon` sets up clocks in its `init()` and doesn't implement any other functions. In case of NRF, vendor extensions are used instead, adding clock specification (accuracy, precision) and tracking of clock users through On-Off subsystem.

Similar, but more generalized version of tracking clients through On-Off could be added to base API and used in other drivers. This would allow for automatically turning off clocks that are no longer used by any peripheral, possibly even propagating that change to parent clocks. This would require describing the clock tree, preferably in a generic way described e.g. by DT bindings or macros.

There is no common way of deciding on which clocks are to be enabled on boot. Some of the drivers base that choice on peripheral's "okay" status, but the details are usually specific to a driver. Adding a common implementation (macros? inline functions?) could make the code easier to follow. Since the initialization dependencies and order matter for some drivers (e.g. often PLL can't be configured unless its parent clock is running), this also requires a clock tree.

# Related work

This was done after analyzing discussion in #89124 and its predecessors. It isn't supposed to be a replacement, since not all of the reported problems can be resolved with current clock control API.