### PR TITLE
kernel: don't read the current thread back after setting it

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -261,26 +261,48 @@ extern atomic_t _cpus_active;
 bool z_smp_cpu_mobile(void);
 #define _current_cpu ({ __ASSERT_NO_MSG(!z_smp_cpu_mobile()); \
 			arch_curr_cpu(); })
-
-__attribute_const__ struct k_thread *z_smp_current_get(void);
-#define _current z_smp_current_get()
-
 #else
 #define _current_cpu (&_kernel.cpus[0])
-#define _current _kernel.cpus[0].current
+#endif
+
+/* The current thread, in the per-CPU structure where the kernel records it.
+ *
+ * This is the definitive location: z_current_thread_set() always writes here
+ * and nothing caches it, so it reports the incoming thread as soon as that
+ * call has been made.  Reading it requires a context that cannot migrate,
+ * which is what _current_cpu asserts: an ISR, or interrupts locked.
+ *
+ * Use _current instead unless the value must be up to date and the caller
+ * already meets that requirement.
+ */
+#define _raw_current (_current_cpu->current)
+
+#ifdef CONFIG_SMP
+__attribute_const__ struct k_thread *z_smp_current_get(void);
+#define _current z_smp_current_get()
+#else
+#define _current _raw_current
 #endif
 
 #define CPU_ID ((CONFIG_MP_MAX_NUM_CPUS == 1) ? 0 : _current_cpu->id)
 
-/* This is always invoked from a context where preemption is disabled */
-#define z_current_thread_set(thread) ({ _current_cpu->current = (thread); })
+/* This is always invoked from a context where preemption is disabled.
+ *
+ * Callers must not assume that _current reflects the new thread before the
+ * switch actually happens.  An architecture may cache the current thread in
+ * a register (CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL), and the compiler is then
+ * free to reuse a value it read earlier in the same function.  Code running
+ * between this call and the switch must therefore use the new thread pointer
+ * it already has, or _raw_current where it has none.
+ */
+#define z_current_thread_set(thread) ({ _raw_current = (thread); })
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL
 #undef _current
 #define _current arch_current_thread()
 #undef z_current_thread_set
 #define z_current_thread_set(thread) \
-	arch_current_thread_set(({ _current_cpu->current = (thread); }))
+	arch_current_thread_set(({ _raw_current = (thread); }))
 #endif
 
 /* kernel wait queue record */

--- a/include/zephyr/spinlock.h
+++ b/include/zephyr/spinlock.h
@@ -104,7 +104,7 @@ struct k_spinlock {
 bool z_spin_lock_valid(struct k_spinlock *l);
 bool z_spin_unlock_valid(struct k_spinlock *l);
 void z_spin_lock_set_owner(struct k_spinlock *l);
-void z_spin_lock_transfer_owner(struct k_spinlock *l);
+void z_spin_lock_transfer_owner(struct k_spinlock *l, struct k_thread *thread);
 void z_assert_can_swap(unsigned int key, struct k_spinlock *swap_lock);
 void z_spin_validate_reset(bool lock_held);
 extern const uint8_t z_spinlock_abort_sentinel;

--- a/kernel/include/kspinlock.h
+++ b/kernel/include/kspinlock.h
@@ -47,10 +47,12 @@ static ALWAYS_INLINE bool z_is_sched_spinlock(struct k_spinlock *lock)
 /**
  * @brief Transfer ownership of the scheduler's spinlock
  */
-static ALWAYS_INLINE void z_sched_spinlock_transfer_owner(void)
+static ALWAYS_INLINE void z_sched_spinlock_transfer_owner(struct k_thread *thread)
 {
 #ifdef CONFIG_SPIN_VALIDATE
-	z_spin_lock_transfer_owner(&_sched_spinlock);
+	z_spin_lock_transfer_owner(&_sched_spinlock, thread);
+#else
+	ARG_UNUSED(thread);
 #endif
 }
 

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -130,7 +130,7 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 		z_time_slice_reset(new_thread);
 #endif /* CONFIG_TIMESLICING */
 
-		z_sched_spinlock_transfer_owner();
+		z_sched_spinlock_transfer_owner(new_thread);
 
 		arch_cohere_stacks(old_thread, NULL, new_thread);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -754,7 +754,7 @@ void *z_get_next_switch_handle(void *interrupted)
 			 * confused when the "wrong" thread tries to
 			 * release the lock.
 			 */
-			z_sched_spinlock_transfer_owner();
+			z_sched_spinlock_transfer_owner(new_thread);
 
 			/* A queued (runnable) old/current thread
 			 * needs to be added back to the run queue

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -674,7 +674,12 @@ struct k_thread *z_swap_next_thread(void)
 }
 
 #ifdef CONFIG_USE_SWITCH
-/* Just a wrapper around z_current_thread_set(xxx) with tracing */
+/* Just a wrapper around z_current_thread_set(xxx) with tracing.
+ *
+ * _current is not guaranteed to report @a new_thread until the switch to it
+ * has happened: see z_current_thread_set(). Code between this call and the
+ * switch must use @a new_thread directly.
+ */
 static inline void set_current(struct k_thread *new_thread)
 {
 	/* If the new thread is the same as the current thread, we
@@ -784,10 +789,12 @@ void *z_get_next_switch_handle(void *interrupted)
 	}
 	return ret;
 #else
-	z_sched_usage_switch(_kernel.ready_q.cache);
+	struct k_thread *next = _kernel.ready_q.cache;
+
+	z_sched_usage_switch(next);
 	_current->switch_handle = interrupted;
-	set_current(_kernel.ready_q.cache);
-	return _current->switch_handle;
+	set_current(next);
+	return next->switch_handle;
 #endif /* CONFIG_SMP */
 }
 #endif /* CONFIG_USE_SWITCH */

--- a/kernel/smp/smp.c
+++ b/kernel/smp/smp.c
@@ -273,12 +273,11 @@ bool z_smp_cpu_mobile(void)
 __attribute_const__ struct k_thread *z_smp_current_get(void)
 {
 	/*
-	 * _current is a field read from _current_cpu, which can race
-	 * with preemption before it is read.  We must lock local
-	 * interrupts when reading it.
+	 * _raw_current can race with preemption before it is read.  We
+	 * must lock local interrupts when reading it.
 	 */
 	unsigned int key = arch_irq_lock();
-	struct k_thread *t = _current_cpu->current;
+	struct k_thread *t = _raw_current;
 
 	arch_irq_unlock(key);
 	return t;

--- a/kernel/spinlock_validate.c
+++ b/kernel/spinlock_validate.c
@@ -37,6 +37,13 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 }
 EXPORT_SYMBOL(z_spin_lock_valid);
 
+/* z_spin_unlock_valid() and z_spin_lock_set_owner() below use _raw_current
+ * rather than _current: they run at points where z_current_thread_set() may
+ * just have changed the current thread, which an architecture caching it in a
+ * register (CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL) would not report.  Both are
+ * called from k_spin_lock() and k_spin_unlock() with the lock held, hence with
+ * interrupts locked as _raw_current requires.
+ */
 bool z_spin_unlock_valid(struct k_spinlock *l)
 {
 	uint8_t cpu_id = _current_cpu->id;
@@ -48,14 +55,15 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 		z_held_spinlock[cpu_id] = NULL;
 	}
 
-	if (arch_is_in_isr() && _current->base.thread_state & _THREAD_DUMMY) {
+	if (arch_is_in_isr() &&
+	    (_raw_current->base.thread_state & _THREAD_DUMMY) != 0) {
 		/* Edge case where an ISR aborted _current */
 		z_held_spinlock_count[cpu_id]--;
 		__ASSERT(z_held_spinlock_count[cpu_id] >= 0,
 			 "spinlock unlock with no matching lock");
 		return true;
 	}
-	if (tcpu != (cpu_id | (uintptr_t)_current)) {
+	if (tcpu != (cpu_id | (uintptr_t)_raw_current)) {
 		return false;
 	}
 	z_held_spinlock_count[cpu_id]--;
@@ -69,7 +77,7 @@ void z_spin_lock_set_owner(struct k_spinlock *l)
 {
 	uint8_t cpu_id = _current_cpu->id;
 
-	l->thread_cpu = cpu_id | (uintptr_t)_current;
+	l->thread_cpu = cpu_id | (uintptr_t)_raw_current;
 
 	if (z_held_spinlock[cpu_id] == NULL) {
 		z_held_spinlock[cpu_id] = l;

--- a/kernel/spinlock_validate.c
+++ b/kernel/spinlock_validate.c
@@ -78,12 +78,16 @@ void z_spin_lock_set_owner(struct k_spinlock *l)
 }
 EXPORT_SYMBOL(z_spin_lock_set_owner);
 
-/* Called from do_swap() after z_current_thread_set() to transfer ownership
- * of an inherited lock.  Does NOT update the tracking arrays.
+/* Called from the switch paths after z_current_thread_set() to transfer
+ * ownership of an inherited lock.  Does NOT update the tracking arrays.
+ *
+ * @a thread is passed in rather than read from _current: the caller has just
+ * made it current, and _current is not required to report it until the switch
+ * completes (see z_current_thread_set()).
  */
-void z_spin_lock_transfer_owner(struct k_spinlock *l)
+void z_spin_lock_transfer_owner(struct k_spinlock *l, struct k_thread *thread)
 {
-	l->thread_cpu = _current_cpu->id | (uintptr_t)_current;
+	l->thread_cpu = _current_cpu->id | (uintptr_t)thread;
 }
 EXPORT_SYMBOL(z_spin_lock_transfer_owner);
 


### PR DESCRIPTION
An arch may keep the current thread in a register rather than in the per-CPU structure (`CONFIG_ARCH_HAS_CUSTOM_CURRENT_IMPL`). That only pays if the compiler may reuse a value it has already read, which requires that nothing depend on `_current` changing under it. #118365 does this on arm64 with TPIDR_EL1, where caching the value is worth roughly 150 fewer `mrs` and 4 KiB of `.text` on a kernel test image.

The first commit names the per-CPU record `_raw_current` and builds `_current` and `z_current_thread_set()` on it, so there is an accessor for the current thread as the kernel recorded it, for the code that needs exactly that. The other three fix the places that read `_current` back after setting it:

- `z_spin_lock_transfer_owner()`, called from both switch paths right after `z_current_thread_set()`, records the outgoing thread instead of the incoming one, and the next release then fails `z_spin_unlock_valid()`. Both callers have the incoming thread in a local; pass it in.

- `z_spin_unlock_valid()` and `z_spin_lock_set_owner()` need whichever thread is current when they run, including the dummy thread an ISR installs when it aborts the thread it interrupted. They run with the lock held, hence with interrupts locked, so they can use `_raw_current`.

- The uniprocessor half of `z_get_next_switch_handle()` reads `_current` back to fetch the switch handle it just stored through it.

That is every window between a `z_current_thread_set()` and the switch that follows it, of which there are six. The other three need no change. `z_cstart()` never reads `_current` after installing the boot dummy. `z_thread_halt()` does read it after `halt_thread()` may have dummified, but only in `(thread == _current) && !arch_is_in_isr()`, whose second term is false whenever the first can be stale. `z_thread_mark_switched_in()`, called right after the set on arm and posix, reads `_current` only under `!CONFIG_USE_SWITCH`, which no arch with a cached `_current` uses.
