### PR TITLE
samples: userspace: Update test to use k_sched_current_thread_query

### DIFF
--- a/samples/userspace/syscall_perf/README.rst
+++ b/samples/userspace/syscall_perf/README.rst
@@ -15,11 +15,11 @@ Overview
 ********
 
 This application creates a supervisor and a user thread.
-Then both threads call :c:func:`k_current_get()` which returns a reference to the
-current thread. The user thread has to go through a system call.
+Then both threads call :c:func:`k_sched_current_thread_query()` which returns a
+reference to the current thread. The user thread has to go through a system call.
 
 Both threads are showing the number of core clock cycles and the number of
-instructions executed while calling :c:func:`k_current_get()`.
+instructions executed while calling :c:func:`k_sched_current_thread_query()`.
 
 
 Sample Output

--- a/samples/userspace/syscall_perf/src/test_supervisor.c
+++ b/samples/userspace/syscall_perf/src/test_supervisor.c
@@ -24,7 +24,11 @@ void supervisor_thread_function(void *p1, void *p2, void *p3)
 
 		inst_before = csr_read(0xB02);
 		cycle_before = csr_read(0xB00);
-		thread = k_current_get();
+		/* Explicitly invoke system call. k_current_get fails to benchmark
+		 * properly if CONFIG_CURRENT_THREAD_USE_TLS is enabled since it
+		 * returns the thread-local cached thread ID
+		 */
+		thread = k_sched_current_thread_query();
 		cycle_count = csr_read(0xB00);
 		inst_count = csr_read(0xB02);
 
@@ -43,7 +47,7 @@ void supervisor_thread_function(void *p1, void *p2, void *p3)
 		/* Remove CSR accesses to be more accurate */
 		inst_count -= 3;
 
-		printf("Supervisor thread(%p):\t%8lu cycles\t%8lu instructions\n",
-			thread, cycle_count, inst_count);
+		printf("Supervisor thread(%p):\t%8lu cycles\t%8lu instructions\n", thread,
+		       cycle_count, inst_count);
 	}
 }

--- a/samples/userspace/syscall_perf/src/test_user.c
+++ b/samples/userspace/syscall_perf/src/test_user.c
@@ -24,7 +24,12 @@ void user_thread_function(void *p1, void *p2, void *p3)
 
 		inst_before = csr_read(0xC02);
 		cycle_before = csr_read(0xC00);
-		thread = k_current_get();
+		/* Explicitly invoke system call. k_current_get fails to benchmark
+		 * properly if CONFIG_CURRENT_THREAD_USE_TLS is enabled since it
+		 * returns the thread-local cached thread ID
+		 */
+		thread = k_sched_current_thread_query();
+
 		cycle_count = csr_read(0xC00);
 		inst_count = csr_read(0xC02);
 
@@ -43,7 +48,7 @@ void user_thread_function(void *p1, void *p2, void *p3)
 		/* Remove CSR accesses to be more accurate */
 		inst_count -= 3;
 
-		printf("User thread(%p):\t\t%8lu cycles\t%8lu instructions\n",
-			thread, cycle_count, inst_count);
+		printf("User thread(%p):\t\t%8lu cycles\t%8lu instructions\n", thread, cycle_count,
+		       inst_count);
 	}
 }


### PR DESCRIPTION
Currently syscall_perf uses "k_current_get". If CONFIG_CURRENT_THREAD_USE_TLS is enabled this will return the thread-local cached value rather than entering the sys-call path.