### PR TITLE
Samv71 xult board audio

### DIFF
--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -198,6 +198,12 @@
 	pinctrl-0 = <&twihs0_default>;
 	pinctrl-names = "default";
 
+	audio_codec: wm8904@1a {
+		compatible = "wolfson,wm8904";
+		reg = <0x1a>;
+		fs-ratio = <512>;
+	};
+
 	eeprom: eeprom@5f {
 		compatible = "atmel,at24", "atmel,24mac402";
 		reg = <0x5f>;

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -364,6 +364,10 @@ zephyr_udc0: &usbhs {
 	dmas = <&xdmac 22 DMA_PERID_SSC_RX>, <&xdmac 23 DMA_PERID_SSC_TX>;
 };
 
+&xdmac {
+	status = "okay";
+};
+
 &can1 {
 	status = "okay";
 


### PR DESCRIPTION
This PR adds the WM8904 codec to the sam_v71_xult board.

Also turns on xdmac, which was off. sam_e70_xplained already has it on.

One thing I want to flag:
-> I used `fs-ratio = <512>` instead of pointing at a clock. Not ideal, but the codec clock MCLK comes off PCK2 here, and clock_control_sam_pmc.c doesn't model programmable clocks yet.

Three options:
- you’re ok with it (because it works ;) )
- you’re really not ok with it and I add what’s missing to `wm8904.c` and `clock_control_sam_pmc.c`. Much longer path.
- you’re ok with it for now. We pass this change to have audio on the board 🔈, and I’ll do the changes to `wm8904.c` and `clock_control_sam_pmc.c` in a next PR. Once it has landed, I’ll fix this code.

---

Tested on my board, I can read and write its registers, tone and music (at a fixed 24 kHz rate) come out of the headphone jack, no I2S errors.

Cheers