### PR TITLE
drivers: audio: wm8904: fix BCLK divider encoding

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -363,16 +363,16 @@ static void wm8904_set_master_clock(const struct device *dev, audio_dai_cfg_t *c
 		audioInterface |= 1U;
 		break;
 	case 20:
-		/* Avoid MISRA 16.4 violation */
+		audioInterface |= 2U;
 		break;
 	case 30:
-		/* Avoid MISRA 16.4 violation */
+		audioInterface |= 3U;
 		break;
 	case 40:
-		/* Avoid MISRA 16.4 violation */
+		audioInterface |= 4U;
 		break;
 	case 50:
-		audioInterface |= (uint16_t)bclkDiv / 10U;
+		audioInterface |= 5U;
 		break;
 	case 55:
 		audioInterface |= 6U;
@@ -384,13 +384,13 @@ static void wm8904_set_master_clock(const struct device *dev, audio_dai_cfg_t *c
 		audioInterface |= 8U;
 		break;
 	case 100:
-		/* Avoid MISRA 16.4 violation */
+		audioInterface |= 9U;
 		break;
 	case 110:
-		/* Avoid MISRA 16.4 violation */
+		audioInterface |= 10U;
 		break;
 	case 120:
-		audioInterface |= (uint16_t)bclkDiv / 10U - 1U;
+		audioInterface |= 11U;
 		break;
 	case 160:
 		audioInterface |= 12U;


### PR DESCRIPTION
Encountered an issue in`wm8904_set_master_clock()`.

Per the datasheet, (table 56, p94) the 21 selectable BCLK_DIV ratios map to field values 0 to 20 in order.
<img width="1032" height="800" alt="image" src="https://github.com/user-attachments/assets/24224dba-c792-4643-ac33-e8ff116311c8" />

However, some cases of the switch are empty. They looked like they should have fallen through the case.

Notes:
- I did the most simple fix, not creating a lookup table or any more complicated changes.
- No in-tree board is affected: the four boards with a WM8904 node compute a bclkDiv of 480, 240, 240 and 120, all already encoded correctly.
- I hit it bringing up sam_v71_xult, where bclkDiv lands on 40. Case 40 is empty, so playback ran four times too fast. #118564 
