### PR TITLE
DTS: ARM: ST: WBA: Fix stm32wba25Xe RAM size

### DIFF
--- a/dts/arm/st/wba/stm32wba25Xe.dtsi
+++ b/dts/arm/st/wba/stm32wba25Xe.dtsi
@@ -16,7 +16,7 @@
 	};
 
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(64)>;
+		reg = <0x20000000 DT_SIZE_K(96)>;
 	};
 
 	sram6: memory@48028000 {


### PR DESCRIPTION
Update the size of the available RAM for stm32wba25Xe to 96Kb