### PR TITLE
drivers: i2c: dw: fix target Rx/configure handling and add Agilex5 I2C nodes

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1142,6 +1142,7 @@ static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 
 	if (!test_bit_status_tfnt(reg_base)) { /* Tx FIFO must not be full */
+		LOG_ERR("Tx FIFO is full");
 		return;
 	}
 
@@ -1167,6 +1168,8 @@ static int i2c_dw_set_controller_mode(const struct device *dev)
 
 	write_tx_tl(ic_comp_param_1.bits.tx_buffer_depth + 1, reg_base);
 	write_rx_tl(ic_comp_param_1.bits.rx_buffer_depth + 1, reg_base);
+
+	LOG_DBG("I2C: Host registered as Master Device");
 
 	return 0;
 }

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1,4 +1,4 @@
-/* dw_i2c.c - I2C file for Design Ware */
+/* i2c_dw.c - I2C file for Design Ware */
 
 /*
  * Copyright (c) 2015 Intel Corporation

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -514,7 +514,7 @@ static inline void i2c_dw_transfer_complete(const struct device *dev)
 }
 
 #ifdef CONFIG_I2C_TARGET
-static inline uint8_t i2c_dw_read_byte_non_blocking(const struct device *dev);
+static inline int i2c_dw_read_byte_non_blocking(const struct device *dev, uint8_t *data);
 static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint8_t data);
 static void i2c_dw_target_read_clear_intr_bits(const struct device *dev,
 					       union ic_interrupt_register intr_stat);
@@ -528,8 +528,8 @@ static void i2c_dw_isr(const struct device *port)
 	int ret = 0;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(port);
 
-	/* Cache ic_intr_stat for processing, so there is no need to read
-	 * the register multiple times.
+	/* Cache I2C Interrupt Status Register(ic_intr_stat) for processing,
+	 * so there is no need to read the register multiple times.
 	 */
 	intr_stat.raw = read_intr_stat(reg_base);
 
@@ -631,7 +631,10 @@ static void i2c_dw_isr(const struct device *port)
 			}
 			/* FIFO needs to be drained here so we don't miss the next interrupt */
 			do {
-				data = i2c_dw_read_byte_non_blocking(port);
+				if (i2c_dw_read_byte_non_blocking(port, &data) != 0) {
+					break;
+				}
+
 				if (target_cb->write_received) {
 					target_cb->write_received(dw->target_cfg, data);
 				}
@@ -1118,15 +1121,18 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 }
 
 #ifdef CONFIG_I2C_TARGET
-static inline uint8_t i2c_dw_read_byte_non_blocking(const struct device *dev)
+static inline int i2c_dw_read_byte_non_blocking(const struct device *dev, uint8_t *data)
 {
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 
 	if (!test_bit_status_rfne(reg_base)) { /* Rx FIFO must not be empty */
+		LOG_ERR("Rx FIFO is empty");
 		return -EIO;
 	}
 
-	return (uint8_t)read_cmd_data(reg_base);
+	*data = (uint8_t)read_cmd_data(reg_base);
+
+	return 0;
 }
 
 static inline void i2c_dw_write_byte_non_blocking(const struct device *dev, uint8_t data)

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1044,11 +1044,9 @@ static int i2c_dw_configure(const struct device *dev, uint32_t config)
 	uint32_t rc = 0U;
 	mm_reg_t reg_base = DEVICE_MMIO_GET(dev);
 
-	dw->app_config = config;
-
 	/* Make sure we have a supported speed for the DesignWare model */
 	/* and have setup the clock frequency and speed mode */
-	switch (I2C_SPEED_GET(dw->app_config)) {
+	switch (I2C_SPEED_GET(config)) {
 	case I2C_SPEED_STANDARD:
 		lcnt_val = I2C_STD_LCNT + rom->lcnt_offset;
 		hcnt_val = I2C_STD_HCNT + rom->hcnt_offset;
@@ -1074,7 +1072,7 @@ static int i2c_dw_configure(const struct device *dev, uint32_t config)
 		rc = -EINVAL;
 	}
 
-	if (I2C_SPEED_GET(dw->app_config) == I2C_SPEED_HIGH) {
+	if (I2C_SPEED_GET(config) == I2C_SPEED_HIGH) {
 		/* Ensure minimum HCNT and LCNT register values for High Speed */
 		lcnt_val = I2C_ENSURE_MIN_SCL_LCNT(lcnt_val, rom->hs_spk_len);
 		hcnt_val = I2C_ENSURE_MIN_SCL_HCNT(hcnt_val, rom->hs_spk_len);
@@ -1087,6 +1085,10 @@ static int i2c_dw_configure(const struct device *dev, uint32_t config)
 	}
 	dw->lcnt = lcnt_val;
 	dw->hcnt = hcnt_val;
+
+	if (rc == 0) {
+		dw->app_config = config;
+	}
 
 	/*
 	 * Clear any interrupts currently waiting in the controller

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -1,4 +1,4 @@
-/* dw_i2c.h - header for Design Ware I2C operations */
+/* i2c_dw.h - header for Design Ware I2C operations */
 
 /*
  * Copyright (c) 2015 Intel Corporation

--- a/dts/arm64/intel/intel_socfpga_agilex5.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex5.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <arm64/armv8-a.dtsi>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/reset/intel_socfpga_reset.h>
 #include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
@@ -263,6 +264,71 @@
 		block-size = <0x20000>;
 		data-rate-mode = <0>;
 		status = "disabled";
+	};
+
+	i2c0: i2c@10c02800 {
+		compatible = "snps,designware-i2c";
+		reg = <0x10c02800 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 103 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		resets = <&reset RSTMGR_I2C0_RSTLINE>;
+	};
+
+	i2c1: i2c@10c02900 {
+		compatible = "snps,designware-i2c";
+		reg = <0x10c02900 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 104 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		resets = <&reset RSTMGR_I2C1_RSTLINE>;
+	};
+
+	i2c2: i2c@10c02a00 {
+		compatible = "snps,designware-i2c";
+		reg = <0x10c02a00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 105 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		resets = <&reset RSTMGR_I2C2_RSTLINE>;
+	};
+
+	i2c3: i2c@10c02b00 {
+		compatible = "snps,designware-i2c";
+		reg = <0x10c02b00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		resets = <&reset RSTMGR_I2C3_RSTLINE>;
+	};
+
+	i2c4: i2c@10c02c00 {
+		compatible = "snps,designware-i2c";
+		reg = <0x10c02c00 0x100>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 107 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+		clock-frequency = <I2C_BITRATE_STANDARD>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+		resets = <&reset RSTMGR_I2C4_RSTLINE>;
 	};
 
 	dma0: dma@10db0000 {


### PR DESCRIPTION
Fix DesignWare I2C target Rx FIFO handling and configure behavior, and add Agilex5 SoC DT nodes for the DW I2C controllers.

In target mode, an empty Rx FIFO could return a truncated error code as data to write_received. Return a proper error from the non-blocking read helper and only pass valid FIFO bytes to the callback. Also store app_config only after the requested speed is validated, so a failed configure leaves the previous settings in place. Add disabled i2c0–i2c4 snps,designware-i2c nodes to intel_socfpga_agilex5.dtsi, plus minor logging and file-comment cleanups.

- Verified on Intel SoC FPGA Agilex 5 hardware with DesignWare I2C controller.