### PR TITLE
dts: st: h5: add sai2 missing clock-names

### DIFF
--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -161,6 +161,7 @@
 			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
+			clock-names = "sai_ck", "sai_ker_ck";
 			status = "disabled";
 
 			sai2_a: sai2a@40015804 {


### PR DESCRIPTION
This change adds missing clock-names in sai2 node