### PR TITLE
Modem cellular: get active cellular registration status

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -266,10 +266,12 @@ static void modem_cellular_emit_modem_info(struct modem_cellular_data *data,
 }
 
 static void modem_cellular_emit_reg_state(struct modem_cellular_data *data,
-					   enum cellular_registration_status status)
+					   enum cellular_registration_status status,
+					   enum cellular_access_technology technology)
 {
 	struct cellular_evt_registration_status evt = {
 		.status = status,
+		.technology = technology,
 	};
 
 	modem_cellular_emit_event(data, CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED, &evt);
@@ -529,19 +531,15 @@ void modem_cellular_chat_on_imsi(struct modem_chat *chat, char **argv, uint16_t 
 
 static bool modem_cellular_is_registered(struct modem_cellular_data *data)
 {
-	return (data->registration_status_gsm == CELLULAR_REGISTRATION_REGISTERED_HOME)
-		|| (data->registration_status_gsm == CELLULAR_REGISTRATION_REGISTERED_ROAMING)
-		|| (data->registration_status_gprs == CELLULAR_REGISTRATION_REGISTERED_HOME)
-		|| (data->registration_status_gprs == CELLULAR_REGISTRATION_REGISTERED_ROAMING)
-		|| (data->registration_status_lte == CELLULAR_REGISTRATION_REGISTERED_HOME)
-		|| (data->registration_status_lte == CELLULAR_REGISTRATION_REGISTERED_ROAMING);
+	return (data->registration_status == CELLULAR_REGISTRATION_REGISTERED_HOME)
+		|| (data->registration_status == CELLULAR_REGISTRATION_REGISTERED_ROAMING);
 }
 
 static void modem_cellular_clear_registration_status(struct modem_cellular_data *data)
 {
-	data->registration_status_gsm = CELLULAR_REGISTRATION_NOT_REGISTERED;
-	data->registration_status_gprs = CELLULAR_REGISTRATION_NOT_REGISTERED;
-	data->registration_status_lte = CELLULAR_REGISTRATION_NOT_REGISTERED;
+	k_mutex_lock(&data->api_lock, K_FOREVER);
+	data->registration_status = CELLULAR_REGISTRATION_NOT_REGISTERED;
+	k_mutex_unlock(&data->api_lock);
 }
 
 #if defined(CONFIG_MODEM_CELLULAR_STATS)
@@ -572,78 +570,116 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 				  void *user_data)
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
-	enum cellular_registration_status registration_status = CELLULAR_REGISTRATION_UNKNOWN;
+	enum cellular_registration_status registration_status = 0;
 	enum cellular_registration_status registration_prev;
-	uint8_t num_args;
-	uint8_t base;
+	enum cellular_access_technology tech;
 
 	/* This receives both +C*REG? read command answers and unsolicited notifications.
 	 * Their syntax differs in that the former has one more parameter, <n>, which is first.
 	 */
 	if (argc >= 3 && argv[2][0] != '"') {
-		/* +CEREG: <n>,<stat>[,<tac>[...]] */
-		base = 2;
+		/* +C*REG: <n>,<stat>[,...] — read command response */
+		registration_status = atoi(argv[2]);
 	} else if (argc >= 2) {
-		/* +CEREG: <stat>[,<tac>[...]] */
-		base = 1;
+		/* +C*REG: <stat>[,...] — unsolicited notification */
+		registration_status = atoi(argv[1]);
 	} else {
 		return;
 	}
-	/* Long form of the various CXREG options:
-	 *   +CREG: <stat>[,<lac>,<ci>[,<AcT>]]
-	 *   +CGREG:<stat>[,<lac>,<ci>[,<AcT>,<rac>]]
-	 *   +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>]]
+
+	/* Determine the access technology from the command and optional AcT field.
+	 * With AT+CEREG=2, CEREG responses include an AcT field:
+	 *   query: +CEREG: <n>,<stat>,<tac>,<ci>,<AcT>  → AcT at argv[5]
+	 *   URC:   +CEREG: <stat>,<tac>,<ci>,<AcT>      → AcT at argv[4]
+	 * AcT 7 = E-UTRAN (LTE), AcT 9 = E-UTRAN NB-S1 (NB-IoT), AcT 8 = EC-GSM-IoT
 	 */
-	num_args = argc - base;
-	registration_status = atoi(argv[base]);
-	if (num_args >= 4) {
-		data->access_tech = strtol(argv[base + 3], NULL, 10);
-	}
-	LOG_DBG("REG %d AcT %d", registration_status, data->access_tech);
-
-	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS,
-		   (const bool was_registered = modem_cellular_is_registered(data)));
-
 	if (strcmp(argv[0], "+CREG: ") == 0) {
-		registration_prev = data->registration_status_gsm;
-		data->registration_status_gsm = registration_status;
+		tech = CELLULAR_ACCESS_TECHNOLOGY_GSM;
 	} else if (strcmp(argv[0], "+CGREG: ") == 0) {
-		registration_prev = data->registration_status_gprs;
-		data->registration_status_gprs = registration_status;
-	} else { /* CEREG */
-		registration_prev = data->registration_status_lte;
-		data->registration_status_lte = registration_status;
+		tech = CELLULAR_ACCESS_TECHNOLOGY_UTRAN;
+	} else { /* +CEREG */
+		int act = -1;
+
+		if (argc >= 3 && argv[2][0] != '"') {
+			/* query response format */
+			if (argc >= 6) {
+				act = atoi(argv[5]);
+			}
+		} else {
+			/* URC format */
+			if (argc >= 5) {
+				act = atoi(argv[4]);
+			}
+		}
+
+		if (act == 9) {
+			tech = CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN_NB_S1;
+		} else if (act == 7) {
+			tech = CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN;
+		} else if (act == 8) {
+			tech = CELLULAR_ACCESS_TECHNOLOGY_EC_GSM_IOT;
+		} else {
+			/* No AcT field — CEREG always implies E-UTRAN class */
+			tech = CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN;
+		}
 	}
 
-	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS,
-		   (modem_cellular_stats_on_reg_transition(data, was_registered,
-							   modem_cellular_is_registered(data))));
+	bool is_registered = (registration_status == CELLULAR_REGISTRATION_REGISTERED_HOME ||
+			      registration_status == CELLULAR_REGISTRATION_REGISTERED_ROAMING);
+	bool is_registered_now;
 
-	if (modem_cellular_is_registered(data)) {
+	/* api_lock serialises this cache against get_registration_status(); take it
+	 * around the update so a concurrent getter never observes a status/tech pair
+	 * that belongs to two different URCs.
+	 */
+	k_mutex_lock(&data->api_lock, K_FOREVER);
+
+	registration_prev = data->registration_status;
+
+	if (is_registered) {
+		/* Always track the most recently registered technology and its status. */
+		data->access_tech = tech;
+		data->registration_status = registration_status;
+	} else if (tech == data->access_tech ||
+		   data->access_tech == CELLULAR_ACCESS_TECHNOLOGY_UNKNOWN) {
+		/*
+		 * Only accept a NOT_REGISTERED status from the technology we are currently
+		 * tracking (or when no technology has been seen yet).  This prevents a
+		 * +CGREG: NOT_REGISTERED response — normal on LTE-only modems — from
+		 * overwriting a valid +CEREG: REGISTERED that arrived earlier in the same
+		 * script run.
+		 */
+		data->registration_status = registration_status;
+	}
+
+	registration_status = data->registration_status;
+	tech = data->access_tech;
+	is_registered_now = modem_cellular_is_registered(data);
+
+	k_mutex_unlock(&data->api_lock);
+
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS,
+		   (modem_cellular_stats_on_reg_transition(
+			   data,
+			   registration_prev == CELLULAR_REGISTRATION_REGISTERED_HOME ||
+				   registration_prev == CELLULAR_REGISTRATION_REGISTERED_ROAMING,
+			   is_registered_now)));
+
+	if (registration_prev != registration_status) {
 		/* Drop any cached serving cell on a registration change; it is stale
 		 * until the next periodic poll, so get_network_status() reports no
 		 * data rather than the previous (deregistered) snapshot.
 		 */
-		if (registration_prev != registration_status) {
-			modem_cellular_invalidate_network_status(data);
-		}
+		modem_cellular_invalidate_network_status(data);
 
-		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
-	} else {
-		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_DEREGISTERED);
-		/* On deregistration report the status, as periodic network status AT
-		 * commands are not guaranteed to respond normally.
-		 */
-		if (registration_prev != registration_status) {
-			struct cellular_evt_network_status evt = {
-				.status = registration_status,
-				.access_tech = data->access_tech,
-			};
-
-			modem_cellular_emit_network_status(data, &evt);
+		if (is_registered_now) {
+			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
+		} else {
+			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_DEREGISTERED);
 		}
 	}
-	modem_cellular_emit_reg_state(data, registration_status);
+
+	modem_cellular_emit_reg_state(data, registration_status, tech);
 }
 
 void modem_cellular_chat_on_cgev(struct modem_chat *chat, char **argv, uint16_t argc,
@@ -2673,44 +2709,19 @@ static int modem_cellular_get_modem_info(const struct device *dev,
 
 	return ret;
 }
+
 static int modem_cellular_get_registration_status(const struct device *dev,
-						  enum cellular_access_technology tech,
+						  enum cellular_access_technology *tech,
 						  enum cellular_registration_status *status)
 {
-	int ret = 0;
 	struct modem_cellular_data *data = (struct modem_cellular_data *)dev->data;
 
-	/* Techs explicitly not handled as N/A to CREG, CGREG, CEREG:
-	 *   CELLULAR_ACCESS_TECHNOLOGY_NR_5G_CN
-	 *   CELLULAR_ACCESS_TECHNOLOGY_NG_RAN
-	 */
-	switch (tech) {
-	case CELLULAR_ACCESS_TECHNOLOGY_GSM:
-	case CELLULAR_ACCESS_TECHNOLOGY_GSM_COMPACT:
-		*status = data->registration_status_gsm;
-		break;
-	case CELLULAR_ACCESS_TECHNOLOGY_GSM_EGPRS:
-	case CELLULAR_ACCESS_TECHNOLOGY_EC_GSM_IOT:
-	case CELLULAR_ACCESS_TECHNOLOGY_UTRAN:
-	case CELLULAR_ACCESS_TECHNOLOGY_UTRAN_HSDPA:
-	case CELLULAR_ACCESS_TECHNOLOGY_UTRAN_HSUPA:
-	case CELLULAR_ACCESS_TECHNOLOGY_UTRAN_HSDPA_HSUPA:
-		*status = data->registration_status_gprs;
-		break;
-	case CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN:
-	case CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN_NB_S1:
-	case CELLULAR_ACCESS_TECHNOLOGY_E_UTRA_NR_DUAL:
-	case CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN_NB_S1_SAT:
-	case CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN_WB_S1_SAT:
-	case CELLULAR_ACCESS_TECHNOLOGY_NG_RAN_SAT:
-		*status = data->registration_status_lte;
-		break;
-	default:
-		ret = -ENODATA;
-		break;
-	}
+	k_mutex_lock(&data->api_lock, K_FOREVER);
+	*status = data->registration_status;
+	*tech = data->access_tech;
+	k_mutex_unlock(&data->api_lock);
 
-	return ret;
+	return 0;
 }
 
 static int modem_cellular_get_network_status(const struct device *dev,

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -96,7 +96,7 @@ static void nrf93m1_on_bcinfosc(struct modem_chat *chat, char **argv, uint16_t a
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
 	struct cellular_evt_network_status evt = {
-		.status = data->registration_status_lte,
+		.status = data->registration_status,
 		.access_tech = data->access_tech,
 	};
 

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
@@ -131,7 +131,7 @@ static void quectel_eg2x_g_on_qeng(struct modem_chat *chat, char **argv, uint16_
 {
 	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
 	struct cellular_evt_network_status evt = {
-		.status = data->registration_status_lte,
+		.status = data->registration_status,
 		.access_tech = data->access_tech,
 	};
 

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
@@ -3730,6 +3730,7 @@ static int hl78xx_init(const struct device *dev)
 	data->buffers.eof_pattern_size = strlen(data->buffers.eof_pattern);
 	data->buffers.termination_pattern_size = strlen(data->buffers.termination_pattern);
 	data->status.kcellmeas.bootstrap_done = false;
+	data->status.registration.rat_mode = HL78XX_RAT_MODE_NONE;
 	memset(data->identity.apn, 0, MDM_APN_MAX_LENGTH);
 #ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
 	data->status.uart.current_baudrate = 0;

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
@@ -1238,7 +1238,7 @@ int hl78xx_hex_string_to_bitmap(const char *hex_str, uint8_t *bitmap_out);
  * @return int Description of return value.
  */
 int hl78xx_api_func_get_registration_status(const struct device *dev,
-					    enum cellular_access_technology tech,
+					    enum cellular_access_technology *tech,
 					    enum cellular_registration_status *status);
 
 /**

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
@@ -584,23 +584,23 @@ enum hl78xx_cell_rat_mode hl78xx_access_tech_to_rat(enum cellular_access_technol
 }
 
 int hl78xx_api_func_get_registration_status(const struct device *dev,
-					    enum cellular_access_technology tech,
+					    enum cellular_access_technology *tech,
 					    enum cellular_registration_status *status)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)dev->data;
 
-	if (status == NULL) {
+	if (tech == NULL || status == NULL) {
 		return -EINVAL;
 	}
-	LOG_DBG("Requested tech: %d, current rat mode: %d REG: %d %d", tech,
-		data->status.registration.rat_mode, data->status.registration.network_state_current,
-		hl78xx_rat_to_access_tech(data->status.registration.rat_mode));
-	if (tech != hl78xx_rat_to_access_tech(data->status.registration.rat_mode)) {
-		return -ENODATA;
-	}
+
 	k_mutex_lock(&data->api_lock, K_FOREVER);
+	*tech = hl78xx_rat_to_access_tech(data->status.registration.rat_mode);
 	*status = data->status.registration.network_state_current;
 	k_mutex_unlock(&data->api_lock);
+
+	LOG_DBG("current rat mode: %d REG: %d %d", data->status.registration.rat_mode, *status,
+		*tech);
+
 	return 0;
 }
 

--- a/drivers/modem/vendor_standalone/quectel/bc66x/bc66x.c
+++ b/drivers/modem/vendor_standalone/quectel/bc66x/bc66x.c
@@ -978,6 +978,8 @@ static void bc66x_init_work_handler(struct k_work *work)
 	atomic_set(&data->modem_state, BC66X_INIT_STATE);
 	memset(&data->connection_info, 0, sizeof(data->connection_info));
 
+	data->connection_info.access_technology = CELLULAR_ACCESS_TECHNOLOGY_UNKNOWN;
+
 	ret = bc66x_do_init(data->dev);
 	if (ret == 0) {
 		atomic_set(&data->is_initialized, 1);
@@ -1102,11 +1104,9 @@ static int bc66x_get_signal(const struct device *dev, const enum cellular_signal
 }
 
 static int bc66x_get_registration_status(const struct device *dev,
-					 enum cellular_access_technology tech,
+					 enum cellular_access_technology *tech,
 					 enum cellular_registration_status *status)
 {
-
-	const struct bc66x_config *cfg = dev->config;
 	struct bc66x_data *data = dev->data;
 	int ret;
 
@@ -1115,19 +1115,10 @@ static int bc66x_get_registration_status(const struct device *dev,
 		LOG_WRN("Cannot update registration info");
 	}
 
-	if (tech == CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN_NB_S1 ||
-	    (cfg->is_bc66 && tech == CELLULAR_ACCESS_TECHNOLOGY_E_UTRAN)) {
+	*tech = data->connection_info.access_technology;
+	*status = data->connection_info.registration_status;
 
-		if (data->connection_info.access_technology == tech) {
-			*status = data->connection_info.registration_status;
-		} else {
-			*status = CELLULAR_REGISTRATION_NOT_REGISTERED;
-		}
-		return 0;
-
-	} else {
-		return -ENOTSUP;
-	}
+	return ret;
 }
 
 static int bc66x_set_apn(const struct device *dev, const char *new_apn)

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -163,6 +163,7 @@ struct cellular_evt_modem_info {
 
 /** Payload for @ref CELLULAR_EVENT_REGISTRATION_STATUS_CHANGED. */
 struct cellular_evt_registration_status {
+	enum cellular_access_technology technology; /**< Active RAT */
 	enum cellular_registration_status status; /**< New registration status */
 };
 
@@ -259,7 +260,7 @@ typedef int (*cellular_api_get_modem_info)(const struct device *dev,
 
 /** API for getting registration status */
 typedef int (*cellular_api_get_registration_status)(const struct device *dev,
-						    enum cellular_access_technology tech,
+						    enum cellular_access_technology *tech,
 						    enum cellular_registration_status *status);
 
 /** API for getting the last reported network (serving cell) status */
@@ -406,18 +407,18 @@ static inline int cellular_get_modem_info(const struct device *dev,
 }
 
 /**
- * @brief Get network registration status for the device
+ * @brief Get network registration status and active access technology for the device
  *
  * @param dev Cellular network device instance
- * @param tech Which access technology to get status for
- * @param status Registration status for given access technology
+ * @param status Current registration status
+ * @param tech Active access technology, or CELLULAR_ACCESS_TECHNOLOGY_UNKNOWN if not registered
  *
- * @return 0 on success, negative errno value on failure.
- * @retval -ENOSYS API is not supported by cellular network device.
- * @retval -ENODATA Modem does not provide the requested info.
+ * @retval 0 if successful.
+ * @retval -ENOSYS if API is not supported by cellular network device.
+ * @retval <0 Negative errno-code from chat module otherwise.
  */
 static inline int cellular_get_registration_status(const struct device *dev,
-						   enum cellular_access_technology tech,
+						   enum cellular_access_technology *tech,
 						   enum cellular_registration_status *status)
 {
 	const struct cellular_driver_api *api = DEVICE_API_GET(cellular, dev);

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -1092,7 +1092,7 @@ typedef int (*hl78xx_api_get_modem_info)(const struct device *dev,
 
 /** API for getting registration status */
 typedef int (*hl78xx_api_get_registration_status)(const struct device *dev,
-						  enum cellular_access_technology tech,
+						  enum cellular_access_technology *tech,
 						  enum cellular_registration_status *status);
 
 /**

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -152,9 +152,7 @@ struct modem_cellular_data {
 	uint8_t recovery_count;
 
 	/* Status */
-	enum cellular_registration_status registration_status_gsm;
-	enum cellular_registration_status registration_status_gprs;
-	enum cellular_registration_status registration_status_lte;
+	enum cellular_registration_status registration_status;
 	enum cellular_access_technology access_tech;
 	uint8_t rssi;
 	uint8_t rsrp;

--- a/samples/drivers/modem/hello_hl78xx/src/main.c
+++ b/samples/drivers/modem/hello_hl78xx/src/main.c
@@ -616,6 +616,7 @@ static int app_collect_and_log_modem_info(void)
 	char imei[MDM_IMEI_LENGTH] = {0};
 	char serial_number[MDM_SERIAL_NUMBER_LENGTH] = {0};
 	enum hl78xx_cell_rat_mode tech = HL78XX_RAT_MODE_NONE;
+	enum cellular_access_technology reg_tech;
 	enum cellular_registration_status status;
 	int16_t signal_strength = 0;
 	uint32_t current_baudrate = 0;
@@ -653,7 +654,7 @@ static int app_collect_and_log_modem_info(void)
 	}
 #endif /* CONFIG_MODEM_HL78XX_AUTORAT */
 
-	cellular_get_registration_status(modem, hl78xx_rat_to_access_tech(tech), &status);
+	cellular_get_registration_status(modem, &reg_tech, &status);
 #ifdef CONFIG_MODEM_HL78XX_RAT_GSM
 	cellular_get_signal(modem, CELLULAR_SIGNAL_RSSI, &signal_strength);
 #else


### PR DESCRIPTION
This PR is a proposal to discuss and if makes sense to others, to change cellular modem registration status getter. Current modem API, required the caller to pass in a specific access technology to get the registration status for.  The caller had to already know which one to ask about. This is awkward in practice, since a modem device has a primary/serving access technology which is active at a time.

For applications quering the registration status, is more useful to ask “Am I currently connected, and over what technology?” rather than "Am I currently connected with NB-IoT?".

This PR reworks the API so cellular_get_registration_status() reports the currently active access technology together with its registration status, instead of requiring the technology as an input. The tech parameter becomes an output.