### PR TITLE
drivers: usb: uhc_dwc2: size the FIFOs for high-speed packets

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -62,6 +62,7 @@ enum uhc_dwc2_channel_event {
 };
 
 #define EPSIZE_BULK_FS			64U
+#define EPSIZE_BULK_HS			512U
 
 /* Mask to clear HPRT register */
 #define USB_DWC2_HPRT_W1C_MSK		(USB_DWC2_HPRT_PRTENA |			\
@@ -485,8 +486,10 @@ static int dwc2_set_fifo_sizes(struct usb_dwc2_reg *const base)
 {
 	const uint32_t ghwcfg2 = sys_read32((mem_addr_t)&base->ghwcfg2);
 	const uint32_t ghwcfg3 = sys_read32((mem_addr_t)&base->ghwcfg3);
-	/* TODO: Check the FIFO setting on hardware, that supports HS */
-	const uint32_t nptx_largest = EPSIZE_BULK_FS / 4;
+	/* The non-periodic TX FIFO has to hold a whole bulk packet */
+	const bool hs_phy = usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2) !=
+			    USB_DWC2_GHWCFG2_HSPHYTYPE_NO_HS;
+	const uint32_t nptx_largest = (hs_phy ? EPSIZE_BULK_HS : EPSIZE_BULK_FS) / 4;
 	const uint32_t ptx_largest = 256 / 4;
 	const uint32_t dfifodepth = FIELD_GET(USB_DWC2_GHWCFG3_DFIFODEPTH_MASK, ghwcfg3);
 	const uint32_t numhstchnl = FIELD_GET(USB_DWC2_GHWCFG2_NUMHSTCHNL_MASK, ghwcfg2);

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -490,7 +490,8 @@ static int dwc2_set_fifo_sizes(struct usb_dwc2_reg *const base)
 	const bool hs_phy = usb_dwc2_get_ghwcfg2_hsphytype(ghwcfg2) !=
 			    USB_DWC2_GHWCFG2_HSPHYTYPE_NO_HS;
 	const uint32_t nptx_largest = (hs_phy ? EPSIZE_BULK_HS : EPSIZE_BULK_FS) / 4;
-	const uint32_t ptx_largest = 256 / 4;
+	/* Sizes the RX FIFO, which is shared by every endpoint */
+	const uint32_t ptx_largest = (hs_phy ? EPSIZE_BULK_HS : 256U) / 4;
 	const uint32_t dfifodepth = FIELD_GET(USB_DWC2_GHWCFG3_DFIFODEPTH_MASK, ghwcfg3);
 	const uint32_t numhstchnl = FIELD_GET(USB_DWC2_GHWCFG2_NUMHSTCHNL_MASK, ghwcfg2);
 	uint32_t fifo_available = dfifodepth - (numhstchnl + 1);


### PR DESCRIPTION
Two FIFO sizing fixes needed to move bulk data to and from a high-speed device on the DWC2 host controller, measured on an STM32N6570-DK. Both only take effect when the controller reports a high-speed PHY, so full-speed-only users are unaffected.

- **Non-periodic TX FIFO**: sized from the full-speed bulk endpoint, so it holds 128 bytes. A high-speed bulk packet is 512 and does not fit, and an OUT transfer larger than the FIFO is never started: no channel interrupt arrives and it sits queued forever. Writes up to 128 bytes completed while an 894 byte one hung; both complete now.

- **Receive FIFO**: shared by every endpoint and sized from a 256 byte packet, too small to absorb back-to-back high-speed bulk packets. Under a sustained IN stream it overruns and the controller reports transaction errors the driver cannot recover from, so the byte stream loses data. Streaming video from a phone went from around twenty transaction errors in five seconds to none.