### PR TITLE
bluetooth: mesh: skip the self-target during the DFU apply step

### DIFF
--- a/include/zephyr/bluetooth/mesh/dfu_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfu_srv.h
@@ -195,7 +195,6 @@ struct bt_mesh_dfu_srv {
 		uint8_t idx;
 		uint16_t timeout_base;
 		uint16_t meta;
-		bool self_update;
 	} update;
 	/** @endcond */
 };

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -915,12 +915,16 @@ static void dfd_srv_find_cb(const struct bt_mesh_model *mod,
 	}
 }
 
-void bt_mesh_dfd_srv_self_applied(void)
+void bt_mesh_dfd_srv_self_applied(struct bt_mesh_dfu_srv *dfu_srv)
 {
 	struct bt_mesh_dfd_srv *srv = NULL;
 
 	bt_mesh_model_foreach(dfd_srv_find_cb, &srv);
 	if (!srv || srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return;
+	}
+
+	if (self_target_dfu_srv(srv) != dfu_srv) {
 		return;
 	}
 
@@ -1194,7 +1198,10 @@ static int dfd_srv_model_start(const struct bt_mesh_model *mod)
 		struct bt_mesh_dfu_srv *dfu_srv = self_target_dfu_srv(srv);
 
 		if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
-			bt_mesh_dfu_srv_applied(dfu_srv);
+			/* Settle the phase without notifying, so the Confirm
+			 * step below decides the outcome.
+			 */
+			bt_mesh_dfu_srv_apply_settle(dfu_srv);
 		}
 	}
 

--- a/subsys/bluetooth/mesh/dfd_srv_internal.h
+++ b/subsys/bluetooth/mesh/dfd_srv_internal.h
@@ -43,7 +43,9 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_fw_delete_all(struct bt_mesh_dfd_srv *sr
 /** Notify a co-located Firmware Distribution Server that the local Firmware
  *  Update Server completed a deferred self-apply.
  */
-void bt_mesh_dfd_srv_self_applied(void);
+void bt_mesh_dfd_srv_self_applied(struct bt_mesh_dfu_srv *dfu_srv);
+
+void bt_mesh_dfu_srv_apply_settle(struct bt_mesh_dfu_srv *srv);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -340,32 +340,6 @@ static void send_info_get(struct bt_mesh_blob_cli *b, uint16_t dst)
 	struct bt_mesh_dfu_cli *cli = DFU_CLI(b);
 	struct bt_mesh_msg_ctx ctx = MSG_CTX(cli, dst);
 
-	if (bt_mesh_has_addr(dst)) {
-		const struct bt_mesh_elem *elem = bt_mesh_elem_find(dst);
-		const struct bt_mesh_model *mod =
-			elem ? bt_mesh_model_find(elem, BT_MESH_MODEL_ID_DFU_SRV) : NULL;
-		struct bt_mesh_dfu_srv *dfu_srv = mod ? mod->rt->user_data : NULL;
-
-		if (dfu_srv &&
-		    dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
-			struct bt_mesh_dfu_target *target = target_get(cli, dst);
-
-			/* The local DFU Server defers its apply callback until
-			 * the Confirm step completes (see dfu_confirmed() in
-			 * dfd_srv.c), so it will reject Firmware Update
-			 * Information Get with EBUSY per MshDFUv1.0 Section 7.2.
-			 * Retrying only delays confirmed() from triggering the
-			 * deferred apply. Ack the self-target immediately and
-			 * drive the broadcast state machine forward.
-			 */
-			if (target) {
-				blob_cli_broadcast_rsp(&cli->blob, &target->blob);
-			}
-			blob_cli_broadcast_tx_complete(&cli->blob);
-			return;
-		}
-	}
-
 	cli->req.img_cnt = 0xff;
 
 	info_get(cli, &ctx, 0, cli->req.img_cnt, &send_cb);
@@ -488,6 +462,17 @@ static void skip_targets_from_broadcast(struct bt_mesh_dfu_cli *cli, bool skip)
 	}
 }
 
+static void skip_self_target(struct bt_mesh_dfu_cli *cli, bool skip)
+{
+	struct bt_mesh_dfu_target *target;
+
+	TARGETS_FOR_EACH(cli, target) {
+		if (bt_mesh_has_addr(target->blob.addr)) {
+			target->blob.skip = skip;
+		}
+	}
+}
+
 static bool transfer_skip(struct bt_mesh_dfu_cli *cli)
 {
 	struct bt_mesh_dfu_target *target;
@@ -590,6 +575,11 @@ static void apply(struct bt_mesh_dfu_cli *cli)
 
 	LOG_DBG("");
 
+	/* The self-target applies from dfd_srv once the Confirm step is done,
+	 * so it takes no part in the Apply and Confirm broadcasts.
+	 */
+	skip_self_target(cli, true);
+
 	cli->xfer.state = STATE_APPLY;
 	cli->op = BT_MESH_DFU_OP_UPDATE_STATUS;
 
@@ -677,15 +667,11 @@ static void confirmed(struct bt_mesh_blob_cli *b)
 			LOG_DBG("Target 0x%04x still provisioned", target->blob.addr);
 			target->phase = BT_MESH_DFU_PHASE_APPLY_FAIL;
 			target_failed(cli, target, BT_MESH_DFU_ERR_INTERNAL);
+		} else if (target->blob.skip) {
+			/* Took no part in the Apply and Confirm broadcasts. */
+			success = true;
+			continue;
 		} else if (!target->blob.acked) {
-			if (bt_mesh_has_addr(target->blob.addr)) {
-				/* Self-target deferred apply until distribution
-				 * completes, so it can't confirm yet.
-				 */
-				success = true;
-				continue;
-			}
-
 			LOG_DBG("Target 0x%04x failed to respond", target->blob.addr);
 			target->phase = BT_MESH_DFU_PHASE_APPLY_FAIL;
 			target_failed(cli, target, BT_MESH_DFU_ERR_INTERNAL);
@@ -693,6 +679,8 @@ static void confirmed(struct bt_mesh_blob_cli *b)
 			success = true;
 		}
 	}
+
+	skip_self_target(cli, false);
 
 	if (success) {
 		cli->xfer.state = STATE_IDLE;
@@ -836,24 +824,12 @@ static int handle_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 			return 0;
 		}
 
-		if (phase == BT_MESH_DFU_PHASE_APPLYING &&
-		    !bt_mesh_has_addr(target->blob.addr)) {
-			/* MshDFUv1.0 Section 6.2.2.4 requires the Confirm step to
-			 * wait until the targets have applied. Keep repeating
-			 * Firmware Update Apply (Section 7.1.2.6) until the
-			 * target leaves Applying Update, otherwise the Confirm
-			 * step reads the old Firmware ID.
-			 */
-			LOG_DBG("Target 0x%04x still applying", target->blob.addr);
-			return 0;
-		}
-
-		/* The self-target defers its apply until the Confirm step
-		 * completes, so it never leaves Applying Update on its own.
+		/* MshDFUv1.0 Section 6.2.2.4 requires the Confirm step to wait
+		 * until the targets have applied. Keep repeating Firmware
+		 * Update Apply (Section 7.1.2.6) until the target leaves
+		 * Applying Update, otherwise the Confirm step reads the old
+		 * Firmware ID.
 		 */
-		LOG_DBG("Target 0x%04x accepted apply (phase %u)",
-			target->blob.addr, phase);
-		blob_cli_broadcast_rsp(&cli->blob, &target->blob);
 		return 0;
 	} else if (cli->xfer.state == STATE_CONFIRM) {
 		if (phase == BT_MESH_DFU_PHASE_APPLYING) {

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -113,11 +113,6 @@ static void apply_rsp_sent(int err, void *cb_params)
 
 	store_state(srv);
 
-	if (srv->update.self_update) {
-		LOG_DBG("Self-update: deferring apply");
-		return;
-	}
-
 	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
 	if (err) {
 		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
@@ -349,7 +344,6 @@ static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	srv->update.ttl = ttl;
 	srv->update.timeout_base = timeout_base;
 	srv->update.meta = meta_checksum;
-	srv->update.self_update = bt_mesh_has_addr(ctx->addr);
 
 	io = NULL;
 	err = srv->cb->start(srv, &srv->imgs[idx], buf, &io);
@@ -627,6 +621,16 @@ void bt_mesh_dfu_srv_cancel(struct bt_mesh_dfu_srv *srv)
 	(void)bt_mesh_blob_srv_cancel(&srv->blob);
 }
 
+void bt_mesh_dfu_srv_apply_settle(struct bt_mesh_dfu_srv *srv)
+{
+	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+		return;
+	}
+
+	srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+	store_state(srv);
+}
+
 void bt_mesh_dfu_srv_applied(struct bt_mesh_dfu_srv *srv)
 {
 	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
@@ -636,14 +640,10 @@ void bt_mesh_dfu_srv_applied(struct bt_mesh_dfu_srv *srv)
 
 	LOG_DBG("");
 
-	srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
-	store_state(srv);
+	bt_mesh_dfu_srv_apply_settle(srv);
 
-	/* Not set after a reboot, so the Distribution Server's own resume path
-	 * does not complete the distribution before the Confirm step re-runs.
-	 */
-	if (IS_ENABLED(CONFIG_BT_MESH_DFD_SRV) && srv->update.self_update) {
-		bt_mesh_dfd_srv_self_applied();
+	if (IS_ENABLED(CONFIG_BT_MESH_DFD_SRV)) {
+		bt_mesh_dfd_srv_self_applied(srv);
 	}
 }
 
@@ -658,7 +658,8 @@ int bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv)
 {
 	int err;
 
-	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+	if (srv->update.phase != BT_MESH_DFU_PHASE_VERIFY_OK &&
+	    srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
 		return 0;
 	}
 
@@ -667,6 +668,13 @@ int bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv)
 		erase_state(srv);
 		return -EINVAL;
 	}
+
+	/* The self-target never receives Firmware Update Apply, so make the
+	 * Section 6.1.2.3 phase transition here and persist it before the
+	 * callback, which may reboot.
+	 */
+	srv->update.phase = BT_MESH_DFU_PHASE_APPLYING;
+	store_state(srv);
 
 	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
 	if (err) {
@@ -679,7 +687,8 @@ int bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv)
 
 void bt_mesh_dfu_srv_apply_cancel(struct bt_mesh_dfu_srv *srv)
 {
-	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+	if (srv->update.phase != BT_MESH_DFU_PHASE_VERIFY_OK &&
+	    srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
 		return;
 	}
 

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -292,12 +292,12 @@ static int target_dfu_apply(struct bt_mesh_dfu_srv *srv, const struct bt_mesh_df
 
 	ASSERT_TRUE(expect_dfu_apply);
 
-	if (self_update_apply_err && srv->update.self_update) {
+	if (self_update_apply_err) {
 		k_sem_give(&dfu_ended);
 		return -EIO;
 	}
 
-	if (self_update_apply_fail && srv->update.self_update) {
+	if (self_update_apply_fail) {
 		/* Emulate power loss before the image swap: unlike the
 		 * self_update_reboot_emulation path below, target_fw_ver_curr
 		 * is deliberately NOT bumped, so the node keeps reporting the
@@ -307,7 +307,7 @@ static int target_dfu_apply(struct bt_mesh_dfu_srv *srv, const struct bt_mesh_df
 		return 0;
 	}
 
-	if (self_update_reboot_emulation && srv->update.self_update) {
+	if (self_update_reboot_emulation) {
 		/* Simulate reboot in the middle of self-update apply:
 		 * install the new firmware image (bump the reported FWID) but
 		 * do NOT call bt_mesh_dfu_srv_applied(). The DFU Server's


### PR DESCRIPTION
Commit 5bdbd5015736 ("bluetooth: mesh: defer self-target apply until
distribution completes") special-cased the self-target in three Firmware
Update Client message paths: send_info_get(), confirmed() and
handle_status().
    
Use the blob broadcast skip mechanism instead, as the Transfer step
already does. The self-target takes no part in the Apply and Confirm
broadcasts, so all three special cases go away and handle_status()
returns to plain Section 7.1.2.6 behaviour. The Distribution Server
drives the deferred apply from dfu_confirmed() as before.
    
The local server no longer receives Firmware Update Apply, so
bt_mesh_dfu_srv_apply_deferred() now makes the Section 6.1.2.3
transition to Applying Update and persists it before the apply callback,
which may reboot the node. bt_mesh_dfu_srv_apply_cancel() accepts the
same phases.
    
Split the phase bookkeeping out as bt_mesh_dfu_srv_apply_settle(). The
resume path must move the local server to Idle so it reports the new
Firmware ID, but must not report the apply as complete, which would end
the distribution before the Confirm step re-runs and turn a failed apply
into a successful one. The self_update flag suppressed that notification
and is dropped; bt_mesh_dfd_srv_self_applied() now takes the applying
server and verifies it is the Distributor's own target.
