### PR TITLE
hal: infineon: fix for custom wifi FW on airoc devices

### DIFF
--- a/modules/hal_infineon/whd-expansion/CMakeLists.txt
+++ b/modules/hal_infineon/whd-expansion/CMakeLists.txt
@@ -327,29 +327,38 @@ if(CONFIG_CYW955573M2IPA1_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55572/COMPONENT_CYW955573M2IPA1/cyw955573m2ipa1_rev1.01.txt)
 endif()
 
-# set fw size
-file(SIZE ${FW_IMAGE_NAME} FW_IMAGE_SIZE)
-zephyr_compile_definitions(FW_IMAGE_NAME="${FW_IMAGE_NAME}")
-zephyr_compile_definitions(FW_IMAGE_SIZE=${FW_IMAGE_SIZE})
+############################################################################################################
+## Generate include file for fw/clm/nvram
+############################################################################################################
 
-# set clm size
-file(SIZE ${CLM_IMAGE_NAME} CLM_IMAGE_SIZE)
-zephyr_compile_definitions(CLM_IMAGE_NAME="${CLM_IMAGE_NAME}")
-zephyr_compile_definitions(CLM_IMAGE_SIZE=${CLM_IMAGE_SIZE})
+if(CONFIG_AIROC_WIFI_CUSTOM)
+  zephyr_compile_definitions(RESOURCE_READ_FROM_C_FILE)
+else()
+  # set fw size
+  file(SIZE ${FW_IMAGE_NAME} FW_IMAGE_SIZE)
+  zephyr_compile_definitions(FW_IMAGE_NAME="${FW_IMAGE_NAME}")
+  zephyr_compile_definitions(FW_IMAGE_SIZE=${FW_IMAGE_SIZE})
+  zephyr_compile_definitions(FW_IMAGE_NAME="${FW_IMAGE_NAME}")
 
-# set nvram size
-file(SIZE ${NVRAM_IMAGE_NAME} NVRAM_IMAGE_SIZE)
-zephyr_compile_definitions(NVRAM_IMAGE_NAME="${NVRAM_IMAGE_NAME}")
-zephyr_compile_definitions(NVRAM_IMAGE_SIZE=${NVRAM_IMAGE_SIZE})
+  # set clm size
+  file(SIZE ${CLM_IMAGE_NAME} CLM_IMAGE_SIZE)
+  zephyr_compile_definitions(CLM_IMAGE_NAME="${CLM_IMAGE_NAME}")
+  zephyr_compile_definitions(CLM_IMAGE_SIZE=${CLM_IMAGE_SIZE})
 
-# generate FW inc_blob from fw_bin
-if(EXISTS ${airoc_wifi_fw_bin})
-  message(INFO " generate include of blob FW file: ${airoc_wifi_fw_bin}")
-  generate_inc_file_for_target(app ${airoc_wifi_fw_bin} ${airoc_wifi_fw_bin_gen_inc})
-endif()
+  # set nvram size
+  file(SIZE ${NVRAM_IMAGE_NAME} NVRAM_IMAGE_SIZE)
+  zephyr_compile_definitions(NVRAM_IMAGE_NAME="${NVRAM_IMAGE_NAME}")
+  zephyr_compile_definitions(NVRAM_IMAGE_SIZE=${NVRAM_IMAGE_SIZE})
 
-# generate CLM inc_blob from clm_bin
-if(EXISTS ${airoc_wifi_clm_bin})
-  message(INFO " generate include of blob CLM file: ${airoc_wifi_clm_bin}")
-  generate_inc_file_for_target(app ${airoc_wifi_clm_bin} ${airoc_wifi_clm_bin_gen_inc})
+  # generate FW inc_blob from fw_bin
+  if(EXISTS ${airoc_wifi_fw_bin})
+    message(INFO " generate include of blob FW file: ${airoc_wifi_fw_bin}")
+    generate_inc_file_for_target(app ${airoc_wifi_fw_bin} ${airoc_wifi_fw_bin_gen_inc})
+  endif()
+
+  # generate CLM inc_blob from clm_bin
+  if(EXISTS ${airoc_wifi_clm_bin})
+    message(INFO " generate include of blob CLM file: ${airoc_wifi_clm_bin}")
+    generate_inc_file_for_target(app ${airoc_wifi_clm_bin} ${airoc_wifi_clm_bin_gen_inc})
+  endif()
 endif()


### PR DESCRIPTION
Recent updates of Infineon HAL broke the build when CONFIG_AIROC_WIFI_CUSTOM is set
This PR restore the possibility to build the module with CONFIG_AIROC_WIFI_CUSTOM defined
The problem can be reproduced issuing the following build:
`west build -p always -b arduino_giga_r1//m7 samples/net/wifi/shell/  -- -DCONFIG_AIROC_WIFI_CUSTOM=y`
The problem is due to the fact that when CONFIG_AIROC_WIFI_CUSTOM is set some of the variables are not 
defined but used at the end of the file.
Here is a log of the errors:
```
CMake Error at /home/daniele/arduino-zephyr/zephyr/modules/hal_infineon/whd-expansion/CMakeLists.txt:331 (file):
  file SIZE requires a file name and output variable


CMake Error at /home/daniele/arduino-zephyr/zephyr/modules/hal_infineon/whd-expansion/CMakeLists.txt:336 (file):
  file SIZE requires a file name and output variable


CMake Error at /home/daniele/arduino-zephyr/zephyr/modules/hal_infineon/whd-expansion/CMakeLists.txt:341 (file):
  file SIZE requires a file name and output variable


-- Found gen_kobject_list: /home/daniele/arduino-zephyr/zephyr/scripts/build/gen_kobject_list.py
-- Configuring incomplete, errors occurred!
FATAL ERROR: command exited with status 1: /usr/bin/cmake -DWEST_PYTHON=/home/daniele/arduino-zephyr/ArduinoCore-zephyr/venv/bin/python3 -DWEST_TOPDIR=/home/daniele/arduino-zephyr -DWEST_VERSION=1.5.0 -B/home/daniele/arduino-zephyr/zephyr/build -GNinja '-DWEST_PYTHON_PROPERTIES="Python;3;12;3;64;;cpython-312-x86_64-linux-gnu.so;abi3;/usr/lib/python3.12;/home/daniele/arduino-zephyr/ArduinoCore-zephyr/venv/lib/python3.12;/home/daniele/arduino-zephyr/ArduinoCore-zephyr/venv/lib/python3.12/site-packages;/home/daniele/arduino-zephyr/ArduinoCore-zephyr/venv/lib/python3.12/site-packages"' -DBOARD=arduino_giga_r1//m7 -DCONFIG_AIROC_WIFI_CUSTOM=y -S/home/daniele/arduino-zephyr/zephyr/samples/net/wifi/shell
```

@pillo79