### PR TITLE
mgmt: mcumgr: img_mgmt_client: support SHA-512 image digests

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -2150,6 +2150,17 @@ MCUmgr
   :ref:`mcumgr_os_application_info` command now always reports the board target as hardware
   platform; the pre-4.3 board and board revision output is no longer available.
 
+* The image management client (:kconfig:option:`CONFIG_MCUMGR_GRP_IMG_CLIENT`)
+  now supports SHA-512 image digests in addition to SHA-256:
+
+  * :c:func:`img_mgmt_client_state_write` takes a new ``hash_len`` argument.
+    When ``hash`` is not ``NULL``, pass its length in bytes (for example, ``32``
+    for SHA-256). Otherwise, pass ``0``.
+  * :c:struct:`mcumgr_image_data` now stores a variable-length digest: the
+    ``hash`` buffer is :c:macro:`IMG_MGMT_CLIENT_HASH_MAX_LEN` (64) bytes, and
+    the new ``hash_len`` field holds the actual length. Code that reads ``hash``
+    must use ``hash_len`` instead of assuming :c:macro:`IMG_MGMT_DATA_SHA_LEN`.
+
 POSIX
 =====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -1851,6 +1851,14 @@ Libraries / Subsystems
     the Semtech LoRaMac-node dependency.  Currently supports the EU868 region.
   * :c:member:`lora_modem_config.sync_word`
 
+* Management
+
+  * MCUmgr
+
+    * The image management client now supports SHA-512 image digests. It can
+      list and select images for testing or confirmation on targets built with
+      :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_USES_SHA512`.
+
 * Video
 
   * Introducing a video subsystem that inherits all the function names previously in

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
@@ -30,6 +30,17 @@ extern "C" {
 #endif
 
 /**
+ * @brief Maximum supported image digest length.
+ *
+ * An image list response can contain a SHA-256 (32-byte) or SHA-512 (64-byte)
+ * digest, depending on the target's MCUboot configuration.
+ *
+ * @note Unlike IMG_MGMT_DATA_SHA_LEN, this value does not specify the fixed
+ * SHA-256 digest length used for image uploads.
+ */
+#define IMG_MGMT_CLIENT_HASH_MAX_LEN 64
+
+/**
  * @brief Image list flags.
  */
 struct mcumgr_image_list_flags {
@@ -53,8 +64,10 @@ struct mcumgr_image_data {
 	uint32_t slot_num;
 	/** Image number */
 	uint32_t img_num;
-	/** Image SHA256 checksum */
-	char hash[IMG_MGMT_DATA_SHA_LEN];
+	/** Image digest (SHA-256 or SHA-512). */
+	char hash[IMG_MGMT_CLIENT_HASH_MAX_LEN];
+	/** Length of the digest in bytes. */
+	size_t hash_len;
 	/** Image Version */
 	char version[IMG_MGMT_VER_MAX_STR_LEN + 1];
 	/** Image Flags */
@@ -163,19 +176,38 @@ int img_mgmt_client_upload(struct img_mgmt_client *client, const uint8_t *data, 
 			   struct mcumgr_image_upload *res_buf);
 
 /**
- * @brief Write image state.
+ * @brief Write the state of an image.
  *
- * @param client	IMG mgmt client object
- * @param hash		Pointer to Hash (Needed for test).
- * @param confirm	Set false for test and true for confirmation.
- * @param res_buf	Pointer for command response structure.
+ * Sends an image state write request to the target. The image is selected by its
+ * digest, which must match the @c hash reported by @ref img_mgmt_client_state_read.
+ * The digest can use SHA-256 or SHA-512, depending on the target configuration.
  *
- * @return 0 on success.
- * @return @ref mcumgr_err_t code on failure.
+ * The requested operation depends on @p hash and @p confirm:
+ *
+ * - If @p hash is not @c NULL and @p confirm is false, the selected image is marked
+ *   for test. Depending on the MCUboot mode, the image is swapped in or selected on
+ *   the next boot and can be reverted unless it is later confirmed.
+ * - If @p hash is not @c NULL and @p confirm is true, the selected image is requested
+ *   for confirmation. The target can reject confirmation of a non-active image.
+ * - If @p hash is @c NULL and @p confirm is true, the currently active image is
+ *   confirmed.
+ * - If @p hash is @c NULL and @p confirm is false, the request is invalid.
+ *
+ * @param client	IMG mgmt client object.
+ * @param hash		Image digest used to select the target image. Set to @c NULL
+ *			to select the currently active image. This is valid only when
+ *			@p confirm is true.
+ * @param hash_len	Length of @p hash in bytes: 32 for SHA-256 or 64 for SHA-512.
+ *			Set to 0 when @p hash is @c NULL.
+ * @param confirm	Set to false to test the image or true to confirm it.
+ * @param res_buf	Command response structure. The image state returned by the target
+ *			is stored here when the request succeeds.
+ *
+ * @retval 0 The request completed successfully.
+ * @return A @ref mcumgr_err_t error code on failure.
  */
-
-int img_mgmt_client_state_write(struct img_mgmt_client *client, char *hash, bool confirm,
-				struct mcumgr_image_state *res_buf);
+int img_mgmt_client_state_write(struct img_mgmt_client *client, const char *hash, size_t hash_len,
+				bool confirm, struct mcumgr_image_state *res_buf);
 
 /**
  * @brief Read image state.

--- a/subsys/mgmt/mcumgr/grp/img_mgmt_client/src/img_mgmt_client.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt_client/src/img_mgmt_client.c
@@ -44,6 +44,11 @@ static K_MUTEX_DEFINE(mcumgr_img_client_grp_mutex);
 static const char smp_images_str[] = "images";
 #define IMAGES_STR_LEN (sizeof(smp_images_str) - 1)
 
+static bool image_digest_len_valid(size_t hash_len)
+{
+	return hash_len == IMG_MGMT_DATA_SHA_LEN || hash_len == IMG_MGMT_CLIENT_HASH_MAX_LEN;
+}
+
 static int image_state_res_fn(struct net_buf *nb, void *user_data)
 {
 	zcbor_state_t zsd[CONFIG_MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS + 2];
@@ -126,7 +131,7 @@ static int image_state_res_fn(struct net_buf *nb, void *user_data)
 			goto out;
 		}
 		/* Check that mandatory parameters have decoded */
-		if (hash.len != IMG_MGMT_DATA_SHA_LEN || !version.len ||
+		if (!image_digest_len_valid(hash.len) || !version.len ||
 		    !zcbor_map_decode_bulk_key_found(list_res_decode, ARRAY_SIZE(list_res_decode),
 						     "slot")) {
 			LOG_ERR("Missing mandatory parameters");
@@ -138,7 +143,8 @@ static int image_state_res_fn(struct net_buf *nb, void *user_data)
 			image_info->image_list[image_info->image_list_length].img_num = img_num;
 			image_info->image_list[image_info->image_list_length].slot_num = slot_num;
 			memcpy(image_info->image_list[image_info->image_list_length].hash,
-			       hash.value, IMG_MGMT_DATA_SHA_LEN);
+			       hash.value, hash.len);
+			image_info->image_list[image_info->image_list_length].hash_len = hash.len;
 			if (version.len > IMG_MGMT_VER_MAX_STR_LEN) {
 				LOG_WRN("Version truncated len %d -> %d", version.len,
 					IMG_MGMT_VER_MAX_STR_LEN);
@@ -449,14 +455,19 @@ end:
 	return rc;
 }
 
-int img_mgmt_client_state_write(struct img_mgmt_client *client, char *hash, bool confirm,
-				struct mcumgr_image_state *res_buf)
+int img_mgmt_client_state_write(struct img_mgmt_client *client, const char *hash, size_t hash_len,
+				bool confirm, struct mcumgr_image_state *res_buf)
 {
 	struct net_buf *nb;
 	int rc;
 	uint32_t map_count;
 	zcbor_state_t zse[CONFIG_MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS];
 	bool ok;
+
+	if ((hash == NULL && hash_len != 0) ||
+	    (hash != NULL && !image_digest_len_valid(hash_len))) {
+		return MGMT_ERR_EINVAL;
+	}
 
 	k_mutex_lock(&mcumgr_img_client_grp_mutex, K_FOREVER);
 	active_client = client;
@@ -484,8 +495,7 @@ int img_mgmt_client_state_write(struct img_mgmt_client *client, char *hash, bool
 	     zcbor_bool_put(zse, confirm);
 	/* Write hash data */
 	if (ok && hash) {
-		ok = zcbor_tstr_put_lit(zse, "hash") &&
-		     zcbor_bstr_encode_ptr(zse, hash, IMG_MGMT_DATA_SHA_LEN);
+		ok = zcbor_tstr_put_lit(zse, "hash") && zcbor_bstr_encode_ptr(zse, hash, hash_len);
 	}
 	/* Close map */
 	if (ok) {

--- a/tests/subsys/mgmt/mcumgr/mcumgr_client/src/img_gr_stub.c
+++ b/tests/subsys/mgmt/mcumgr/mcumgr_client/src/img_gr_stub.c
@@ -95,7 +95,7 @@ void img_fail_response(int status)
 	}
 }
 
-void img_read_response(int count)
+void img_read_response(int count, size_t hash_len)
 {
 	struct net_buf *nb;
 	zcbor_state_t zse[CONFIG_MCUMGR_SMP_CBOR_MAX_DECODING_LEVELS + 2];
@@ -113,6 +113,7 @@ void img_read_response(int count)
 	     zcbor_list_start_encode(zse, 2);
 
 	for (int i = 0; ok && i < count; i++) {
+		image_dummy_info[i].hash_len = hash_len;
 
 		ok = zcbor_map_start_encode(zse, 15) &&
 		     ((zcbor_tstr_put_lit(zse, "image") &&
@@ -121,10 +122,10 @@ void img_read_response(int count)
 		     zcbor_uint32_put(zse, image_dummy_info[i].slot_num) &&
 		     zcbor_tstr_put_lit(zse, "version") &&
 		     zcbor_tstr_put_term(zse, image_dummy_info[i].version,
-					sizeof(image_dummy_info[i].version)) &&
+					 sizeof(image_dummy_info[i].version)) &&
 
 		     zcbor_tstr_put_lit(zse, "hash") &&
-		     zcbor_bstr_encode_ptr(zse, image_dummy_info[i].hash, IMG_MGMT_DATA_SHA_LEN) &&
+		     zcbor_bstr_encode_ptr(zse, image_dummy_info[i].hash, hash_len) &&
 		     ZCBOR_ENCODE_FLAG(zse, "bootable", image_dummy_info[i].flags.bootable) &&
 		     ZCBOR_ENCODE_FLAG(zse, "pending", image_dummy_info[i].flags.pending) &&
 		     ZCBOR_ENCODE_FLAG(zse, "confirmed", image_dummy_info[i].flags.confirmed) &&
@@ -197,7 +198,9 @@ void img_state_write_verify(struct net_buf *nb)
 	}
 	if (hash.len) {
 		printf("HASH %d", hash.len);
-		if (memcmp(hash.value, image_dummy_info[1].hash, 32) == 0) {
+		if (hash.len <= sizeof(image_dummy_info[1].hash) &&
+		    hash.len == image_dummy_info[1].hash_len &&
+		    memcmp(hash.value, image_dummy_info[1].hash, hash.len) == 0) {
 			if (confirm) {
 				/* Set Permanent bit */
 				image_dummy_info[1].flags.permanent = true;
@@ -205,7 +208,7 @@ void img_state_write_verify(struct net_buf *nb)
 				/* Set pending */
 				image_dummy_info[1].flags.pending = true;
 			}
-			img_read_response(2);
+			img_read_response(2, image_dummy_info[1].hash_len);
 		} else {
 			img_fail_response(MGMT_ERR_EINVAL);
 		}
@@ -213,7 +216,7 @@ void img_state_write_verify(struct net_buf *nb)
 		if (confirm) {
 			image_dummy_info[0].flags.confirmed = true;
 		}
-		img_read_response(2);
+		img_read_response(2, image_dummy_info[0].hash_len);
 	}
 }
 
@@ -281,8 +284,10 @@ void img_upload_init_verify(struct net_buf *nb)
 void img_gr_stub_data_init(uint8_t *hash_ptr)
 {
 	image_hash_ptr = hash_ptr;
-	for (int i = 0; i < 32; i++) {
+	for (int i = 0; i < IMG_MGMT_DATA_SHA_LEN; i++) {
 		image_hash_ptr[i] = i;
+	}
+	for (int i = 0; i < IMG_MGMT_CLIENT_HASH_MAX_LEN; i++) {
 		image_dummy_info[0].hash[i] = i + 32;
 		image_dummy_info[1].hash[i] = i + 64;
 	}
@@ -290,6 +295,7 @@ void img_gr_stub_data_init(uint8_t *hash_ptr)
 	for (int i = 0; i < 2; i++) {
 		image_dummy_info[i].img_num = i;
 		image_dummy_info[i].slot_num = i;
+		image_dummy_info[i].hash_len = IMG_MGMT_DATA_SHA_LEN;
 		/* Write version */
 		snprintf(image_dummy_info[i].version, IMG_MGMT_VER_MAX_STR_LEN, "1.1.%u", i);
 		image_dummy_info[i].version[sizeof(image_dummy_info[i].version) - 1] = '\0';

--- a/tests/subsys/mgmt/mcumgr/mcumgr_client/src/img_gr_stub.h
+++ b/tests/subsys/mgmt/mcumgr/mcumgr_client/src/img_gr_stub.h
@@ -21,7 +21,7 @@ extern "C" {
 void img_upload_stub_init(void);
 void img_upload_response(size_t offset, int status);
 void img_fail_response(int status);
-void img_read_response(int count);
+void img_read_response(int count, size_t hash_len);
 void img_erase_response(int status);
 void img_upload_init_verify(struct net_buf *nb);
 void img_state_write_verify(struct net_buf *nb);

--- a/tests/subsys/mgmt/mcumgr/mcumgr_client/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/mcumgr_client/src/main.c
@@ -141,35 +141,42 @@ ZTEST(mcumgr_client, test_image_state_read)
 	zassert_equal(MGMT_ERR_ETIMEOUT, rc, "Expected to receive %d response %d",
 		      MGMT_ERR_ETIMEOUT, rc);
 	/* Testing read successfully 1 image info and print that */
-	img_read_response(1);
+	img_read_response(1, IMG_MGMT_DATA_SHA_LEN);
 	rc = img_mgmt_client_state_read(&img_client, &res_buf);
 	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
 	zassert_equal(1, res_buf.image_list_length, "Expected to receive %d response %d", 1,
 		      res_buf.image_list_length);
-	img_read_response(2);
+	img_read_response(2, IMG_MGMT_DATA_SHA_LEN);
 	rc = img_mgmt_client_state_read(&img_client, &res_buf);
 	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
 	zassert_equal(2, res_buf.image_list_length, "Expected to receive %d response %d", 2,
 		      res_buf.image_list_length);
+	zassert_equal(IMG_MGMT_DATA_SHA_LEN, image_info[1].hash_len);
+
+	/* Test a SHA-512 image state response */
+	img_read_response(2, IMG_MGMT_CLIENT_HASH_MAX_LEN);
+	rc = img_mgmt_client_state_read(&img_client, &res_buf);
+	zassert_equal(MGMT_ERR_EOK, rc);
+	zassert_equal(IMG_MGMT_CLIENT_HASH_MAX_LEN, image_info[1].hash_len);
 }
 
 ZTEST(mcumgr_client, test_image_state_set)
 {
 	int rc;
-	char hash[32];
+	char hash[IMG_MGMT_CLIENT_HASH_MAX_LEN];
 	struct mcumgr_image_state res_buf;
 
 	smp_client_response_buf_clean();
 	smp_stub_set_rx_data_verify(NULL);
 	smp_client_send_status_stub(MGMT_ERR_EOK);
 	/* Test timeout */
-	rc = img_mgmt_client_state_write(&img_client, NULL, false, &res_buf);
+	rc = img_mgmt_client_state_write(&img_client, NULL, 0, false, &res_buf);
 	zassert_equal(MGMT_ERR_ETIMEOUT, rc, "Expected to receive %d response %d",
 		      MGMT_ERR_ETIMEOUT, rc);
 
 	printf("Timeout OK\r\n");
 	/* Read secondary image hash for testing */
-	img_read_response(2);
+	img_read_response(2, IMG_MGMT_DATA_SHA_LEN);
 	rc = img_mgmt_client_state_read(&img_client, &res_buf);
 	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
 	zassert_equal(2, res_buf.image_list_length, "Expected to receive %d response %d", 2,
@@ -177,21 +184,34 @@ ZTEST(mcumgr_client, test_image_state_set)
 	zassert_equal(false, image_info[1].flags.pending, "Expected to receive %d response %d",
 		      false, image_info[1].flags.pending);
 	/* Copy hash for set pending flag */
-	memcpy(hash, image_info[1].hash, 32);
+	memcpy(hash, image_info[1].hash, image_info[1].hash_len);
 	printf("Read OK\r\n");
 
 	/* Read secondary image hash for testing */
 	smp_stub_set_rx_data_verify(img_state_write_verify);
-	rc = img_mgmt_client_state_write(&img_client, hash, false, &res_buf);
+	rc = img_mgmt_client_state_write(&img_client, hash, image_info[1].hash_len, false,
+					 &res_buf);
 	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
 	zassert_equal(2, res_buf.image_list_length, "Expected to receive %d response %d", 2,
 		      res_buf.image_list_length);
 	zassert_equal(true, image_info[1].flags.pending, "Expected to receive %d response %d",
 		      true, image_info[1].flags.pending);
+
+	/* Test selecting an image using a SHA-512 digest */
+	img_read_response(2, IMG_MGMT_CLIENT_HASH_MAX_LEN);
+	rc = img_mgmt_client_state_read(&img_client, &res_buf);
+	zassert_equal(MGMT_ERR_EOK, rc);
+	memcpy(hash, image_info[1].hash, image_info[1].hash_len);
+	smp_stub_set_rx_data_verify(img_state_write_verify);
+	rc = img_mgmt_client_state_write(&img_client, hash, image_info[1].hash_len, false,
+					 &res_buf);
+	zassert_equal(MGMT_ERR_EOK, rc);
+	zassert_equal(IMG_MGMT_CLIENT_HASH_MAX_LEN, image_info[1].hash_len);
+
 	/* Test to set confirmed bit  */
 	image_info[0].flags.confirmed = false;
 	smp_stub_set_rx_data_verify(img_state_write_verify);
-	rc = img_mgmt_client_state_write(&img_client, NULL, true, &res_buf);
+	rc = img_mgmt_client_state_write(&img_client, NULL, 0, true, &res_buf);
 	zassert_equal(MGMT_ERR_EOK, rc, "Expected to receive %d response %d", MGMT_ERR_EOK, rc);
 	zassert_equal(2, res_buf.image_list_length, "Expected to receive %d response %d", 2,
 		      res_buf.image_list_length);


### PR DESCRIPTION
The image management server reports 64-byte image digests when MCUboot uses SHA-512. The client currently accepts only 32-byte state-response digests and encodes that fixed length in state-write requests, preventing it from listing or selecting images on such targets.

Support both 32-byte SHA-256 and 64-byte SHA-512 digests. Store the received digest length and add a hash length argument to img_mgmt_client_state_write().
    
Update the tests to cover both digest lengths. Also tested locally against SMP server with 32-byte SHA-256 and 64-byte SHA-512 image digests.

Fixes #118616