### PR TITLE
samples: drivers: soc_flash_qspi: add Cadence QSPI flash validation

### DIFF
--- a/samples/drivers/soc_flash_qspi/CMakeLists.txt
+++ b/samples/drivers/soc_flash_qspi/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(cdns_qspi)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/soc_flash_qspi/boards/intel_socfpga_agilex5_socdk.overlay
+++ b/samples/drivers/soc_flash_qspi/boards/intel_socfpga_agilex5_socdk.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The overlay file should be used to enable any
+ * dts nodes required by this application for this
+ * board.
+ */
+
+/ {
+	aliases {
+		qspi = &qspi;
+	};
+};
+
+&qspi {
+	status = "okay";
+};

--- a/samples/drivers/soc_flash_qspi/boards/intel_socfpga_agilex_socdk.overlay
+++ b/samples/drivers/soc_flash_qspi/boards/intel_socfpga_agilex_socdk.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* The overlay file should be used to enable any
+ * dts nodes required by this application for this
+ * board.
+ */
+
+/ {
+	aliases {
+		qspi = &qspi;
+	};
+};
+
+&qspi {
+	status = "okay";
+};

--- a/samples/drivers/soc_flash_qspi/prj.conf
+++ b/samples/drivers/soc_flash_qspi/prj.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# Misc
+CONFIG_HEAP_MEM_POOL_SIZE=363840
+
+# Enable Flash
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y

--- a/samples/drivers/soc_flash_qspi/src/main.c
+++ b/samples/drivers/soc_flash_qspi/src/main.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023, Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <zephyr/sys/printk.h>
+
+#define OFFSET_PAGE    0x00
+#define QSPI_NUM_PAGES 10
+
+#define QSPI_DEV       DEVICE_DT_GET(DT_ALIAS(qspi));
+
+int main(void)
+{
+	const struct device *qspi_dev;
+	struct flash_pages_info page;
+	size_t flash_block_size;
+	size_t total_pages;
+	int ret;
+	uint8_t *w_page_buffer;
+	uint8_t *r_page_buffer;
+	uint8_t page_data = 0;
+	const struct flash_parameters *flash_cad_parameters;
+
+	printk("QSPI flash driver test sample\n");
+
+	qspi_dev = QSPI_DEV;
+
+	if (!device_is_ready(qspi_dev)) {
+		printk("QSPI flash driver is not ready\n");
+		return -ENODEV;
+	}
+
+	flash_cad_parameters = flash_get_parameters(qspi_dev);
+	printk("QSPI flash device block size = %lx\n", flash_cad_parameters->write_block_size);
+
+	total_pages = flash_get_page_count(qspi_dev);
+	printk("QSPI flash number of pages = %lx\n", total_pages);
+
+	flash_block_size = flash_get_write_block_size(qspi_dev);
+	printk("QSPI flash driver block size %lx\n", flash_block_size);
+
+	ret = flash_get_page_info_by_offs(qspi_dev, 0x00, &page);
+	if (ret < 0) {
+		printk("QSPI flash driver page info error\n");
+		return ret;
+	}
+	printk("The Page size of %lx\n", page.size);
+
+	w_page_buffer = (uint8_t *)k_malloc(page.size * QSPI_NUM_PAGES);
+
+	if (w_page_buffer != NULL) {
+		for (int index = 0; index < page.size * QSPI_NUM_PAGES; index++) {
+			w_page_buffer[index] = (page_data++ % 255);
+		}
+	} else {
+		printk("Write memory not allocated\n");
+		return -ENOSR;
+	}
+
+	r_page_buffer = (uint8_t *)k_malloc(page.size * QSPI_NUM_PAGES);
+	if (r_page_buffer != NULL) {
+		memset(r_page_buffer, 0x55, page.size * QSPI_NUM_PAGES);
+	} else {
+		printk("Read memory not allocated\n");
+		k_free(w_page_buffer);
+		return -ENOSR;
+	}
+
+	ret = flash_erase(qspi_dev, OFFSET_PAGE, flash_block_size);
+	if (ret < 0) {
+		printk("QSPI flash driver read Error\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver data erase successful....\n");
+
+	ret = flash_write(qspi_dev, OFFSET_PAGE, w_page_buffer, page.size * QSPI_NUM_PAGES);
+	if (ret < 0) {
+		printk("QSPI flash driver write error\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver write completed....\n");
+
+	ret = flash_read(qspi_dev, OFFSET_PAGE, r_page_buffer, page.size * QSPI_NUM_PAGES);
+	if (ret < 0) {
+		printk("QSPI flash driver read error\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver read completed....\n");
+
+	ret = memcmp(w_page_buffer, r_page_buffer, page.size * QSPI_NUM_PAGES);
+
+	if (ret != 0) {
+		printk("QSPI flash driver read not match\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver read verified\n");
+
+	ret = flash_erase(qspi_dev, OFFSET_PAGE, flash_block_size);
+
+	if (ret < 0) {
+		printk("QSPI flash driver read Error\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver data erase successful....\n");
+
+	ret = flash_read(qspi_dev, OFFSET_PAGE, r_page_buffer, page.size * QSPI_NUM_PAGES);
+	if (ret != 0) {
+		printk("QSPI flash driver read error\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	memset(w_page_buffer, 0xFF, page.size * QSPI_NUM_PAGES);
+
+	ret = memcmp(w_page_buffer, r_page_buffer, page.size * QSPI_NUM_PAGES);
+
+	if (ret != 0) {
+		printk("QSPI flash driver read not match\n");
+		k_free(w_page_buffer);
+		k_free(r_page_buffer);
+		return ret;
+	}
+	printk("QSPI flash driver read verified after erase....\n");
+	printk("QSPI flash driver test sample completed....\n");
+
+	return 0;
+}

--- a/samples/drivers/soc_flash_qspi/tests.yaml
+++ b/samples/drivers/soc_flash_qspi/tests.yaml
@@ -1,0 +1,30 @@
+sample:
+  description: Cadence QSPI Driver sample application.
+  name: cdns_qspi_nor
+tests:
+  sample.drivers.flash.soc_flash_qspi:
+    platform_allow:
+      - intel_socfpga_agilex5_socdk
+    integration_platforms:
+      - intel_socfpga_agilex5_socdk
+    tags:
+      - flash
+      - cdns
+    harness: console
+    harness_config:
+      fixture: external_flash
+      type: multi_line
+      ordered: true
+      regex:
+        - "QSPI flash driver test sample"
+        - "QSPI flash device block size = 100"
+        - "QSPI flash number of pages = 100000"
+        - "QSPI flash driver block size 100"
+        - "The Page size of 100"
+        - "QSPI flash driver data erase successful...."
+        - "QSPI flash driver write completed...."
+        - "QSPI flash driver read completed...."
+        - "QSPI flash driver read verified"
+        - "QSPI flash driver data erase successful...."
+        - "QSPI flash driver read verified after erase...."
+        - "QSPI flash driver test sample completed...."


### PR DESCRIPTION
Add a sample that validates Cadence QSPI NOR flash through the Zephyr flash API.

The sample erases, writes, reads, and verifies patterned data across multiple pages, then erases again and confirms the cleared contents. Board overlays enable the QSPI alias on Agilex / Agilex 5 SoCDK, and `tests.yaml` covers console-harness checks for `intel_socfpga_agilex5_socdk`.

- Verified on Intel SoC FPGA Agilex 5 SoCDK with Cadence QSPI NOR erase/write/read.