### PR TITLE
soc: abov: add ABOV32 (A31C156) SoC and STK-A31C156-RLN-A board support

### DIFF
--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/Kconfig.stk_a31c156_rln_a
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/Kconfig.stk_a31c156_rln_a
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STK_A31C156_RLN_A
+	select SOC_A31C156

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/board.yml
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: stk_a31c156_rln_a
+  full_name: STK-A31C156-RLN-A
+  vendor: ABOV
+  socs:
+    - name: a31c156

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/doc/index.rst
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/doc/index.rst
@@ -1,0 +1,52 @@
+.. zephyr:board:: stk_a31c156_rln_a
+
+Overview
+********
+
+The STK-A31C156-RLN-A is a starter kit from ABOV Semiconductor built around
+the A31C156 microcontroller, part of the ABOV32 A31C15x series. The A31C156
+is an Arm® Cortex®-M0+ MCU with 256 KB of flash and 32 KB of RAM,
+clocked from a 48 MHz internal HSI oscillator.
+
+Key features:
+
+- ABOV32 A31C156 (256 KB flash, 32 KB RAM, Cortex-M0+ @ 48 MHz)
+- Six user LEDs
+- Two user push-buttons
+- USART10 used as the console UART
+
+Supported Features
+*******************
+
+The following hardware features are currently supported:
+
+- GPIO
+- USART (console)
+
+.. zephyr:board-supported-hw::
+
+Connections and IOs
+********************
+
+Default board configuration:
+
+- USART10 TX/RX : PB0/PB1 (console, 38400 8N1)
+- LED0-LED5      : PE0-PE5 (active low)
+- Button 0       : PF6 (active low, internal pull-up)
+- Button 1       : PF7 (active low, internal pull-up)
+
+Programming and Debugging
+**************************
+
+Zephyr does not yet have a flash/debug runner configured for this board
+(see ``board.cmake``). Build the application as usual:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: stk_a31c156_rln_a
+   :goals: build
+
+and program the resulting ``build/zephyr/zephyr.hex`` onto the board with an
+external SWD programmer.
+
+Connect a serial terminal to the console UART at 38400 baud to see output.

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a-pinctrl.dtsi
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a-pinctrl.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/abov32-pinctrl.h>
+
+&pinctrl {
+	/*
+	 * USART10 Pin Configuration (PB0: TX, PB1: RX, ALT1), per the default
+	 * debug console pin mapping in debug_a31c15x.h (DEBUG_UART_ID=0,
+	 * DEBUG_PORT_ID=1/PORT B, TX pin 0, RX pin 1, ALT 1).
+	 */
+	usart10_default: usart10_default {
+		group1 {
+			pinmux = <ABOV_PINMUX(1, 0, 1)>, /* PB0 - USART10_TX (ALT1) */
+				 <ABOV_PINMUX(1, 1, 1)>; /* PB1 - USART10_RX (ALT1) */
+		};
+	};
+
+};

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a.dts
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a.dts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <abov/a31xxxx/a31c15x/abov_a31c15x.dtsi>
+#include "stk_a31c156_rln_a-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "ABOV STK-A31C156-RLN-A Starter Kit";
+	compatible = "abov,stk-a31c156-rln-a";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart10;
+		zephyr,shell-uart = &usart10;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpioe 0 GPIO_ACTIVE_LOW>;
+			label = "STK LED 0";
+		};
+		led1: led_1 {
+			gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
+			label = "STK LED 1";
+		};
+		led2: led_2 {
+			gpios = <&gpioe 2 GPIO_ACTIVE_LOW>;
+			label = "STK LED 2";
+		};
+		led3: led_3 {
+			gpios = <&gpioe 3 GPIO_ACTIVE_LOW>;
+			label = "STK LED 3";
+		};
+		led4: led_4 {
+			gpios = <&gpioe 4 GPIO_ACTIVE_LOW>;
+			label = "STK LED 4";
+		};
+		led5: led_5 {
+			gpios = <&gpioe 5 GPIO_ACTIVE_LOW>;
+			label = "STK LED 5";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpiof 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "STK Button 0";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		button1: button_1 {
+			gpios = <&gpiof 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "STK Button 1";
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+		led3 = &led3;
+		led4 = &led4;
+		led5 = &led5;
+		sw0 = &button0;
+		sw1 = &button1;
+	};
+};
+
+&usart10 {
+	status = "okay";
+	current-speed = <38400>;
+	pinctrl-0 = <&usart10_default>;
+	pinctrl-names = "default";
+};

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a.yaml
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: stk_a31c156_rln_a
+name: ABOV STK_A31C156_RLN_A
+type: mcu
+arch: arm
+ram: 32
+flash: 256
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - uart
+  - gpio
+vendor: abov

--- a/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a_defconfig
+++ b/boards/abov/a31xxxx/a31c15x/stk_a31c156_rln_a/stk_a31c156_rln_a_defconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y
+
+CONFIG_BUILD_OUTPUT_HEX=y

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -81,6 +81,7 @@ if(CONFIG_CLOCK_CONTROL_ESP32)
 endif()
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ABOV32 clock_control_abov32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ADI_AXI_CLKGEN clock_control_adi_axi_clkgen.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ADSP clock_control_adsp.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_AGILEX5 clock_control_agilex5.c)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -27,6 +27,7 @@ module-str = clock control
 source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
+source "drivers/clock_control/Kconfig.abov32"
 source "drivers/clock_control/Kconfig.adi_axi_clkgen"
 source "drivers/clock_control/Kconfig.agilex5"
 source "drivers/clock_control/Kconfig.alif"

--- a/drivers/clock_control/Kconfig.abov32
+++ b/drivers/clock_control/Kconfig.abov32
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_CONTROL_ABOV32
+	bool "ABOV32 clock control driver"
+	default y
+	depends on DT_HAS_ABOV_ABOV32_CCTL_ENABLED
+	help
+	  Enable driver for ABOV System Control Clock Unit.

--- a/drivers/clock_control/clock_control_abov32.c
+++ b/drivers/clock_control/clock_control_abov32.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT abov_abov32_cctl
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/dt-bindings/clock/abov32-clock.h>
+#include <zephyr/kernel.h>
+
+#include <hal_scu_clk.h>
+#include <type/scu_clk_type.h>
+
+#include "clock_control_abov32.h"
+
+struct clock_control_abov32_config {
+	uint32_t hsi_frequency;
+	uint32_t lsi_frequency;
+	bool hse_enabled;
+	uint32_t hse_frequency;
+	bool lse_enabled;
+	uint32_t lse_frequency;
+	bool pll_enabled;
+	SCUCLK_PLL_CFG_t pll_cfg;
+	uint32_t pll_output_frequency;
+	SCUCLK_SRC_e mclk_source;
+	SCUCLK_DIV_e mclk_pre_div;
+	SCUCLK_DIV_e mclk_post_div;
+	SCUCLK_DIV_e pclk_div;
+};
+
+static uint32_t clock_control_abov32_src_rate(const struct clock_control_abov32_config *cfg,
+					       SCUCLK_SRC_e src)
+{
+	switch (src) {
+	case SCUCLK_SRC_HSE:
+		return cfg->hse_frequency;
+	case SCUCLK_SRC_HSI:
+		return cfg->hsi_frequency;
+	case SCUCLK_SRC_LSI:
+		return cfg->lsi_frequency;
+	case SCUCLK_SRC_LSE:
+		return cfg->lse_frequency;
+	case SCUCLK_SRC_PLL:
+		return cfg->pll_output_frequency;
+	default:
+		return 0U;
+	}
+}
+
+static int clock_control_abov32_get_rate(const struct device *dev, clock_control_subsys_t sys,
+					  uint32_t *rate)
+{
+	const struct clock_control_abov32_config *cfg = dev->config;
+	uint32_t id = (uint32_t)(uintptr_t)sys;
+	uint32_t mclk_rate;
+	uint32_t hclk_rate;
+
+	switch (id) {
+	case ABOV32_CLOCK_HSE:
+	case ABOV32_CLOCK_HSI:
+	case ABOV32_CLOCK_LSI:
+	case ABOV32_CLOCK_LSE:
+	case ABOV32_CLOCK_PLL:
+		*rate = clock_control_abov32_src_rate(cfg, (SCUCLK_SRC_e)id);
+		return 0;
+	case ABOV32_CLOCK_MCLK:
+	case ABOV32_CLOCK_HCLK:
+		mclk_rate = clock_control_abov32_src_rate(cfg, cfg->mclk_source) >>
+			    cfg->mclk_pre_div;
+		hclk_rate = mclk_rate >> cfg->mclk_post_div;
+		*rate = (id == ABOV32_CLOCK_MCLK) ? mclk_rate : hclk_rate;
+		return 0;
+	case ABOV32_CLOCK_PCLK:
+		mclk_rate = clock_control_abov32_src_rate(cfg, cfg->mclk_source) >>
+			    cfg->mclk_pre_div;
+		hclk_rate = mclk_rate >> cfg->mclk_post_div;
+		*rate = hclk_rate >> cfg->pclk_div;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static enum clock_control_status clock_control_abov32_get_status(const struct device *dev,
+								   clock_control_subsys_t sys)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sys);
+
+	/* SCU clock sources configured at init are never gated off at runtime. */
+	return CLOCK_CONTROL_STATUS_ON;
+}
+
+static DEVICE_API(clock_control, clock_control_abov32_api) = {
+	.get_rate = clock_control_abov32_get_rate,
+	.get_status = clock_control_abov32_get_status,
+};
+
+static int clock_control_abov32_configure(const struct clock_control_abov32_config *cfg)
+{
+	SCUCLK_MCLK_CFG_t mclk_cfg = {
+		.eMClk = cfg->mclk_source,
+		.ePreMClkDiv = cfg->mclk_pre_div,
+		.ePostMClkDiv = cfg->mclk_post_div,
+	};
+
+	if (cfg->hse_enabled && HAL_SCU_CLK_SetSrcEnable(SCUCLK_SRC_HSE, true) != HAL_ERR_OK) {
+		return -EIO;
+	}
+
+	if (cfg->lse_enabled && HAL_SCU_CLK_SetSrcEnable(SCUCLK_SRC_LSE, true) != HAL_ERR_OK) {
+		return -EIO;
+	}
+
+	if (cfg->pll_enabled) {
+		SCUCLK_PLL_CFG_t pll_cfg = cfg->pll_cfg;
+
+		if (HAL_SCU_CLK_SetPLLConfig(true, &pll_cfg) != HAL_ERR_OK) {
+			return -EIO;
+		}
+	}
+
+	if (HAL_SCU_CLK_SetMClk(&mclk_cfg) != HAL_ERR_OK) {
+		return -EIO;
+	}
+
+	if (HAL_SCU_CLK_SetPClkDiv(cfg->pclk_div) != HAL_ERR_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int clock_control_abov32_init(const struct device *dev)
+{
+	return clock_control_abov32_configure(dev->config);
+}
+
+static const struct clock_control_abov32_config clock_control_abov32_cfg_0 = {
+	.hsi_frequency = DT_INST_PROP(0, hsi_frequency),
+	.lsi_frequency = DT_INST_PROP(0, lsi_frequency),
+	.hse_enabled = DT_INST_NODE_HAS_PROP(0, hse_frequency),
+	.hse_frequency = DT_INST_PROP_OR(0, hse_frequency, 0),
+	.lse_enabled = DT_INST_NODE_HAS_PROP(0, lse_frequency),
+	.lse_frequency = DT_INST_PROP_OR(0, lse_frequency, 0),
+	.pll_enabled = DT_INST_NODE_HAS_PROP(0, pll_output_frequency),
+	.pll_cfg = {
+		.eSrc = DT_INST_PROP(0, pll_source_hse) ? SCUCLK_PLL_SRC_HSE : SCUCLK_PLL_SRC_HSI,
+		.eSrcDiv = DT_INST_PROP_OR(0, pll_source_div, 0),
+		.un8OutDiv = DT_INST_PROP_OR(0, pll_out_div, 0),
+		.un8PostDiv1 = DT_INST_PROP_OR(0, pll_post_div1, 0),
+		.un8PostDiv2 = DT_INST_PROP_OR(0, pll_post_div2, 0),
+		.un8PreDiv = DT_INST_PROP_OR(0, pll_pre_div, 0),
+		.eCurOpt = SCUCLK_PLL_CTRLOPT_10UA,
+		.eVcoBias = SCUCLK_PLL_VCOBIAS_NONE,
+		.ePllMode = DT_INST_PROP(0, pll_vco2x) ? SCUCLK_PLL_MODE_VCO2X
+							: SCUCLK_PLL_MODE_VCO,
+	},
+	.pll_output_frequency = DT_INST_PROP_OR(0, pll_output_frequency, 0),
+	.mclk_source = DT_INST_PROP_OR(0, mclk_source, ABOV32_CLOCK_HSI),
+	.mclk_pre_div = DT_INST_PROP_OR(0, mclk_pre_div, 0),
+	.mclk_post_div = DT_INST_PROP_OR(0, mclk_post_div, 0),
+	.pclk_div = DT_INST_PROP_OR(0, pclk_div, 0),
+};
+
+DEVICE_DT_INST_DEFINE(0, clock_control_abov32_init, NULL, NULL, &clock_control_abov32_cfg_0,
+		       PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		       &clock_control_abov32_api);
+
+void clock_control_abov32_reinit(void)
+{
+	/*
+	 * Only one cctl instance exists on this SoC (DT_DRV_COMPAT is
+	 * single-instance here), so there's no device pointer to look up --
+	 * go straight at the same config struct clock_control_abov32_init()
+	 * used. A failure here has nowhere useful to report to (this runs
+	 * from pm_state_exit_post_ops(), which returns void), so it's
+	 * intentionally not checked.
+	 */
+	(void)clock_control_abov32_configure(&clock_control_abov32_cfg_0);
+}

--- a/drivers/clock_control/clock_control_abov32.h
+++ b/drivers/clock_control/clock_control_abov32.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_ABOV32_H_
+#define ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_ABOV32_H_
+
+/**
+ * @brief Re-apply the board's cctl devicetree clock configuration to the SCU.
+ *
+ * DEEP-SLEEP wake-up on this SoC leaves MCLK on its HSI fallback with the
+ * HCLK divider back at its power-on-reset default (A31C15x user's manual
+ * section 4.7.5) -- everything clock_control_abov32_init() set up at boot
+ * (MCLK source/dividers, PCLK divider, and any configured HSE/LSE/PLL
+ * enables) needs to be redone. Call this from pm_state_exit_post_ops()
+ * before anything that assumes CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC is
+ * actually true again (notably SysTick).
+ */
+void clock_control_abov32_reinit(void);
+
+#endif /* ZEPHYR_DRIVERS_CLOCK_CONTROL_CLOCK_CONTROL_ABOV32_H_ */

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 # zephyr-keep-sorted-start
 zephyr_library_include_directories_ifdef(CONFIG_GPIO_NPM10XX ${ZEPHYR_BASE}/drivers/mfd)
+zephyr_library_sources_ifdef(CONFIG_GPIO_ABOV32 gpio_abov32.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_AD559X gpio_ad559x.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_ADP5585 gpio_adp5585.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_ADS1X4S0X gpio_ads1x4s0x.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -94,6 +94,7 @@ config GPIO_ENABLE_DISABLE_INTERRUPT
 	  pending register, etc. The driver must implement it to work.
 
 # zephyr-keep-sorted-start
+source "drivers/gpio/Kconfig.abov32"
 source "drivers/gpio/Kconfig.ad559x"
 source "drivers/gpio/Kconfig.adp5585"
 source "drivers/gpio/Kconfig.ads1x4s0x"

--- a/drivers/gpio/Kconfig.abov32
+++ b/drivers/gpio/Kconfig.abov32
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config GPIO_ABOV32
+	bool "ABOV32 GPIO driver"
+	default y
+	depends on DT_HAS_ABOV_ABOV32_GPIO_ENABLED
+	help
+	  Enable the GPIO driver for the ABOV32 Port Control Unit (PCU), built
+	  on the ABOV HAL PCU API (hal_pcu.h).

--- a/drivers/gpio/gpio_abov32.c
+++ b/drivers/gpio/gpio_abov32.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT abov_abov32_gpio
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_utils.h>
+#include <zephyr/init.h>
+#include <zephyr/irq.h>
+
+/* Platform HAL headers */
+#include <hal_pcu.h>
+#include <hll_pcu.h>
+
+struct gpio_abov32_config {
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	PCU_ID_e port_id;
+};
+
+struct gpio_abov32_data {
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	sys_slist_t callbacks;
+};
+
+static int gpio_abov32_pin_configure(const struct device *dev, gpio_pin_t pin,
+				      gpio_flags_t flags)
+{
+	const struct gpio_abov32_config *config = dev->config;
+	PCU_ID_e port = config->port_id;
+	PCU_PUPD_e pupd;
+
+	if ((flags & GPIO_OUTPUT) != 0U) {
+		if (HAL_PCU_SetInOutMode(port, (PCU_PIN_ID_e)pin,
+					  (flags & GPIO_OPEN_DRAIN) != 0U
+						  ? PCU_INOUT_OUTPUT_OPEN_DRAIN
+						  : PCU_INOUT_OUTPUT_PUSH_PULL) != HAL_ERR_OK) {
+			return -EINVAL;
+		}
+
+		if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0U) {
+			HAL_PCU_SetOutputValue(port, (PCU_PIN_ID_e)pin, PCU_PORT_HIGH);
+		} else if ((flags & GPIO_OUTPUT_INIT_LOW) != 0U) {
+			HAL_PCU_SetOutputValue(port, (PCU_PIN_ID_e)pin, PCU_PORT_LOW);
+		}
+	} else if ((flags & GPIO_INPUT) != 0U) {
+		if (HAL_PCU_SetInOutMode(port, (PCU_PIN_ID_e)pin, PCU_INOUT_INPUT) !=
+		    HAL_ERR_OK) {
+			return -EINVAL;
+		}
+	} else {
+		return -ENOTSUP;
+	}
+
+	if ((flags & GPIO_PULL_UP) != 0U) {
+		pupd = PCU_PUPD_UP;
+	} else if ((flags & GPIO_PULL_DOWN) != 0U) {
+		pupd = PCU_PUPD_DOWN;
+	} else {
+		pupd = PCU_PUPD_DISABLED;
+	}
+
+	if (HAL_PCU_SetPullUpDown(port, (PCU_PIN_ID_e)pin, pupd) != HAL_ERR_OK) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int gpio_abov32_port_get_raw(const struct device *dev, gpio_port_value_t *value)
+{
+	const struct gpio_abov32_config *config = dev->config;
+	gpio_port_value_t result = 0;
+
+	for (uint32_t pin = 0U; pin < PCU_PIN_ID_MAX; pin++) {
+		PCU_PORT_e level;
+
+		if (HAL_PCU_GetInputValue(config->port_id, (PCU_PIN_ID_e)pin, &level) ==
+			    HAL_ERR_OK &&
+		    level == PCU_PORT_HIGH) {
+			result |= (gpio_port_value_t)BIT(pin);
+		}
+	}
+
+	*value = result;
+
+	return 0;
+}
+
+static int gpio_abov32_port_set_masked_raw(const struct device *dev, gpio_port_pins_t mask,
+					    gpio_port_value_t value)
+{
+	const struct gpio_abov32_config *config = dev->config;
+
+	for (uint32_t pin = 0U; pin < PCU_PIN_ID_MAX; pin++) {
+		if ((mask & BIT(pin)) == 0U) {
+			continue;
+		}
+
+		HAL_PCU_SetOutputValue(config->port_id, (PCU_PIN_ID_e)pin,
+					(value & BIT(pin)) != 0U ? PCU_PORT_HIGH : PCU_PORT_LOW);
+	}
+
+	return 0;
+}
+
+static int gpio_abov32_port_set_bits_raw(const struct device *dev, gpio_port_pins_t pins)
+{
+	return gpio_abov32_port_set_masked_raw(dev, pins, pins);
+}
+
+static int gpio_abov32_port_clear_bits_raw(const struct device *dev, gpio_port_pins_t pins)
+{
+	return gpio_abov32_port_set_masked_raw(dev, pins, 0U);
+}
+
+static int gpio_abov32_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
+{
+	const struct gpio_abov32_config *config = dev->config;
+
+	for (uint32_t pin = 0U; pin < PCU_PIN_ID_MAX; pin++) {
+		PCU_PORT_e level;
+
+		if ((pins & BIT(pin)) == 0U) {
+			continue;
+		}
+
+		if (HAL_PCU_GetInputValue(config->port_id, (PCU_PIN_ID_e)pin, &level) !=
+		    HAL_ERR_OK) {
+			continue;
+		}
+
+		HAL_PCU_SetOutputValue(config->port_id, (PCU_PIN_ID_e)pin,
+					level == PCU_PORT_HIGH ? PCU_PORT_LOW : PCU_PORT_HIGH);
+	}
+
+	return 0;
+}
+
+/*
+ * PCU_INTR_MODE_e/PCU_INTR_TRG_e are a (mode x trigger) pair: the mode
+ * selects level- vs edge-sensing, the trigger selects which physical level
+ * (or edge direction) it reacts to. By the time flags reach here,
+ * z_impl_gpio_pin_interrupt_configure() has already resolved GPIO_ACTIVE_LOW
+ * into the physical trigger direction, so no extra inversion is needed.
+ */
+static int gpio_abov32_pin_interrupt_configure(const struct device *dev, gpio_pin_t pin,
+						enum gpio_int_mode mode, enum gpio_int_trig trig)
+{
+	const struct gpio_abov32_config *config = dev->config;
+	PCU_INTR_MODE_e pcu_mode;
+	PCU_INTR_TRG_e pcu_trig;
+
+	if (mode == GPIO_INT_MODE_DISABLED) {
+		pcu_mode = PCU_INTR_MODE_DISABLE;
+		pcu_trig = PCU_INTR_TRG_DISABLE;
+	} else {
+		pcu_mode = (mode == GPIO_INT_MODE_EDGE) ? PCU_INTR_MODE_EDGE
+							 : PCU_INTR_MODE_LEVEL_NONPEND;
+
+		switch (trig) {
+		case GPIO_INT_TRIG_LOW:
+			pcu_trig = PCU_INTR_TRG_LOW_FALLING;
+			break;
+		case GPIO_INT_TRIG_HIGH:
+			pcu_trig = PCU_INTR_TRG_HIGH_RISING;
+			break;
+		case GPIO_INT_TRIG_BOTH:
+			pcu_trig = PCU_INTR_TRG_BOTH_LEVEL_EDGE;
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	if (HAL_PCU_SetIntrPort(config->port_id, (PCU_PIN_ID_e)pin, pcu_mode, pcu_trig, 0U) !=
+	    HAL_ERR_OK) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int gpio_abov32_manage_callback(const struct device *dev, struct gpio_callback *callback,
+					bool set)
+{
+	struct gpio_abov32_data *data = dev->data;
+
+	return gpio_manage_callback(&data->callbacks, callback, set);
+}
+
+/* Indexed by PCU_ID_e; populated as each abov,abov32-gpio instance inits. */
+static const struct device *gpio_abov32_ports[PCU_ID_MAX];
+
+static void gpio_abov32_port_isr(const struct device *dev)
+{
+	const struct gpio_abov32_config *config = dev->config;
+	struct gpio_abov32_data *data = dev->data;
+	PORT_Type *regs = HLL_PCU_GET_REG(config->port_id);
+	uint32_t isr = regs->ISR;
+	gpio_port_pins_t fired = 0U;
+	uint32_t clear_mask = 0U;
+
+	for (uint32_t pin = 0U; pin < PCU_PIN_ID_MAX; pin++) {
+		uint32_t status = (isr >> PCU_INTR_BIT(pin)) & MASK_2BITS;
+
+		if (status != PCU_INTR_STATUS_NONE) {
+			fired |= (gpio_port_pins_t)BIT(pin);
+			clear_mask |= (MASK_2BITS << PCU_INTR_BIT(pin));
+		}
+	}
+
+	if (clear_mask != 0U) {
+		HLL_PCU_SetWriteEnable();
+		regs->ISR = clear_mask;
+		HLL_PCU_SetWriteDisable();
+	}
+
+	if (fired != 0U) {
+		gpio_fire_callbacks(&data->callbacks, dev, fired);
+	}
+}
+
+/*
+ * PCU pairs ports onto shared NVIC lines (A+B, C+D, E+F, ...), so one
+ * physical interrupt can belong to more than one abov,abov32-gpio instance.
+ * Rather than hardcode that pairing, this shared handler polls every
+ * *registered* port -- a port with nothing pending just reads back an ISR
+ * of 0, so this stays correct (and cheap, at most PCU_ID_MAX ports)
+ * regardless of which ports end up sharing a line.
+ */
+static void gpio_abov32_isr(const struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(gpio_abov32_ports); i++) {
+		if (gpio_abov32_ports[i] != NULL) {
+			gpio_abov32_port_isr(gpio_abov32_ports[i]);
+		}
+	}
+}
+
+/*
+ * Each shared NVIC line must be IRQ_CONNECT()'d from exactly one call site:
+ * gen_isr_tables.py rejects a second registration for the same line, even
+ * with an identical handler, so this can't just be done from every per-port
+ * instance's own init. Pick whichever of a shared line's ports is actually
+ * enabled to source the connect; when both are, either works since they
+ * report the same DT_IRQN().
+ */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpioe))
+#define GPIO_ABOV32_EF_IRQ_NODE DT_NODELABEL(gpioe)
+#elif DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpiof))
+#define GPIO_ABOV32_EF_IRQ_NODE DT_NODELABEL(gpiof)
+#endif
+
+static int gpio_abov32_shared_irq_init(void)
+{
+#if defined(GPIO_ABOV32_EF_IRQ_NODE)
+	IRQ_CONNECT(DT_IRQN(GPIO_ABOV32_EF_IRQ_NODE), DT_IRQ(GPIO_ABOV32_EF_IRQ_NODE, priority),
+		    gpio_abov32_isr, NULL, 0);
+	irq_enable(DT_IRQN(GPIO_ABOV32_EF_IRQ_NODE));
+#endif
+	return 0;
+}
+
+SYS_INIT(gpio_abov32_shared_irq_init, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY);
+
+static DEVICE_API(gpio, gpio_abov32_driver_api) = {
+	.pin_configure = gpio_abov32_pin_configure,
+	.port_get_raw = gpio_abov32_port_get_raw,
+	.port_set_masked_raw = gpio_abov32_port_set_masked_raw,
+	.port_set_bits_raw = gpio_abov32_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_abov32_port_clear_bits_raw,
+	.port_toggle_bits = gpio_abov32_port_toggle_bits,
+	.pin_interrupt_configure = gpio_abov32_pin_interrupt_configure,
+	.manage_callback = gpio_abov32_manage_callback,
+};
+
+#define GPIO_ABOV32_INIT(inst)                                                                   \
+	static const struct gpio_abov32_config gpio_abov32_config_##inst = {                     \
+		.common = GPIO_COMMON_CONFIG_FROM_DT_INST(inst),                                  \
+		.port_id = (PCU_ID_e)((DT_INST_REG_ADDR(inst) - PCU_REG_BASE) / PCU_REG_OFFSET),  \
+	};                                                                                         \
+	static struct gpio_abov32_data gpio_abov32_data_##inst;                                   \
+	static int gpio_abov32_init_##inst(const struct device *dev)                             \
+	{                                                                                          \
+		gpio_abov32_ports[gpio_abov32_config_##inst.port_id] = dev;                      \
+		return 0;                                                                         \
+	}                                                                                          \
+	DEVICE_DT_INST_DEFINE(inst, gpio_abov32_init_##inst, NULL, &gpio_abov32_data_##inst,      \
+			      &gpio_abov32_config_##inst, POST_KERNEL,                            \
+			      CONFIG_GPIO_INIT_PRIORITY, &gpio_abov32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_ABOV32_INIT)

--- a/drivers/pinctrl/CMakeLists.txt
+++ b/drivers/pinctrl/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library()
 zephyr_library_sources(common.c)
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_PINCTRL_ABOV32 pinctrl_abov32.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_AESC pinctrl_aesc.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_ALIF pinctrl_alif.c)
 zephyr_library_sources_ifdef(CONFIG_PINCTRL_AMBIQ pinctrl_ambiq.c)

--- a/drivers/pinctrl/Kconfig
+++ b/drivers/pinctrl/Kconfig
@@ -39,6 +39,7 @@ config PINCTRL_KEEP_SLEEP_STATE
 	default y if PM || PM_DEVICE || DEVICE_DEINIT_SUPPORT
 
 # zephyr-keep-sorted-start
+source "drivers/pinctrl/Kconfig.abov32"
 source "drivers/pinctrl/Kconfig.aesc"
 source "drivers/pinctrl/Kconfig.alif"
 source "drivers/pinctrl/Kconfig.ambiq"

--- a/drivers/pinctrl/Kconfig.abov32
+++ b/drivers/pinctrl/Kconfig.abov32
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config PINCTRL_ABOV32
+	bool "ABOV32 pinctrl driver"
+	default y
+	depends on DT_HAS_ABOV_ABOV32_PINCTRL_ENABLED
+	help
+	  Enable pin controller driver for ABOV32 SoCs.

--- a/drivers/pinctrl/pinctrl_abov32.c
+++ b/drivers/pinctrl/pinctrl_abov32.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/pinctrl.h>
+
+/* Platform HLL headers */
+#include <hll_pcu.h>
+#include <type/pcu_type.h>
+
+/* Static assertion checks to ensure pinctrl definitions match HLL definitions */
+BUILD_ASSERT((ABOV_PUPD_NONE == PCU_PUPD_DISABLED) &&
+	     (ABOV_PUPD_PULLUP == PCU_PUPD_UP) &&
+	     (ABOV_PUPD_PULLDN == PCU_PUPD_DOWN),
+	     "pinctrl pull-up/down definitions != HLL definitions");
+
+/**
+ * @brief Configure a single pin according to pinctrl_soc_pin_t settings using HLL API.
+ *
+ * @param pin Pin configuration encoded in pinctrl_soc_pin_t format.
+ */
+static void pinctrl_configure_pin(pinctrl_soc_pin_t pin)
+{
+	PCU_ID_e port = ABOV_PORT_GET(pin);
+	uint32_t pin_num = (uint32_t)ABOV_PIN_GET(pin);
+	uint8_t alt = (uint8_t)ABOV_ALT_GET(pin);
+	uint8_t pupd = (uint8_t)ABOV_PUPD_GET(pin);
+	uint32_t otype = ABOV_OTYPE_GET(pin);
+
+	/* 1. Enable PCU protected register write access */
+	HLL_PCU_SetWriteEnable();
+
+	/*
+	 * 2. Configure alternate function (pin multiplexing) via HLL. Once a
+	 *    pin's ALT type is selected, the peripheral's own open-drain vs
+	 *    push-pull behavior applies automatically -- there is no separate
+	 *    software output-type selection for alt-function pins on this
+	 *    chip (confirmed against the datasheet), so `otype` only matters
+	 *    for plain-GPIO pins, not here.
+	 */
+	if (pin_num < 8U) {
+		HLL_PCU_SetAlt1Type(port, pin_num, alt);
+	} else {
+		HLL_PCU_SetAlt2Type(port, pin_num, alt);
+	}
+
+	/* 3. Configure pull-up / pull-down mode via HLL */
+	HLL_PCU_SetPullUpDown(port, pin_num, pupd);
+
+	/* 4. Disable PCU protected register write access */
+	HLL_PCU_SetWriteDisable();
+
+	ARG_UNUSED(otype);
+}
+
+/**
+ * @brief Configure a set of pins for a peripheral state.
+ *
+ * This API is invoked by the Zephyr pinctrl subsystem to configure all pins
+ * assigned to a specific peripheral state (e.g., pinctrl-0 / default state).
+ *
+ * @param pins Array of pin configurations.
+ * @param pin_cnt Number of pins in the array.
+ * @param reg Peripheral base address (unused for ABOV PCU).
+ *
+ * @return 0 on success, or negative error code on failure.
+ */
+int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintptr_t reg)
+{
+	ARG_UNUSED(reg);
+
+	for (uint8_t i = 0U; i < pin_cnt; i++) {
+		pinctrl_configure_pin(pins[i]);
+	}
+
+	return 0;
+}

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -116,6 +116,7 @@ zephyr_library_sources_ifdef(CONFIG_UART_XEN_HVC_CONSOLEIO uart_hvc_xen_consolei
 zephyr_library_sources_ifdef(CONFIG_UART_XLNX_PS uart_xlnx_ps.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XLNX_UARTLITE uart_xlnx_uartlite.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XMC4XXX uart_xmc4xxx.c)
+zephyr_library_sources_ifdef(CONFIG_USART_ABOV32 usart_abov32.c)
 zephyr_library_sources_ifdef(CONFIG_USART_GD32 usart_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_USART_SAM usart_sam.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE uart_handlers.c)

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -166,6 +166,7 @@ config UART_SHELL
 comment "Serial Drivers"
 
 # zephyr-keep-sorted-start
+rsource "Kconfig.abov32"
 rsource "Kconfig.aesc"
 rsource "Kconfig.altera"
 rsource "Kconfig.altera_jtag"

--- a/drivers/serial/Kconfig.abov32
+++ b/drivers/serial/Kconfig.abov32
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config USART_ABOV32
+	bool "ABOV32 USART serial driver"
+	default y
+	depends on DT_HAS_ABOV_ABOV32_USART_ENABLED
+	select PINCTRL
+	select CLOCK_CONTROL
+	select SERIAL_HAS_DRIVER
+	select SERIAL_SUPPORT_INTERRUPT
+	help
+	  Enable the asynchronous (UART mode) driver for the ABOV32 USART
+	  peripheral, built on the ABOV HLL USART API (hll_usart.h).

--- a/drivers/serial/usart_abov32.c
+++ b/drivers/serial/usart_abov32.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT abov_abov32_usart
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/irq.h>
+
+#include <hll_usart.h>
+
+struct usart_abov32_config {
+	USART_ID_e id;
+	const struct pinctrl_dev_config *pcfg;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	void (*irq_config_func)(const struct device *dev);
+#endif
+};
+
+struct usart_abov32_data {
+	struct uart_config cfg;
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	uart_irq_callback_user_data_t callback;
+	void *cb_data;
+#endif
+};
+
+static int usart_abov32_data_bits(uint8_t data_bits, USART_DATA_e *out)
+{
+	switch (data_bits) {
+	case UART_CFG_DATA_BITS_5:
+		*out = USART_DATA_5;
+		break;
+	case UART_CFG_DATA_BITS_6:
+		*out = USART_DATA_6;
+		break;
+	case UART_CFG_DATA_BITS_7:
+		*out = USART_DATA_7;
+		break;
+	case UART_CFG_DATA_BITS_8:
+		*out = USART_DATA_8;
+		break;
+	case UART_CFG_DATA_BITS_9:
+		*out = USART_DATA_9;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int usart_abov32_parity(uint8_t parity, USART_PARITY_e *out)
+{
+	switch (parity) {
+	case UART_CFG_PARITY_NONE:
+		*out = USART_PARITY_NONE;
+		break;
+	case UART_CFG_PARITY_ODD:
+		*out = USART_PARITY_ODD;
+		break;
+	case UART_CFG_PARITY_EVEN:
+		*out = USART_PARITY_EVEN;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int usart_abov32_stop_bits(uint8_t stop_bits, USART_STOP_e *out)
+{
+	switch (stop_bits) {
+	case UART_CFG_STOP_BITS_1:
+		*out = USART_STOP_1;
+		break;
+	case UART_CFG_STOP_BITS_2:
+		*out = USART_STOP_2;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int usart_abov32_configure(const struct device *dev, const struct uart_config *cfg)
+{
+	const struct usart_abov32_config *config = dev->config;
+	struct usart_abov32_data *data = dev->data;
+	USART_DATA_e data_bits;
+	USART_PARITY_e parity;
+	USART_STOP_e stop_bits;
+	uint32_t bdr, bfr;
+	int ret;
+
+	if (cfg->flow_ctrl != UART_CFG_FLOW_CTRL_NONE) {
+		return -ENOTSUP;
+	}
+
+	ret = usart_abov32_data_bits(cfg->data_bits, &data_bits);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = usart_abov32_parity(cfg->parity, &parity);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = usart_abov32_stop_bits(cfg->stop_bits, &stop_bits);
+	if (ret != 0) {
+		return ret;
+	}
+
+	HLL_USART_ClearControl(config->id);
+	HLL_USART_SetMode(config->id, USART_MODE_UART);
+	HLL_USART_SetUartFormat(config->id, parity, data_bits, stop_bits, false);
+
+	HLL_USART_CalcUartBaud(cfg->baudrate, false, &bdr, &bfr);
+	HLL_USART_SetBaudRate(config->id, bdr, bfr);
+
+	HLL_USART_SetTxEnable(config->id, true);
+	HLL_USART_SetRxEnable(config->id, true);
+	HLL_USART_SetEnable(config->id, true);
+
+	data->cfg = *cfg;
+
+	return 0;
+}
+
+static int usart_abov32_config_get(const struct device *dev, struct uart_config *cfg)
+{
+	struct usart_abov32_data *data = dev->data;
+
+	*cfg = data->cfg;
+
+	return 0;
+}
+
+static int usart_abov32_poll_in(const struct device *dev, unsigned char *c)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	if (!HLL_USART_GetRxReady(config->id)) {
+		return -1;
+	}
+
+	*c = (unsigned char)HLL_USART_ReceiveByte(config->id);
+
+	return 0;
+}
+
+static void usart_abov32_poll_out(const struct device *dev, unsigned char c)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	HLL_USART_TransmitByte(config->id, c);
+	while (!HLL_USART_GetTxReady(config->id)) {
+	}
+}
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static int usart_abov32_fifo_fill(const struct device *dev, const uint8_t *tx_data, int len)
+{
+	const struct usart_abov32_config *config = dev->config;
+	int num_tx = 0;
+
+	while (num_tx < len && HLL_USART_GetTxReady(config->id)) {
+		HLL_USART_TransmitByte(config->id, tx_data[num_tx]);
+		num_tx++;
+	}
+
+	return num_tx;
+}
+
+static int usart_abov32_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
+{
+	const struct usart_abov32_config *config = dev->config;
+	int num_rx = 0;
+
+	while (num_rx < size && HLL_USART_GetRxReady(config->id)) {
+		rx_data[num_rx++] = (uint8_t)HLL_USART_ReceiveByte(config->id);
+	}
+
+	return num_rx;
+}
+
+static void usart_abov32_irq_tx_enable(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	HLL_USART_SetTxIntrEnable(config->id, true);
+}
+
+static void usart_abov32_irq_tx_disable(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	HLL_USART_SetTxIntrEnable(config->id, false);
+}
+
+static int usart_abov32_irq_tx_ready(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	return HLL_USART_GetTxReady(config->id) ? 1 : 0;
+}
+
+static int usart_abov32_irq_tx_complete(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	return (HLL_USART_GetStatus(config->id) & USART_STATUS_TXC) ? 1 : 0;
+}
+
+static void usart_abov32_irq_rx_enable(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	HLL_USART_SetRxIntrEnable(config->id, true);
+}
+
+static void usart_abov32_irq_rx_disable(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	HLL_USART_SetRxIntrEnable(config->id, false);
+}
+
+static int usart_abov32_irq_rx_ready(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+
+	return HLL_USART_GetRxReady(config->id) ? 1 : 0;
+}
+
+static int usart_abov32_irq_is_pending(const struct device *dev)
+{
+	return usart_abov32_irq_tx_ready(dev) || usart_abov32_irq_rx_ready(dev);
+}
+
+static void usart_abov32_irq_callback_set(const struct device *dev,
+					   uart_irq_callback_user_data_t cb, void *cb_data)
+{
+	struct usart_abov32_data *data = dev->data;
+
+	data->callback = cb;
+	data->cb_data = cb_data;
+}
+
+static void usart_abov32_isr(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+	struct usart_abov32_data *data = dev->data;
+	uint32_t status = HLL_USART_GetStatus(config->id);
+
+	HLL_USART_ClearStatus(config->id, status);
+
+	if (data->callback) {
+		data->callback(dev, data->cb_data);
+	}
+}
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
+static DEVICE_API(uart, usart_abov32_driver_api) = {
+	.poll_in = usart_abov32_poll_in,
+	.poll_out = usart_abov32_poll_out,
+#ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
+	.configure = usart_abov32_configure,
+	.config_get = usart_abov32_config_get,
+#endif
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	.fifo_fill = usart_abov32_fifo_fill,
+	.fifo_read = usart_abov32_fifo_read,
+	.irq_tx_enable = usart_abov32_irq_tx_enable,
+	.irq_tx_disable = usart_abov32_irq_tx_disable,
+	.irq_tx_ready = usart_abov32_irq_tx_ready,
+	.irq_tx_complete = usart_abov32_irq_tx_complete,
+	.irq_rx_enable = usart_abov32_irq_rx_enable,
+	.irq_rx_disable = usart_abov32_irq_rx_disable,
+	.irq_rx_ready = usart_abov32_irq_rx_ready,
+	.irq_is_pending = usart_abov32_irq_is_pending,
+	.irq_callback_set = usart_abov32_irq_callback_set,
+#endif
+};
+
+static int usart_abov32_init(const struct device *dev)
+{
+	const struct usart_abov32_config *config = dev->config;
+	struct usart_abov32_data *data = dev->data;
+	int ret;
+
+	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret != 0) {
+		return ret;
+	}
+
+	HLL_USART_SetClockEnable(config->id, true);
+
+	ret = usart_abov32_configure(dev, &data->cfg);
+	if (ret != 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+	config->irq_config_func(dev);
+#endif
+
+	return 0;
+}
+
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+#define ABOV32_USART_IRQ_HANDLER(n)                                                               \
+	static void usart_abov32_irq_config_##n(const struct device *dev)                        \
+	{                                                                                          \
+		ARG_UNUSED(dev);                                                                  \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), usart_abov32_isr,          \
+			    DEVICE_DT_INST_GET(n), 0);                                            \
+		irq_enable(DT_INST_IRQN(n));                                                      \
+	}
+#define ABOV32_USART_IRQ_FUNC_INIT(n) .irq_config_func = usart_abov32_irq_config_##n,
+#else
+#define ABOV32_USART_IRQ_HANDLER(n)
+#define ABOV32_USART_IRQ_FUNC_INIT(n)
+#endif
+
+#define ABOV32_USART_INIT(n)                                                                     \
+	PINCTRL_DT_INST_DEFINE(n);                                                                \
+	ABOV32_USART_IRQ_HANDLER(n)                                                               \
+                                                                                                   \
+	static const struct usart_abov32_config usart_abov32_cfg_##n = {                         \
+		.id = (USART_ID_e)((DT_INST_REG_ADDR(n) - USART_REG_BASE) / USART_REG_OFFSET),    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                        \
+		ABOV32_USART_IRQ_FUNC_INIT(n)                                                     \
+	};                                                                                         \
+                                                                                                   \
+	static struct usart_abov32_data usart_abov32_data_##n = {                                \
+		.cfg = {                                                                          \
+			.baudrate = DT_INST_PROP(n, current_speed),                               \
+			.parity = UART_CFG_PARITY_NONE,                                           \
+			.stop_bits = UART_CFG_STOP_BITS_1,                                        \
+			.data_bits = UART_CFG_DATA_BITS_8,                                        \
+			.flow_ctrl = UART_CFG_FLOW_CTRL_NONE,                                     \
+		},                                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, usart_abov32_init, NULL, &usart_abov32_data_##n,                 \
+			      &usart_abov32_cfg_##n, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,   \
+			      &usart_abov32_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(ABOV32_USART_INIT)

--- a/dts/arm/abov/a31xxxx/a31c15x/abov_a31c15x.dtsi
+++ b/dts/arm/abov/a31xxxx/a31c15x/abov_a31c15x.dtsi
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/clock/abov32-clock.h>
+#include <mem.h>
+
+/ {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <0>;
+			clock-frequency = <48000000>;
+		};
+
+	};
+
+	sram0: memory@20000000 {
+		compatible = "mmio-sram";
+		reg = <0x20000000 DT_SIZE_K(32)>;
+	};
+
+	soc {
+		flash_controller: flash-controller@40080000 {
+			compatible = "abov,abov32-flash-controller";
+			reg = <0x40080000 0x1000>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0x0 DT_SIZE_K(256)>;
+			};
+		};
+
+		pinctrl: pinctrl@40090000 {
+			compatible = "abov,abov32-pinctrl";
+			reg = <0x40090000 0x1000>;
+		};
+
+		gpioe: gpio@40090400 {
+			compatible = "abov,abov32-gpio";
+			reg = <0x40090400 0x100>;
+			/* GPIOEF_IRQn is shared between Port E and Port F. */
+			interrupts = <13 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <16>;
+		};
+
+		gpiof: gpio@40090500 {
+			compatible = "abov,abov32-gpio";
+			reg = <0x40090500 0x100>;
+			/* GPIOEF_IRQn is shared between Port E and Port F. */
+			interrupts = <13 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <16>;
+		};
+
+		cctl: cctl@40000000 {
+			compatible = "abov,abov32-cctl";
+			reg = <0x40000000 0x400>;
+			#clock-cells = <1>;
+			/* A31C15x's HSI is 48 MHz (see startup_a31c15x.h's HSI_CLOCK). */
+			hsi-frequency = <48000000>;
+		};
+
+		usart10: usart@40001000 {
+			compatible = "abov,abov32-usart";
+			reg = <0x40001000 0x100>;
+			interrupts = <16 0>;
+			clocks = <&cctl ABOV32_CLOCK_PCLK>;
+			status = "disabled";
+		};
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <2>;
+};

--- a/dts/bindings/clock/abov,abov32-cctl.yaml
+++ b/dts/bindings/clock/abov,abov32-cctl.yaml
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+title: ABOV32 System Control Clock Unit (CCTL)
+
+description: |
+  ABOV 32-bit SoC System Control Unit (SCU) clock sub-system. Configures the
+  HSE/HSI/LSE/LSI oscillators, the PLL, and the MCLK/HCLK/PCLK dividers via
+  the ABOV HAL SCU_CLK API (hal_scu_clk.h).
+
+  To specify a clock in a peripheral node, use the standard clocks property
+  with one of the ABOV32_CLOCK_* identifiers from
+  include/zephyr/dt-bindings/clock/abov32-clock.h, e.g.:
+
+    uart0: uart@xxx {
+        ...
+        clocks = <&cctl ABOV32_CLOCK_PCLK>;
+        ...
+    };
+
+  The PLL output frequency is not derived from the divider fields, since
+  their register-level scaling is chip-specific; it must be supplied
+  directly via pll-output-frequency, computed from the datasheet by the
+  board integrator.
+
+compatible: "abov,abov32-cctl"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#clock-cells":
+    const: 1
+
+  hse-frequency:
+    type: int
+    description: HSE (high-speed external) crystal frequency in Hz. Enables HSE if present.
+
+  lse-frequency:
+    type: int
+    description: LSE (low-speed external) crystal frequency in Hz. Enables LSE if present.
+
+  hsi-frequency:
+    type: int
+    default: 8000000
+    description: HSI (high-speed internal) oscillator frequency in Hz. Fixed by the SoC.
+
+  lsi-frequency:
+    type: int
+    default: 0
+    description: |
+      LSI (low-speed internal) oscillator frequency in Hz. Must be set to
+      the value from the SoC datasheet before any LSI-derived clock is
+      used; the default of 0 is a placeholder, not a valid oscillator
+      frequency.
+
+  pll-source-hse:
+    type: boolean
+    description: Use HSE as the PLL input source. Defaults to HSI if not set.
+
+  pll-source-div:
+    type: int
+    default: 0
+    description: PLL input source divider, as a SCUCLK_DIV_e index (0 = /1, 1 = /2, 2 = /4, ...).
+
+  pll-pre-div:
+    type: int
+    default: 0
+    description: PLL input pre-divider register field (un8PreDiv).
+
+  pll-out-div:
+    type: int
+    default: 0
+    description: PLL feedback/output divider register field (un8OutDiv).
+
+  pll-post-div1:
+    type: int
+    default: 0
+    description: PLL post-divider 1 register field (un8PostDiv1).
+
+  pll-post-div2:
+    type: int
+    default: 0
+    description: PLL post-divider 2 register field (un8PostDiv2).
+
+  pll-vco2x:
+    type: boolean
+    description: Run the PLL VCO at twice the output frequency. Defaults to matching FOUT.
+
+  pll-output-frequency:
+    type: int
+    description: |
+      Resulting PLL output frequency in Hz, computed from the datasheet by
+      the board integrator. Presence of this property enables the PLL.
+
+  mclk-source:
+    type: int
+    default: 1
+    description: Main clock source, one of the ABOV32_CLOCK_* identifiers (default ABOV32_CLOCK_HSI).
+
+  mclk-pre-div:
+    type: int
+    default: 0
+    description: Main clock pre-divider, as a SCUCLK_DIV_e index.
+
+  mclk-post-div:
+    type: int
+    default: 0
+    description: Main clock post-divider (yields HCLK/FCLK), as a SCUCLK_DIV_e index.
+
+  pclk-div:
+    type: int
+    default: 0
+    description: Peripheral clock (PCLK) divider, as a SCUCLK_DIV_e index.
+
+clock-cells:
+  - id

--- a/dts/bindings/flash_controller/abov,abov32-flash-controller.yaml
+++ b/dts/bindings/flash_controller/abov,abov32-flash-controller.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: ABOV32 code flash memory controller (CFMC)
+
+compatible: "abov,abov32-flash-controller"
+
+include: flash-controller.yaml

--- a/dts/bindings/gpio/abov,abov32-gpio.yaml
+++ b/dts/bindings/gpio/abov,abov32-gpio.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ABOV32 Port Control Unit (PCU) GPIO port. Each PCU port (A..G) is exposed
+  as one gpio-controller node.
+
+compatible: "abov,abov32-gpio"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/dts/bindings/pinctrl/abov,abov32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/abov,abov32-pinctrl.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ABOV32 Port Control Unit (PCU) pin controller.
+
+  Pin state child nodes use the pinmux property, encoded with the
+  ABOV_PINMUX(port, pin, alt) macro from
+  include/zephyr/dt-bindings/pinctrl/abov32-pinctrl.h, e.g.:
+
+    uart0_default: uart0_default {
+        group1 {
+            pinmux = <ABOV_PINMUX(5, 0, 4)>, /* PF0 - UART0_TX (ALT4) */
+                     <ABOV_PINMUX(5, 1, 4)>; /* PF1 - UART0_RX (ALT4) */
+        };
+    };
+
+compatible: "abov,abov32-pinctrl"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+child-binding:
+  description: ABOV32 pin group configuration.
+
+  child-binding:
+    description: ABOV32 pin configuration.
+
+    include:
+      - name: pincfg-node.yaml
+        property-allowlist:
+          - bias-pull-up
+          - bias-pull-down
+          - drive-open-drain
+
+    properties:
+      pinmux:
+        required: true
+        type: array
+        description: |
+          Pin encoded with the ABOV_PINMUX(port, pin, alt) macro.

--- a/dts/bindings/serial/abov,abov32-usart.yaml
+++ b/dts/bindings/serial/abov,abov32-usart.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ABOV32 USART controller. The IP block supports asynchronous (UART),
+  synchronous, and SPI communication modes.
+
+compatible: "abov,abov32-usart"
+
+include: [uart-controller.yaml, pinctrl-device.yaml, base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clocks:
+    required: true

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -19,6 +19,7 @@
 aaeon	AAEON Technology Inc.
 abb	ABB
 abilis	Abilis Systems
+abov	ABOV Semiconductor Co., Ltd.
 abracon	Abracon Corporation
 abt	ShenZhen Asia Better Technology Ltd.
 acer	Acer Inc.

--- a/include/zephyr/dt-bindings/clock/abov32-clock.h
+++ b/include/zephyr/dt-bindings/clock/abov32-clock.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ABOV32_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ABOV32_CLOCK_H_
+
+/**
+ * @name ABOV32 SCU clock identifiers
+ *
+ * Used as the clock-cells value when referencing the SCU clock controller,
+ * e.g. `clocks = <&scu_clk ABOV32_CLOCK_PCLK>;`. Values match the ordering
+ * of SCUCLK_SRC_e in the ABOV HLL (type/scu_clk_type.h).
+ * @{
+ */
+#define ABOV32_CLOCK_HSE  0U
+#define ABOV32_CLOCK_HSI  1U
+#define ABOV32_CLOCK_LSI  2U
+#define ABOV32_CLOCK_LSE  3U
+#define ABOV32_CLOCK_PLL  4U
+#define ABOV32_CLOCK_MCLK 5U
+#define ABOV32_CLOCK_HCLK 6U
+#define ABOV32_CLOCK_PCLK 7U
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ABOV32_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/pinctrl/abov32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/abov32-pinctrl.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * ABOV Semiconductor SoC specific Devicetree pin control definitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ABOV32_PINCTRL_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ABOV32_PINCTRL_H_
+
+/**
+ * @name ABOV pinmux bitfield positions and masks
+ * @{
+ */
+
+/** Pin number position (bits 0..3: 0..15) */
+#define ABOV_PIN_POS     0U
+/** Pin number mask */
+#define ABOV_PIN_MSK     0xFU
+
+/** Port ID position (bits 4..7: 0=PA, 1=PB, 2=PC, etc.) */
+#define ABOV_PORT_POS    4U
+/** Port ID mask */
+#define ABOV_PORT_MSK    0xFU
+
+/** Alternate function position (bits 8..11: 0=GPIO/ALT0, 1=ALT1, etc.) */
+#define ABOV_ALT_POS     8U
+/** Alternate function mask */
+#define ABOV_ALT_MSK     0xFU
+
+/** @} */
+
+/**
+ * @brief Utility macro to encode port, pin, and alternate function for Devicetree.
+ *
+ * @param port Port number (0 = Port A, 1 = Port B, 2 = Port C, etc.).
+ * @param pin Pin number (0..15).
+ * @param alt Alternate function number (0..10).
+ */
+#define ABOV_PINMUX(port, pin, alt) \
+	(((port) << ABOV_PORT_POS) | ((pin) << ABOV_PIN_POS) | ((alt) << ABOV_ALT_POS))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_ABOV32_PINCTRL_H_ */

--- a/soc/abov/abov32/CMakeLists.txt
+++ b/soc/abov/abov32/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(${CONFIG_SOC_PRODUCT_LINE})
+add_subdirectory(common)

--- a/soc/abov/abov32/Kconfig
+++ b/soc/abov/abov32/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_FAMILY_ABOV32
+	bool
+
+if SOC_FAMILY_ABOV32
+
+config SOC_PRODUCT_LINE
+	string
+
+rsource "*/Kconfig"
+
+endif # SOC_FAMILY_ABOV32

--- a/soc/abov/abov32/Kconfig.defconfig
+++ b/soc/abov/abov32/Kconfig.defconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.defconfig"

--- a/soc/abov/abov32/Kconfig.soc
+++ b/soc/abov/abov32/Kconfig.soc
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_FAMILY_ABOV32
+	bool
+
+config SOC_FAMILY
+	default "abov32" if SOC_FAMILY_ABOV32
+
+rsource "*/Kconfig.soc"

--- a/soc/abov/abov32/a31xxxx/CMakeLists.txt
+++ b/soc/abov/abov32/a31xxxx/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(${CONFIG_SOC_SERIES})

--- a/soc/abov/abov32/a31xxxx/Kconfig
+++ b/soc/abov/abov32/a31xxxx/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# All A31xxxx series share the same Cortex-M0+ core, so the capability
+# selects live here once instead of being repeated in every series' Kconfig.
+config SOC_PRODUCT_LINE_A31XXXX
+	bool
+	select ARM
+	select CPU_CORTEX_M0PLUS
+	select CPU_CORTEX_M_HAS_VTOR
+	select CPU_CORTEX_M_HAS_SYSTICK
+	select SOC_EARLY_INIT_HOOK
+
+config SOC_PRODUCT_LINE
+	default "a31xxxx" if SOC_PRODUCT_LINE_A31XXXX
+
+orsource "*/Kconfig"

--- a/soc/abov/abov32/a31xxxx/Kconfig.defconfig
+++ b/soc/abov/abov32/a31xxxx/Kconfig.defconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.defconfig"

--- a/soc/abov/abov32/a31xxxx/Kconfig.soc
+++ b/soc/abov/abov32/a31xxxx/Kconfig.soc
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Common identity for every A31xxxx series (a31c15x, a31t51x, ...): they all
+# belong to the ABOV32 family. Series-specific Kconfig.soc files select this
+# instead of SOC_FAMILY_ABOV32 directly.
+config SOC_PRODUCT_LINE_A31XXXX
+	bool
+	select SOC_FAMILY_ABOV32
+
+rsource "*/Kconfig.soc"

--- a/soc/abov/abov32/a31xxxx/a31c15x/CMakeLists.txt
+++ b/soc/abov/abov32/a31xxxx/a31c15x/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources(soc.c)
+
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/abov/abov32/a31xxxx/a31c15x/Kconfig.defconfig
+++ b/soc/abov/abov32/a31xxxx/a31c15x/Kconfig.defconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# ABOV Semiconductor A31C15x MCU series
+
+if SOC_SERIES_A31C15X
+
+config NUM_IRQS
+	default 32
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+endif # SOC_SERIES_A31C15X

--- a/soc/abov/abov32/a31xxxx/a31c15x/Kconfig.soc
+++ b/soc/abov/abov32/a31xxxx/a31c15x/Kconfig.soc
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# ABOV Semiconductor A31C15x MCU series
+
+config SOC_SERIES_A31C15X
+	bool
+	select SOC_PRODUCT_LINE_A31XXXX
+
+config SOC_SERIES
+	default "a31c15x" if SOC_SERIES_A31C15X
+
+config SOC_A31C156
+	bool
+	select SOC_SERIES_A31C15X
+
+config SOC
+	default "a31c156" if SOC_A31C156

--- a/soc/abov/abov32/a31xxxx/a31c15x/soc.c
+++ b/soc/abov/abov32/a31xxxx/a31c15x/soc.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System/hardware module for A31C15x processor
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <cmsis_core.h>
+
+#include "abov_config.h"
+
+/**
+ * @brief Perform basic hardware initialization at boot.
+ *
+ * This needs to be run from the very beginning.
+ *
+ * Deliberately calls PRV_CHIPSET_Init() (WDT disable, SCU register-write
+ * enable, flash wait-state) instead of the vendor's SystemInit() from
+ * system_a31xxxx.c: that function also relocates VTOR to a vendor
+ * __VECTOR_TABLE that doesn't exist in a Zephyr build, since Zephyr owns the
+ * vector table and VTOR itself.
+ *
+ * PRV_PORT_Init() must run here too: it enables the per-port GPIO
+ * peripheral/bus-clock gates (SCU->PER1, SCU->PCER1) and unlocks PCU
+ * register writes (PORTEN). Without it, every PCU port (including the ones
+ * pinctrl configures for USART pin muxing) is unpowered/unclocked, so reads
+ * and writes to its MR1/MR2/CR registers are meaningless.
+ */
+void soc_early_init_hook(void)
+{
+	PRV_CHIPSET_Init();
+	PRV_PORT_Init();
+}

--- a/soc/abov/abov32/a31xxxx/a31c15x/soc.h
+++ b/soc/abov/abov32/a31xxxx/a31c15x/soc.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file SoC configuration macros for the A31C15X family processors.
+ *
+ * Based on reference manual:
+ *   advanced ARM(r)-based 32-bit MCUs
+ *
+ */
+
+
+#ifndef ZEPHYR_SOC_ABOV_ABOV32_A31XXXX_A31C15X_SOC_H_
+#define ZEPHYR_SOC_ABOV_ABOV32_A31XXXX_A31C15X_SOC_H_
+
+#ifndef _ASMLANGUAGE
+
+/* CMSIS device header from the ABOV HAL (modules/hal/abov32). It supplies
+ * __NVIC_PRIO_BITS, the IRQn_Type enum and the peripheral register structs.
+ * Its own core_cm0plus.h/system_a31xxxx.h includes are compiled out under
+ * Zephyr (see the __ZEPHYR__ guard in a31c15x.h) so they don't collide with
+ * the CMSIS core Zephyr already provides via modules/cmsis_6.
+ */
+#include "a31c15x.h"
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_SOC_ABOV_ABOV32_A31XXXX_A31C15X_SOC_H_ */

--- a/soc/abov/abov32/common/CMakeLists.txt
+++ b/soc/abov/abov32/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)

--- a/soc/abov/abov32/common/pinctrl_soc.h
+++ b/soc/abov/abov32/common/pinctrl_soc.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 ABOV Semiconductor Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * ABOV Semiconductor SoC specific helpers for pinctrl driver
+ */
+
+#ifndef ZEPHYR_SOC_ABOV_COMMON_PINCTRL_SOC_H_
+#define ZEPHYR_SOC_ABOV_COMMON_PINCTRL_SOC_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/types.h>
+#include <zephyr/dt-bindings/pinctrl/abov32-pinctrl.h>
+
+/* ABOV HLL PCU type definitions */
+#include <type/pcu_type.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Type for ABOV pin configuration bitfield.
+ *
+ * Bit allocation:
+ * - 0..3:   Pin number (0..15)
+ * - 4..7:   Port ID (0=PA, 1=PB, 2=PC, etc.)
+ * - 8..11:  Alternate function number (0..10)
+ * - 12..15: Reserved
+ * - 16..17: Pull-up/pull-down configuration (@ref ABOV_PUPD)
+ * - 18:     Output type configuration (@ref ABOV_OTYPE)
+ * - 19..31: Reserved
+ */
+typedef uint32_t pinctrl_soc_pin_t;
+
+/**
+ * @name ABOV pin configuration field bitfield mask and positions
+ * @{
+ */
+
+/** Pull-up/down field position */
+#define ABOV_PUPD_POS     16U
+/** Pull-up/down field mask */
+#define ABOV_PUPD_MSK     0x3U
+
+/** Output type field position */
+#define ABOV_OTYPE_POS    18U
+/** Output type field mask */
+#define ABOV_OTYPE_MSK    0x1U
+
+/** @} */
+
+/**
+ * @name ABOV Pull-up/pull-down values (mapped to PCU_PUPD_e in HLL)
+ * @anchor ABOV_PUPD
+ * @{
+ */
+
+/** Pull-up/pull-down disabled */
+#define ABOV_PUPD_NONE    0U
+/** Pull-up enabled */
+#define ABOV_PUPD_PULLUP  1U
+/** Pull-down enabled */
+#define ABOV_PUPD_PULLDN  2U
+
+/** @} */
+
+/**
+ * @name ABOV Output type values
+ * @anchor ABOV_OTYPE
+ * @{
+ */
+
+/** Push-pull output */
+#define ABOV_OTYPE_PP     0U
+/** Open-drain output */
+#define ABOV_OTYPE_OD     1U
+
+/** @} */
+
+/**
+ * @brief Utility macro to initialize each pin in pinctrl_soc_pin_t format.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name describing state pins.
+ * @param idx Property entry index.
+ */
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)			       \
+	(DT_PROP_BY_IDX(node_id, prop, idx) |				       \
+	 ((ABOV_PUPD_PULLUP * DT_PROP(node_id, bias_pull_up)) << ABOV_PUPD_POS) | \
+	 ((ABOV_PUPD_PULLDN * DT_PROP(node_id, bias_pull_down)) << ABOV_PUPD_POS) | \
+	 ((ABOV_OTYPE_OD * DT_PROP(node_id, drive_open_drain)) << ABOV_OTYPE_POS)),
+
+/**
+ * @brief Utility macro to initialize state pins contained in a given property.
+ *
+ * @param node_id Node identifier.
+ * @param prop Property name describing state pins.
+ */
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
+				DT_FOREACH_PROP_ELEM, pinmux,		       \
+				Z_PINCTRL_STATE_PIN_INIT)}
+
+/** @endcond */
+
+/**
+ * @brief Obtain Port ID field from pinctrl_soc_pin_t configuration.
+ *
+ * @param pin pinctrl_soc_pin_t bitfield value.
+ * @return Port ID as PCU_ID_e type.
+ */
+#define ABOV_PORT_GET(pin)  ((PCU_ID_e)(((pin) >> ABOV_PORT_POS) & ABOV_PORT_MSK))
+
+/**
+ * @brief Obtain Pin number field from pinctrl_soc_pin_t configuration.
+ *
+ * @param pin pinctrl_soc_pin_t bitfield value.
+ * @return Pin number as PCU_PIN_ID_e type.
+ */
+#define ABOV_PIN_GET(pin)   ((PCU_PIN_ID_e)(((pin) >> ABOV_PIN_POS) & ABOV_PIN_MSK))
+
+/**
+ * @brief Obtain Alternate Function field from pinctrl_soc_pin_t configuration.
+ *
+ * @param pin pinctrl_soc_pin_t bitfield value.
+ * @return Alternate Function as PCU_ALT_e type.
+ */
+#define ABOV_ALT_GET(pin)   ((PCU_ALT_e)(((pin) >> ABOV_ALT_POS) & ABOV_ALT_MSK))
+
+/**
+ * @brief Obtain Pull-up/down field from pinctrl_soc_pin_t configuration.
+ *
+ * @param pin pinctrl_soc_pin_t bitfield value.
+ * @return Pull configuration as PCU_PUPD_e type.
+ */
+#define ABOV_PUPD_GET(pin)  ((PCU_PUPD_e)(((pin) >> ABOV_PUPD_POS) & ABOV_PUPD_MSK))
+
+/**
+ * @brief Obtain Output Type field from pinctrl_soc_pin_t configuration.
+ *
+ * @param pin pinctrl_soc_pin_t bitfield value.
+ * @return 0 for Push-Pull, 1 for Open-Drain.
+ */
+#define ABOV_OTYPE_GET(pin) (((pin) >> ABOV_OTYPE_POS) & ABOV_OTYPE_MSK)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_ABOV_COMMON_PINCTRL_SOC_H_ */

--- a/soc/abov/abov32/soc.yml
+++ b/soc/abov/abov32/soc.yml
@@ -1,0 +1,6 @@
+family:
+  - name: abov32
+    series:
+      - name: a31c15x
+        socs:
+          - name: a31c156

--- a/west.yml
+++ b/west.yml
@@ -146,6 +146,12 @@ manifest:
       path: modules/fs/fatfs
       groups:
         - fs
+    - name: hal_abov
+      url: git@github.com:abovsemiconductor/zephyr_hal.git
+      revision: main
+      path: modules/hal/abov32
+      groups:
+        - hal
     - name: hal_adi
       revision: 1a5d9748b680adf0669739f37d05cb985f39b7b8
       path: modules/hal/adi


### PR DESCRIPTION
This series adds initial support for the ABOV ABOV32 SoC series
(starting with the A31C156) and the STK-A31C156-RLN-A starter kit board.

The A31C156 is being registered first as the foundation for ABOV chip
support in Zephyr, ahead of the A31T434 which will be required for an
upcoming Electrolux customer project.

Included in this series:
- dts: bindings: add ABOV vendor prefix
- drivers: pinctrl: add ABOV pinctrl driver
- drivers: clock_control: add ABOV clock control driver
- drivers: gpio: add ABOV GPIO driver
- drivers: serial: add ABOV UART driver
- soc: abov: add initial support for the ABOV32 series
- boards: abov: add ABOV STK-A31C156-RLN-A board

Testing performed on STK-A31C156-RLN-A:
- samples/hello_world built and run successfully
- samples/boards/abov/blink added and tested
- samples/boards/abov/button_interrupt (GPIO interrupt) added and tested