### PR TITLE
Bluetooth: Classic: HID: include Report ID in Boot Protocol reports

### DIFF
--- a/subsys/bluetooth/host/classic/shell/hid_device.c
+++ b/subsys/bluetooth/host/classic/shell/hid_device.c
@@ -587,24 +587,24 @@ static int cmd_hid_send_report(const struct shell *sh, size_t argc, char *argv[]
 		return -ENOEXEC;
 	}
 
-	/* BDIT/BV-01-C: Boot Protocol mouse = buttons(1) + X(1) + Y(1).
-	 * Report Protocol mouse = Report ID(1) + buttons(1) + X(1) + Y(1) + wheel(1).
+	/* HID spec v1.1.2 Section 3.3.2: a Device in Boot Protocol Mode includes the
+	 * Report ID in every report, both in a GET_REPORT response and in one sent
+	 * asynchronously on the Interrupt channel, so the only difference from Report
+	 * Protocol Mode is the wheel byte. Boot Protocol Mode fixes the mouse Report
+	 * ID to 2, which is what this descriptor declares anyway.
 	 *
 	 * Button byte (bit fields):
 	 *  bit0 = Left, bit1 = Right, bit2 = Middle, bit3..7 = Button 4..8
 	 * X/Y: signed 8-bit relative displacement
 	 * Wheel: signed 8-bit scroll (Report Protocol only)
 	 */
-	if (hid_boot_mode) {
-		net_buf_add_u8(buf, (uint8_t)button); /* buttons */
-		net_buf_add_u8(buf, (uint8_t)dx);     /* X displacement */
-		net_buf_add_u8(buf, (uint8_t)dy);     /* Y displacement */
-	} else {
-		net_buf_add_u8(buf, SHELL_MOUSE_REPORT_ID); /* Report ID */
-		net_buf_add_u8(buf, (uint8_t)button);        /* buttons */
-		net_buf_add_u8(buf, (uint8_t)dx);            /* X displacement */
-		net_buf_add_u8(buf, (uint8_t)dy);            /* Y displacement */
-		net_buf_add_u8(buf, (uint8_t)wheel);         /* wheel scroll */
+	net_buf_add_u8(buf, SHELL_MOUSE_REPORT_ID); /* Report ID */
+	net_buf_add_u8(buf, (uint8_t)button);       /* buttons */
+	net_buf_add_u8(buf, (uint8_t)dx);           /* X displacement */
+	net_buf_add_u8(buf, (uint8_t)dy);           /* Y displacement */
+
+	if (!hid_boot_mode) {
+		net_buf_add_u8(buf, (uint8_t)wheel); /* wheel scroll */
 	}
 
 	err = bt_hid_device_input_report(default_hid, buf);


### PR DESCRIPTION
## Summary

The mouse report the `hid_device` shell sends on the Interrupt channel left the Report ID out in Boot Protocol Mode, while the `GET_REPORT` response of the same shell always included it.

HID spec v1.1.2 Section 3.3.2 puts both under one rule: every report a Device sends in Boot Protocol Mode, either asynchronously on the Interrupt channel or in answer to `GET_REPORT`, has to include the Report ID. A Host that follows this strips the first byte of the report, so what it read as the button bits was the Report ID and the whole report was off by one.

The Report ID is now sent in both modes, which leaves the wheel byte as the only difference between them and gives the two paths the same shape. The value does not change: Boot Protocol Mode fixes the mouse Report ID to 2, and the descriptor this shell registers declares 2 as well.

## Test plan

* Builds for `native_sim/native/64` with `CONFIG_BT_CLASSIC=y` and `CONFIG_BT_HID_DEVICE=y`, warnings as errors, clean.
* `checkpatch.pl` clean.


Found while reviewing #109289, where the reading of Section 3.3.2 was raised.
