### PR TITLE
drivers: clock control: npcx: support FMCLK for eSPI when chip in deep sleep

### DIFF
--- a/drivers/clock_control/Kconfig.npcx
+++ b/drivers/clock_control/Kconfig.npcx
@@ -32,4 +32,15 @@ config CLOCK_CONTROL_NPCX_SUPP_FIU1
 	help
 	  Selected if NPCX series supports FIU1 bus.
 
+config CLOCK_CONTROL_NPCX_ESPI_FMCLK_IN_SLEEP
+	bool "Keep the fast clock to the eSPI_SIF module in sleep states"
+	default y
+	depends on $(dt_nodelabel_bool_prop,pcc,fast-clk-to-espi-sleep-support)
+	depends on ESPI_PERIPHERAL_UART && PM
+	help
+	  When this option is enabled, the fast clock (FMCLK) to the eSPI_SIF
+	  module remains enabled while the chip is in the Sleep or Deep Sleep
+	  power state. It is required by the eSPI virtual UART channel, which
+	  cannot receive host traffic without FMCLK.
+
 endif # CLOCK_CONTROL_NPCX

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -261,6 +261,10 @@ static int npcx_clock_control_init(const struct device *dev)
 		NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) |= BIT(7);
 	}
 
+#if defined(CONFIG_CLOCK_CONTROL_NPCX_ESPI_FMCLK_IN_SLEEP)
+	HAL_PMC_INST(dev)->ENSLP_CTL |= BIT(NPCX_ENSLP_CTL_ESPI_FMCLK_ENSLP);
+#endif
+
 	return 0;
 }
 

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -159,6 +159,7 @@
 			apb3-prescaler = <8>; /* APB3_CLK runs at 15MHz */
 			apb4-prescaler = <8>; /* APB4_CLK runs at 15MHz */
 			ram-pd-depth = <8>; /* Valid bit-depth of RAM_PDn reg */
+			fast-clk-to-espi-sleep-support;
 			pwdwn-ctl-val = <0xfb
 					 0xff
 					 0x1f /* No GDMA1_PD/GDMA2_PD */

--- a/dts/bindings/clock/nuvoton,npcx-pcc.yaml
+++ b/dts/bindings/clock/nuvoton,npcx-pcc.yaml
@@ -222,6 +222,14 @@ properties:
       Power-down (turn off clock) the modules during system initialization for
       better power consumption.
 
+  fast-clk-to-espi-sleep-support:
+    type: boolean
+    description: |
+      The fast clock (FMCLK) to the eSPI_SIF module can be kept enabled while
+      the chip is in the Sleep or Deep Sleep power state. Only set it on the
+      series that implement the ESPI_FMCLK_ENSLP field of the ENSLP_CTL
+      register, that is SOC_SERIES_NPCX4 and later of the NPCXn variant.
+
 clock-cells:
   - bus
   - ctl

--- a/soc/nuvoton/npcx/common/npckn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/reg_def.h
@@ -73,7 +73,10 @@ struct pmc_reg {
 	volatile uint8_t PMCSR;
 	volatile uint8_t reserved1[2];
 	/* 0x003: Enable in Sleep Control */
-	volatile uint8_t ENIDL_CTL;
+	union {
+		volatile uint8_t ENSLP_CTL;
+		volatile uint8_t ENIDL_CTL; /* Deprecated name of ENSLP_CTL */
+	};
 	/* 0x004: Disable in Idle Control */
 	volatile uint8_t DISIDL_CTL;
 	/* 0x005: Disable in Idle Control 1 */
@@ -98,10 +101,10 @@ struct pmc_reg {
 #define NPCX_PMCSR_OHFC                       6
 #define NPCX_PMCSR_OLFC                       7
 #define NPCX_DISIDL_CTL_RAM_DID               5
-#define NPCX_ENIDL_CTL_ADC_ACC_DIS            1
-#define NPCX_ENIDL_CTL_PECI_ENI               2
-#define NPCX_ENIDL_CTL_LP_WK_CTL              6
-#define NPCX_ENIDL_CTL_ADC_LFSL               7
+#define NPCX_ENSLP_CTL_ADC_ACC_DIS            1
+#define NPCX_ENSLP_CTL_PECI_ENI               2
+#define NPCX_ENSLP_CTL_LP_WK_CTL              6
+#define NPCX_ENSLP_CTL_ADC_LFSL               7
 
 /* Macro functions for Development and Debugger Interface (DDI) registers */
 #define NPCX_DBGCTRL(base)   (*(volatile uint8_t *)(base + 0x004))
@@ -1960,5 +1963,11 @@ struct gdma_reg {
 /* BBRM register fields */
 #define NPCX_BKUPSTS_VCC1_STS BIT(5)
 #define NPCX_BKUPSTS_IBBR     BIT(7)
+
+/* Deprecated ENIDL_CTL names of the ENSLP_CTL register fields */
+#define NPCX_ENIDL_CTL_ADC_ACC_DIS NPCX_ENSLP_CTL_ADC_ACC_DIS
+#define NPCX_ENIDL_CTL_PECI_ENI    NPCX_ENSLP_CTL_PECI_ENI
+#define NPCX_ENIDL_CTL_LP_WK_CTL   NPCX_ENSLP_CTL_LP_WK_CTL
+#define NPCX_ENIDL_CTL_ADC_LFSL    NPCX_ENSLP_CTL_ADC_LFSL
 
 #endif /* _NUVOTON_NPCX_REG_DEF_H */

--- a/soc/nuvoton/npcx/common/npckn/registers.c
+++ b/soc/nuvoton/npcx/common/npckn/registers.c
@@ -17,6 +17,8 @@ NPCX_REG_OFFSET_CHECK(cdcg_reg, LFCGCTL2, 0x114);
 
 /* PMC register structure check */
 NPCX_REG_SIZE_CHECK(pmc_reg, 0x013);
+NPCX_REG_OFFSET_CHECK(pmc_reg, ENSLP_CTL, 0x003);
+/* Deprecated alias of ENSLP_CTL, kept for out-of-tree users */
 NPCX_REG_OFFSET_CHECK(pmc_reg, ENIDL_CTL, 0x003);
 NPCX_REG_OFFSET_CHECK(pmc_reg, PWDWN_CTL0, 0x007);
 

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -107,11 +107,13 @@ struct pmc_reg {
 #define NPCX_PMCSR_NWBI            3
 #define NPCX_PMCSR_OHFC            6
 #define NPCX_PMCSR_OLFC            7
-#define NPCX_DISIDL_CTL_RAM_DID    5
-#define NPCX_ENSLP_CTL_ADC_LFSL    7
-#define NPCX_ENSLP_CTL_LP_WK_CTL   6
-#define NPCX_ENSLP_CTL_PECI_ENI    2
-#define NPCX_ENSLP_CTL_ADC_ACC_DIS 1
+#define NPCX_DISIDL_CTL_RAM_DID         5
+#define NPCX_ENSLP_CTL_ADC_LFSL         7
+#define NPCX_ENSLP_CTL_LP_WK_CTL        6
+#define NPCX_ENSLP_CTL_PECI_ENI         2
+#define NPCX_ENSLP_CTL_ADC_ACC_DIS      1
+/* Implemented from SOC_SERIES_NPCX4 onwards */
+#define NPCX_ENSLP_CTL_ESPI_FMCLK_ENSLP 0
 
 /* Macro functions for Development and Debugger Interface (DDI) registers */
 #define NPCX_DBGCTRL(base)   (*(volatile uint8_t *)(base + 0x004))

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -77,7 +77,10 @@ struct pmc_reg {
 	volatile uint8_t PMCSR;
 	volatile uint8_t reserved1[2];
 	/* 0x003: Enable in Sleep Control */
-	volatile uint8_t ENIDL_CTL;
+	union {
+		volatile uint8_t ENSLP_CTL;
+		volatile uint8_t ENIDL_CTL; /* Deprecated name of ENSLP_CTL */
+	};
 	/* 0x004: Disable in Idle Control */
 	volatile uint8_t DISIDL_CTL;
 	/* 0x005: Disable in Idle Control 1 */
@@ -105,10 +108,10 @@ struct pmc_reg {
 #define NPCX_PMCSR_OHFC            6
 #define NPCX_PMCSR_OLFC            7
 #define NPCX_DISIDL_CTL_RAM_DID    5
-#define NPCX_ENIDL_CTL_ADC_LFSL    7
-#define NPCX_ENIDL_CTL_LP_WK_CTL   6
-#define NPCX_ENIDL_CTL_PECI_ENI    2
-#define NPCX_ENIDL_CTL_ADC_ACC_DIS 1
+#define NPCX_ENSLP_CTL_ADC_LFSL    7
+#define NPCX_ENSLP_CTL_LP_WK_CTL   6
+#define NPCX_ENSLP_CTL_PECI_ENI    2
+#define NPCX_ENSLP_CTL_ADC_ACC_DIS 1
 
 /* Macro functions for Development and Debugger Interface (DDI) registers */
 #define NPCX_DBGCTRL(base)   (*(volatile uint8_t *)(base + 0x004))
@@ -2278,5 +2281,11 @@ struct lct_reg {
 #define NPCX_LCTCONT_LCT_CLK_EN   6
 #define NPCX_LCTCONT_LCT_VSBY_PWR 7
 #define NPCX_LCTSTAT_LCTEVST      0
+
+/* Deprecated ENIDL_CTL names of the ENSLP_CTL register fields */
+#define NPCX_ENIDL_CTL_ADC_LFSL    NPCX_ENSLP_CTL_ADC_LFSL
+#define NPCX_ENIDL_CTL_LP_WK_CTL   NPCX_ENSLP_CTL_LP_WK_CTL
+#define NPCX_ENIDL_CTL_PECI_ENI    NPCX_ENSLP_CTL_PECI_ENI
+#define NPCX_ENIDL_CTL_ADC_ACC_DIS NPCX_ENSLP_CTL_ADC_ACC_DIS
 
 #endif /* _NUVOTON_NPCX_REG_DEF_H */

--- a/soc/nuvoton/npcx/common/npcxn/registers.c
+++ b/soc/nuvoton/npcx/common/npcxn/registers.c
@@ -17,6 +17,8 @@ NPCX_REG_OFFSET_CHECK(cdcg_reg, LFCGCTL2, 0x114);
 
 /* PMC register structure check */
 NPCX_REG_SIZE_CHECK(pmc_reg, 0x025);
+NPCX_REG_OFFSET_CHECK(pmc_reg, ENSLP_CTL, 0x003);
+/* Deprecated alias of ENSLP_CTL, kept for out-of-tree users */
 NPCX_REG_OFFSET_CHECK(pmc_reg, ENIDL_CTL, 0x003);
 NPCX_REG_OFFSET_CHECK(pmc_reg, PWDWN_CTL1, 0x008);
 NPCX_REG_OFFSET_CHECK(pmc_reg, PWDWN_CTL7, 0x024);


### PR DESCRIPTION
The Host UART (Serial Port) cannot receive host traffic once the fast clock (FMCLK) to the eSPI_SIF module stops when the chip enters Sleep or Deep Sleep. This PR:
1. keep FMCLK to eSPI_SIF in (Deep) Sleep —  adds the `fast-clk-to-espi-sleep-support` devicetree property for the series implementing the ESPI_FMCLK_ENSLP field of ENSLP_CTL (NPCX4 and later of the NPCXn variant), sets it on npcx4, and writes the bit at the end of `npcx_clock_control_init()` under the new `CLOCK_CONTROL_NPCX_ESPI_FMCLK_IN_SLEEP` option, which also requires `ESPI_PERIPHERAL_UART` and `PM`.

2. Fix the name of PMC register at offset 0x003 from `ENIDL_CTL` to ` ENSLP_CTL`.
Becuase Out-of-tree code uses the old spelling, so It keeps `ENIDL_CTL` becomes a second member of an anonymous union over the same byte

