### PR TITLE
toolchain: iar: experimental C++ support

### DIFF
--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -16,7 +16,10 @@ zephyr_library_sources(
   nmi_on_reset.S
 )
 
-zephyr_library_sources_ifdef(CONFIG_CPP __aeabi_atexit.c)
+# The IAR C++ runtime library provides __aeabi_atexit
+if(CONFIG_CPP AND NOT CONFIG_IAR_LIBCPP)
+  zephyr_library_sources(__aeabi_atexit.c)
+endif()
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)

--- a/cmake/compiler/iar/compiler_flags.cmake
+++ b/cmake/compiler/iar/compiler_flags.cmake
@@ -115,16 +115,19 @@ set_compiler_property(TARGET compiler-cpp PROPERTY nostdincxx)
 # Required C++ flags when compiling C++ code
 set_property(TARGET compiler-cpp PROPERTY required --c++)
 
-# Compiler flags to use for specific C++ dialects
+# Compiler flags to use for specific C++ dialects.
+# ICCARM has no option for selecting the C++ dialect, --c++ always selects
+# C++17 (see the STD_CPP17 default in cmake/toolchain/iar/Kconfig.defconfig).
+# The C++ standard library is selected with CONFIG_IAR_LIBCPP, see target.cmake.
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp98)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp11)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp14)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp17 --libc++)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a --libc++)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 --libc++)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b --libc++)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp23 --libc++)
-set_property(TARGET compiler-cpp PROPERTY dialect_cpp26 --libc++)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp17)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp20)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp23)
+set_property(TARGET compiler-cpp PROPERTY dialect_cpp26)
 
 # Flag for disabling strict aliasing rule in C and C++
 set_compiler_property(PROPERTY no_strict_aliasing)

--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -140,8 +140,14 @@ if("${IAR_TOOLCHAIN_VARIANT}" STREQUAL "iccarm")
   if(CONFIG_IAR_LIBC)
     # Zephyr requires AEABI portability to ensure correct functioning of the C
     # library, for example error numbers, errno.h.
-    list(APPEND IAR_COMMON_FLAGS -D__AEABI_PORTABILITY_LEVEL=1)
+    list(APPEND IAR_C_ONLY_FLAGS -D__AEABI_PORTABILITY_LEVEL=1)
   endif()
+  # The C++ standard library headers (both the IAR DLIB C++ library and
+  # libc++) require errno values and MB_LEN_MAX to be integer constant
+  # expressions, which they are not in AEABI portability mode where they
+  # are turned into external constants. Note that --aeabi makes the
+  # portability level default to 1, so it must be disabled explicitly.
+  list(APPEND IAR_CXX_ONLY_FLAGS -D__AEABI_PORTABILITY_LEVEL=0)
 endif()
 
 if(CONFIG_IAR_LIBC)
@@ -149,11 +155,27 @@ if(CONFIG_IAR_LIBC)
   # Zephyr uses the type FILE for normal LIBC while IAR
   # only has it for full LIBC support, so always choose
   # full libc when using IAR C libraries.
-  list(APPEND IAR_COMMON_FLAGS --dlib_config full)
+  list(APPEND IAR_C_ONLY_FLAGS --dlib_config full)
+  if(CONFIG_IAR_LIBCPP)
+    message(STATUS "IAR C++ library (libc++) used")
+    # --libc++ selects the IAR libc++ C++ standard library. It implies the
+    # full DLIB configuration and cannot be combined with --dlib_config.
+    list(APPEND IAR_CXX_ONLY_FLAGS --libc++)
+  else()
+    list(APPEND IAR_CXX_ONLY_FLAGS --dlib_config full)
+  endif()
 endif()
 
 foreach(F ${IAR_COMMON_FLAGS})
   list(APPEND TOOLCHAIN_C_FLAGS $<$<COMPILE_LANGUAGE:C>:${F}>)
+  list(APPEND TOOLCHAIN_C_FLAGS $<$<COMPILE_LANGUAGE:CXX>:${F}>)
+endforeach()
+
+foreach(F ${IAR_C_ONLY_FLAGS})
+  list(APPEND TOOLCHAIN_C_FLAGS $<$<COMPILE_LANGUAGE:C>:${F}>)
+endforeach()
+
+foreach(F ${IAR_CXX_ONLY_FLAGS})
   list(APPEND TOOLCHAIN_C_FLAGS $<$<COMPILE_LANGUAGE:CXX>:${F}>)
 endforeach()
 

--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -41,6 +41,17 @@ function(process_region)
           EXPR "@ADDR(.ramfunc_init)@"
           )
       else()
+        # make lower case aliases for ITCM and DTCM
+        if(${name} STREQUAL ITCM)
+          create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __itcm_load_start
+            EXPR "@LOADADDR(${name_clean})@"
+            )
+        endif()
+        if(${name} STREQUAL DTCM)
+          create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __dtcm_load_start
+            EXPR "@LOADADDR(${name_clean})@"
+            )
+        endif()
         create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __${name_clean}_load_start
           EXPR "@LOADADDR(${name_clean})@"
           )
@@ -69,6 +80,17 @@ function(process_region)
     get_property(symbol_val GLOBAL PROPERTY SYMBOL_TABLE___${name_clean}_end)
 
     if("${symbol_val}" STREQUAL "${name_clean}")
+      # make lower case aliases for ITCM and DTCM
+      if(${name} STREQUAL ITCM)
+        create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __itcm_size
+          EXPR "@SIZE(${name_clean})@"
+          )
+      endif()
+      if(${name} STREQUAL DTCM)
+        create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __dtcm_size
+          EXPR "@SIZE(${name_clean})@"
+          )
+      endif()
       create_symbol(OBJECT ${REGION_OBJECT} SYMBOL __${name_clean}_size
         EXPR "@SIZE(${name_clean})@"
         )
@@ -520,6 +542,15 @@ function(section_to_string)
       set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__${name_clean}_start = (__iar_tls$$INIT_DATA$$Base)")
       set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__${name_clean}_end = (__iar_tls$$INIT_DATA$$Limit)")
     else()
+      # make lower case aliases for ITCM and DTCM
+      if(${name} STREQUAL ITCM)
+        set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__itcm_start = ADDR(${name_clean})")
+        set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__itcm_end = END(${name_clean})")
+      endif()
+      if(${name} STREQUAL DTCM)
+        set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__dtcm_start = ADDR(${name_clean})")
+        set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__dtcm_end = END(${name_clean})")
+      endif()
       set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__${name_clean}_start = ADDR(${name_clean})")
       set_property(GLOBAL APPEND PROPERTY ILINK_SYMBOL_ICF "__${name_clean}_end = END(${name_clean})")
     endif()

--- a/cmake/linker/iar/linker_flags.cmake
+++ b/cmake/linker/iar/linker_flags.cmake
@@ -13,11 +13,17 @@ set_property(TARGET linker PROPERTY optimization_size_aggressive "")
 
 set_linker_property(TARGET linker PROPERTY undefined "--keep=")
 
-string(APPEND CMAKE_C_LINK_FLAGS --no-wrap-diagnostics)
+set(IAR_LINK_FLAGS --no-wrap-diagnostics)
 
 if(CONFIG_IAR_DATA_INIT)
-  string(APPEND CMAKE_C_LINK_FLAGS " --redirect arch_data_copy=__iar_data_init3")
+  string(APPEND IAR_LINK_FLAGS " --redirect arch_data_copy=__iar_data_init3")
 endif()
+
+# The link language is CXX when the application contains C++ sources
+foreach(lang C CXX)
+  string(APPEND CMAKE_${lang}_LINK_FLAGS "${IAR_LINK_FLAGS}")
+endforeach()
+
 foreach(lang C CXX ASM)
   set(commands "--log modules,libraries,initialization,redirects,sections")
   set(CMAKE_${lang}_LINK_EXECUTABLE

--- a/cmake/linker/iar/linker_flags.cmake
+++ b/cmake/linker/iar/linker_flags.cmake
@@ -19,6 +19,11 @@ if(CONFIG_IAR_DATA_INIT)
   string(APPEND IAR_LINK_FLAGS " --redirect arch_data_copy=__iar_data_init3")
 endif()
 
+if(CONFIG_STATIC_INIT_IAR)
+  # Zephyr calls __iar_dynamic_initialization() itself, see kernel/init.c
+  string(APPEND IAR_LINK_FLAGS " --manual_dynamic_initialization")
+endif()
+
 # The link language is CXX when the application contains C++ sources
 foreach(lang C CXX)
   string(APPEND CMAKE_${lang}_LINK_FLAGS "${IAR_LINK_FLAGS}")

--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -70,6 +70,9 @@ if(CONFIG_CPP)
 #		KEEP(*(SORT_BY_NAME(".init_array*")))
 #		__init_array_end = .;
 #	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+  zephyr_linker_section(NAME init_array KVMA RAM_REGION GROUP RODATA_REGION NOINPUT)
+  zephyr_linker_section_configure(SECTION init_array INPUT ".preinit_array*" KEEP SORT NAME)
+  zephyr_linker_section_configure(SECTION init_array INPUT ".init_array*" KEEP SORT NAME)
 endif()
 
 if(CONFIG_USERSPACE)

--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -36,6 +36,11 @@ config LINKER_USE_NO_RELAX
 config REQUIRES_STD_C17
 	default y
 
+# ICCARM keeps constructors in .init_array but the IAR runtime is used to run
+# them, see STATIC_INIT_IAR
+config TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU
+	default n
+
 config CODING_GUIDELINE_CHECK
 	default n
 	help

--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -36,6 +36,11 @@ config LINKER_USE_NO_RELAX
 config REQUIRES_STD_C17
 	default y
 
+# ICCARM has no option for selecting the C++ dialect, --c++ is always C++17
+choice STD_CPP
+	default STD_CPP17
+endchoice
+
 # ICCARM keeps constructors in .init_array but the IAR runtime is used to run
 # them, see STATIC_INIT_IAR
 config TOOLCHAIN_SUPPORTS_STATIC_INIT_GNU

--- a/doc/develop/toolchains/iar_arm_toolchain.rst
+++ b/doc/develop/toolchains/iar_arm_toolchain.rst
@@ -39,7 +39,10 @@ For example:
 
     - The GNU Assembler distributed with the Zephyr SDK is used for ``.S-files``.
 
-    - C library support for ``Minimal libc`` only. C++ is not supported.
+    - C library support for ``Minimal libc`` and the IAR C library (``CONFIG_IAR_LIBC``).
+      C++ is supported with the IAR libc++ library (``CONFIG_IAR_LIBCPP``) when a full
+      C++ standard library is required, or with Zephyr's minimal C++ library.
+      The compiler only supports the C++17 dialect.
 
     - Some Zephyr subsystems or modules may contain C or assembly code that relies on GNU intrinsics and have not yet been updated to work fully with ``iar``.
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1149,6 +1149,19 @@ config STATIC_INIT_GNU
 	  will emit an error if constructors are needed and this option has been
 	  disabled.
 
+config STATIC_INIT_IAR
+	bool "Support IAR dynamic initialization of static objects"
+	default y if CPP
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "iar"
+	help
+	  Run the constructors of C++ objects with static storage duration
+	  using the dynamic initialization routine of the IAR runtime,
+	  __iar_dynamic_initialization(). Since Zephyr provides its own startup
+	  code, the IAR linker is told not to perform the dynamic
+	  initialization automatically (--manual_dynamic_initialization) and
+	  Zephyr calls it before the application init level, at the same point
+	  where STATIC_INIT_GNU runs the constructors for GNU toolchains.
+
 config DEVICE_API_ASSERT
 	bool "Assert on DEVICE_API_GET"
 	default y

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -42,6 +42,10 @@
 #include <zephyr/arch/common/init.h>
 #include <scheduler.h>
 
+#ifdef CONFIG_STATIC_INIT_IAR
+#include <iar_dynamic_init.h>
+#endif
+
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* the only struct z_kernel instance */
@@ -307,6 +311,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #ifdef CONFIG_STATIC_INIT_GNU
 	z_static_init_gnu();
 #endif /* CONFIG_STATIC_INIT_GNU */
+
+#ifdef CONFIG_STATIC_INIT_IAR
+	__iar_dynamic_initialization();
+#endif /* CONFIG_STATIC_INIT_IAR */
 
 	/* Final init level before app starts */
 	z_sys_init_run_level(INIT_LEVEL_APPLICATION);

--- a/lib/cpp/Kconfig
+++ b/lib/cpp/Kconfig
@@ -109,6 +109,7 @@ choice LIBCPP_IMPLEMENTATION
 	prompt "C++ Standard Library Implementation"
 	default EXTERNAL_LIBCPP if REQUIRES_FULL_LIBCPP && NATIVE_BUILD
 	default LIBCXX_LIBCPP if REQUIRES_FULL_LIBCPP && "$(TOOLCHAIN_HAS_LIBCXX)" = "y" && "$(TOOLCHAIN_VARIANT_COMPILER)" = "llvm"
+	default IAR_LIBCPP if REQUIRES_FULL_LIBCPP && IAR_LIBC
 	default GLIBCXX_LIBCPP if REQUIRES_FULL_LIBCPP
 	default MINIMAL_LIBCPP
 
@@ -148,6 +149,14 @@ config ARCMWDT_LIBCPP
 	help
 	  Build with ARC MetaWare C++ Standard Library provided by the ARC
 	  MetaWare Development Tools (MWDT) toolchain.
+
+config IAR_LIBCPP
+	bool "IAR C++ Library"
+	depends on IAR_LIBC
+	select FULL_LIBCPP_SUPPORTED
+	help
+	  Build with the libc++ C++ Standard Library provided by the IAR
+	  toolchain.
 
 config EXTERNAL_LIBCPP
 	bool "External C++ standard library"

--- a/lib/cpp/minimal/CMakeLists.txt
+++ b/lib/cpp/minimal/CMakeLists.txt
@@ -8,6 +8,11 @@ zephyr_system_include_directories(include)
 
 zephyr_sources(
   cpp_virtual.c
-  cpp_vtable.cpp
   cpp_new.cpp
 )
+
+# The IAR compiler reserves the __cxxabiv1 type_info class names, the vtables
+# are provided by the IAR C++ runtime library.
+if(NOT ZEPHYR_TOOLCHAIN_VARIANT STREQUAL "iar")
+  zephyr_sources(cpp_vtable.cpp)
+endif()

--- a/lib/libc/iar/include/errno.h
+++ b/lib/libc/iar/include/errno.h
@@ -14,7 +14,6 @@
 
 #include_next <errno.h>
 
-#ifndef __cplusplus
 #define EPERM            1  /**< Not owner */
 #define ENOENT           2  /**< No such file or directory */
 #define ESRCH            3  /**< No such context */
@@ -92,5 +91,4 @@
 #define EOVERFLOW       139 /**< Value overflow */
 #define ECANCELED       140 /**< Operation canceled */
 #define EWOULDBLOCK  EAGAIN /**< Operation would block */
-#endif /* __cplusplus */
 #endif /* ZEPHYR_LIB_LIBC_IAR_INCLUDE_ERRNO_H_ */

--- a/lib/libc/iar/src/libc-hooks.c
+++ b/lib/libc/iar/src/libc-hooks.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <stdio.h>
+#include <LowLevelIOInterface.h>
 
 static int _stdout_hook_default(int c)
 {
@@ -50,4 +51,50 @@ size_t __write(int handle, const unsigned char *buf, size_t bufSize)
 		++nChars;
 	}
 	return nChars;
+}
+
+/*
+ * The remaining low-level I/O functions of the DLIB runtime are referenced by
+ * the file I/O parts of the library, which are pulled in by e.g. the C++
+ * stream classes. There is no file system support, so these fail (or report
+ * end-of-file on stdin).
+ */
+
+#pragma weak __read
+size_t __read(int handle, unsigned char *buf, size_t buf_size)
+{
+	ARG_UNUSED(buf);
+	ARG_UNUSED(buf_size);
+
+	if (handle == _LLIO_STDIN) {
+		return 0;
+	}
+
+	return _LLIO_ERROR;
+}
+
+#pragma weak __lseek
+long __lseek(int handle, long offset, int whence)
+{
+	ARG_UNUSED(handle);
+	ARG_UNUSED(offset);
+	ARG_UNUSED(whence);
+
+	return -1;
+}
+
+#pragma weak __close
+int __close(int handle)
+{
+	ARG_UNUSED(handle);
+
+	return 0;
+}
+
+#pragma weak remove
+int remove(const char *filename)
+{
+	ARG_UNUSED(filename);
+
+	return -1;
 }

--- a/tests/lib/cpp/libcxx/tests.yaml
+++ b/tests/lib/cpp/libcxx/tests.yaml
@@ -64,6 +64,15 @@ tests:
     extra_configs:
       - CONFIG_ARCMWDT_LIBC=y
       - CONFIG_ARCMWDT_LIBCPP=y
+  # IAR C++ Standard Library (libc++)
+  cpp.libcxx.iarlib:
+    toolchain_allow: iar
+    tags: cpp
+    extra_configs:
+      - CONFIG_IAR_LIBC=y
+      - CONFIG_IAR_LIBCPP=y
+    integration_platforms:
+      - mps2/an385
   # Host C++ Standard Library
   cpp.libcxx.host:
     arch_allow: posix


### PR DESCRIPTION
toolchain: iar: experimental C++ support

Adds C++ support for the IAR toolchain. Status is experimental: it builds and
runs the C++ samples and tests on qemu_cortex_m3 and links on mimxrt1060_evk,
but it has not seen wider use yet and C++ exceptions are not supported.

Stacked on #116149, which fixes the ITCM link failure on mimxrt1060_evk
(#115901). The first commit here is that PR's commit.

## What was broken

Any C++ file that included a standard header failed to compile with
`CONFIG_IAR_LIBC`, and even trivial C++ did not link:

- `__AEABI_PORTABILITY_LEVEL=1` makes errno values and `MB_LEN_MAX` runtime
  constants, which the C++ headers need as constant expressions.
- `--dlib_config full` and `--libc++` cannot be combined, so the C++17 dialect
  flags could never have worked.
- Static constructors were never run: `STATIC_INIT_GNU` is off with the CMake
  linker generator and `.init_array` was not placed at all.
- IAR link flags were only applied to the C link rule, but a C++ app links as
  CXX.
- Duplicate `__aeabi_atexit`, missing DLIB low-level I/O hooks, and Zephyr's
  minimal-libcpp `__cxxabiv1` vtable stubs clashing with names the IAR
  compiler reserves.

## What this does

- New `CONFIG_IAR_LIBCPP` selects IAR's libc++ and is the default when a full
  C++ library is required with `IAR_LIBC`. Maps to `--libc++`.
- New `CONFIG_STATIC_INIT_IAR`: link with `--manual_dynamic_initialization`
  and call `__iar_dynamic_initialization()` from `bg_thread_main()` at the same
  point GNU constructors run.
- Per-language flags for iccarm: portability level 1 for C, 0 for C++,
  `--dlib_config full` for C only.
- `STD_CPP17` is the default for IAR since iccarm has no dialect switch.
- Lower-level I/O stubs (`__read`, `__lseek`, `__close`, `remove`) and POSIX
  errno values visible to C++ in the IAR libc glue.
- An `iar` variant for `tests/lib/cpp/libcxx`, docs update.

## Blast radius

Everything is behind `ZEPHYR_TOOLCHAIN_VARIANT=iar`, `CONFIG_IAR_LIBC`,
`CONFIG_IAR_LIBCPP` or `CONFIG_STATIC_INIT_IAR`, with one exception: the
`init_array` output section in `common-rom.cmake` is now emitted for every
CMake linker generator user when `CONFIG_CPP=y`. That is what GNU ld already
does in `cplusplus-rom.ld`; for armlink it means `.init_array` gets an explicit
placement. Untested on armlink.

Files outside the IAR directories are in their own commits with the reason in
the message: `common-rom.cmake`, `kernel/Kconfig` + `kernel/init.c`,
`lib/cpp/Kconfig`, `arch/arm/core/CMakeLists.txt`,
`lib/cpp/minimal/CMakeLists.txt`, `tests/lib/cpp/libcxx/tests.yaml`.

## Tested

IAR cxarm 9.70.2, Zephyr SDK 1.0.1.

| Target | Result |
|---|---|
| qemu_cortex_m3 `samples/cpp/hello_world` | prints via `std::cout` |
| qemu_cortex_m3 `samples/cpp/cpp_synchronization` | runs |
| qemu_cortex_m3 `tests/lib/cpp/libcxx` (IAR libc++) | 4 pass, 1 skip (exceptions) |
| qemu_cortex_m3 `tests/lib/cpp/cxx` (minimal libcpp) | 3 pass |
| mimxrt1060_evk `samples/cpp/hello_world`, `samples/hello_world` (IAR libc and minimal libc) | link |

## Known gaps

- `CONFIG_CPP_EXCEPTIONS=y` fails to link: the IAR runtime's `.exc.text` and
  `.tdata` need placement in the generated linker config.
- ilinkarm `--whole_archive` loads only one module per member name, so
  libraries with duplicate object basenames (tflite-micro has six) lose
  symbols. Needs unique archive member names for IAR; separate change.
- With no k_heap configured the DLIB heap is `expanding size`, so the map
  reports all of RAM as readwrite data. Pre-existing behaviour.
- The DLIB thread-safety hooks (`__iar_system_Mtx*`, `__iar_file_Mtx*`,
  `__iar_*dynamiclock`, `__iar_Initlocks`) are not implemented and
  `__iar_Initlocks()` is never called, so the IAR C and C++ libraries run
  without locks. Heap (unless `CONFIG_COMMON_LIBC_MALLOC`), stdio/iostreams
  and C++ function-local statics are not thread-safe. Pre-existing for C
  with `CONFIG_IAR_LIBC`; a `k_mutex` based implementation is the follow-up.