### PR TITLE
arch: riscv: Initialize sscratch for secondary CPUs in S-mode with SMP enabled

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -64,7 +64,11 @@ void arch_secondary_cpu_init(int hartid)
 		}
 	}
 
+#ifdef CONFIG_RISCV_S_MODE
+	csr_write(sscratch, &_kernel.cpus[cpu_num]);
+#else
 	csr_write(mscratch, &_kernel.cpus[cpu_num]);
+#endif
 
 	/*
 	 * The no-match check must sit after the mscratch write:


### PR DESCRIPTION
Update smp.c to initialize sscratch in instances where S-mode is running in an SMP configuration. As-is sscratch for all secondary cores do not have sscratch set, which is read in arch_curr_cpu.