### PR TITLE
samples: boards: espressif: flash_memory_mapped: use the storage partition

### DIFF
--- a/samples/boards/espressif/flash_memory_mapped/README.rst
+++ b/samples/boards/espressif/flash_memory_mapped/README.rst
@@ -2,7 +2,7 @@
    :name: Memory-Mapped Flash
    :relevant-api: flash_interface
 
-   Write data into scratch area and read it using flash API and memory-mapped pointer.
+   Write data into the storage partition and read it using flash API and memory-mapped pointer.
 
 Overview
 ********
@@ -42,7 +42,7 @@ port at ``/dev/ttyUSB0``:
 
    $ west espressif monitor
 
-The sample code erases the scratch area defined in DTS file and writes a 32-bytes data buffer in it.
+The sample code erases the storage partition defined in the DTS file and writes a 32-bytes data buffer in it.
 Next, it prints that region content using flash API read and also using memory-mapped pointer.
 Both readings should return the same value. Important to notice that writing using memory-mapped pointer
 is not allowed.

--- a/samples/boards/espressif/flash_memory_mapped/src/main.c
+++ b/samples/boards/espressif/flash_memory_mapped/src/main.c
@@ -22,8 +22,8 @@ int main(void)
 	const struct device *flash_device;
 	const void *mem_ptr;
 	spi_flash_mmap_handle_t handle;
-	off_t address = PARTITION_OFFSET(scratch_partition);
-	size_t size = PARTITION_SIZE(scratch_partition);
+	off_t address = PARTITION_OFFSET(storage_partition);
+	size_t size = PARTITION_SIZE(storage_partition);
 
 	flash_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	if (!device_is_ready(flash_device)) {


### PR DESCRIPTION
The sample maps and rewrites the scratch partition, which
commit 7854af5430bb ("dts: espressif: drop the scratch partition from
the tables") removed from the shared Espressif partition tables, so it
no longer builds on any Espressif board. Use the storage partition
instead: every table keeps it, and it starts on a 64 KB boundary as the
flash mapping hardware requires.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
