### PR TITLE
AGENTS.md: clarify the Signed-off-by rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,12 @@ do not rely on this digest or on training data alone.
 
 ## Rules for agents
 
-- Never add a `Signed-off-by:` line: only the human submitter may sign off (DCO). Never add
-  `Co-authored-by:`. Do not put "Generated with ...", session links or any other mention of AI
-  tools in commit messages, PR bodies, issues or comments. The `Assisted-by:` trailer below is
-  the only place AI involvement is recorded.
+- Every commit must carry a `Signed-off-by:` line from the human responsible for the work; it
+  is required, not optional. Never add, edit or copy one yourself: only a human can certify the
+  DCO, and the submitter adds their own (`git commit -s`). Never add `Co-authored-by:`. Do not
+  put "Generated with ...", session links or any other mention of AI tools in commit messages,
+  PR bodies, issues or comments. The `Assisted-by:` trailer below is the only place AI
+  involvement is recorded.
 - Add exactly one `Assisted-by: <Agent>:<model-version> [tool ...]` trailer, for example
   `Assisted-by: Claude:claude-opus-4.6 coccinelle`, naming the tool actually used. Replace it
   rather than stacking when a different model amends the commit. `checkpatch.pl` validates the


### PR DESCRIPTION
The first bullet of "Rules for agents" reads "Never add a `Signed-off-by:`
line", which states the opposite of the DCO requirement: every Zephyr commit
must carry one, and it must come from the human responsible for the work. As
written it also contradicts the "Commits" section further down, which requires
exactly one sign-off matching the commit author and forbids removing an
existing one.

The intent was that an agent must not manufacture a sign-off on someone's
behalf. Reword the bullet to require the trailer, say whose identity it
carries, and narrow the prohibition to inventing or copying one.