### PR TITLE
drivers: pwm: nxp_flexio: fix high-frequency output during init

### DIFF
--- a/drivers/pwm/pwm_nxp_flexio.c
+++ b/drivers/pwm/pwm_nxp_flexio.c
@@ -245,10 +245,9 @@ static int mcux_flexio_pwm_init(const struct device *dev)
 		FLEXIO_SetPinLevel(flexio_base, pwm_info->pin_id, false);
 		FLEXIO_ConfigPinOverride(flexio_base, pwm_info->pin_id, false);
 #endif
-		/* Timer output is logic one and is not affected by timer reset */
-		timerConfig.timerOutput = kFLEXIO_TimerOutputOneNotAffectedByReset;
-		/* Set the timer mode to dual 8-bit counter PWM high */
-		timerConfig.timerMode = kFLEXIO_TimerModeDual8BitPWM;
+		/* Leave the timer disabled with its output parked at the inactive level. */
+		timerConfig.timerOutput = kFLEXIO_TimerOutputZeroNotAffectedByReset;
+		timerConfig.timerMode = kFLEXIO_TimerModeDisabled;
 
 		/* Timer scaling factor w.r.t Flexio Clock */
 		timerConfig.timerDecrement = pwm_info->prescaler;


### PR DESCRIPTION
Init left each channel's timer in dual 8-bit PWM mode with timerCompare = 0, always enabled and its output routed to the pin. Since a FlexIO timer has no start bit, the pin free-ran at flexio_clk / prescaler / 2 frequency until the first pwm_set_cycles().

Park it disabled with output zero so the pin stays driven low; pwm_set_cycles() reprograms it anyway.

This patch fixes #118232