### PR TITLE
Bluetooth: hci: Allow userchan on native library boards

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -143,16 +143,18 @@ config BT_STM32WB0
 
 config BT_USERCHAN
 	bool
-	depends on BOARD_NATIVE_SIM
+	depends on NATIVE_LIBRARY
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_USERCHAN_ENABLED
 	select NATIVE_USE_NSI_ERRNO
 	help
 	  This driver provides access to the local Linux host's Bluetooth
 	  adapter using a User Channel HCI socket to the Linux kernel. It
-	  is only intended to be used with the native_sim[//64] build of Zephyr.
-	  The Bluetooth adapter must be powered off in order for Zephyr to
-	  be able to use it.
+	  can also connect to a UNIX socket or TCP HCI endpoint. It is
+	  intended to be used with native simulator based targets that run
+	  in real time, including out-of-tree boards.
+	  When using a local Bluetooth adapter, the adapter must be powered
+	  off in order for Zephyr to be able to use it.
 
 config BT_ESP32
 	bool


### PR DESCRIPTION
BT_USERCHAN is currently limited to BOARD_NATIVE_SIM, but the driver is implemented for the native simulator host environment rather than for that specific board.
