### PR TITLE
drivers: pcie: fix bar counter not advancing past 64-bit BARs

### DIFF
--- a/drivers/pcie/host/controller.c
+++ b/drivers/pcie/host/controller.c
@@ -127,6 +127,7 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 		if (!PCIE_CONF_BAR_ADDR(size)) {
 			if (found_mem64) {
 				reg++;
+				bar++;
 			}
 			continue;
 		}
@@ -169,6 +170,7 @@ static void pcie_generic_ctrl_enumerate_bars(const struct device *ctrl_dev, pcie
 
 		if (found_mem64) {
 			reg++;
+			bar++;
 		}
 	}
 }


### PR DESCRIPTION
When enumerating BARs, a 64-bit BAR occupies two consecutive BAR register slots (low 32-bit in slot N, high 32-bit in slot N+1). The loop increments `reg` to skip the high-word slot, but it did not increment `bar` accordingly. As a result, the loop consumed two register slots while only counting one BAR, causing subsequent iterations to read the wrong register (e.g. BAR2 was treated as a second independent BAR on a Type 1 bridge that only has two slots). This produced an incorrect size value and a spurious "Failed memory allocation" error for the phantom BAR..

Fix it by incrementing `bar` alongside `reg` in both early-continue and normal-exit paths when a 64-bit BAR is detected.