### PR TITLE
Bluetooth: HCI: clarify pairing error scope

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1781,7 +1781,7 @@ int bt_conn_le_set_default_phy(uint8_t pref_tx_phy, uint8_t pref_rx_phy);
  *   - @ref BT_HCI_ERR_REMOTE_LOW_RESOURCES
  *   - @ref BT_HCI_ERR_REMOTE_POWER_OFF
  *   - @ref BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
- *   - @ref BT_HCI_ERR_PAIRING_NOT_SUPPORTED
+ *   - @ref BT_HCI_ERR_PAIRING_NOT_SUPPORTED (BR/EDR connections only)
  *   - @ref BT_HCI_ERR_UNACCEPT_CONN_PARAM
  *
  *  @param conn Connection to disconnect.

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -4679,6 +4679,7 @@ struct bt_hci_evt_le_conn_rate_change {
 #define BT_HCI_ERR_LINK_KEY_CANNOT_BE_CHANGED   0x26
 #define BT_HCI_ERR_REQUESTED_QOS_NOT_SUPPORTED  0x27
 #define BT_HCI_ERR_INSTANT_PASSED               0x28
+/** Pairing with Unit Key Not Supported. This error is only valid for BR/EDR. */
 #define BT_HCI_ERR_PAIRING_NOT_SUPPORTED        0x29
 #define BT_HCI_ERR_DIFF_TRANS_COLLISION         0x2a
 #define BT_HCI_ERR_QOS_UNACCEPTABLE_PARAM       0x2c

--- a/tests/bluetooth/common/testlib/include/testlib/conn.h
+++ b/tests/bluetooth/common/testlib/include/testlib/conn.h
@@ -57,7 +57,7 @@ int bt_testlib_connect(const bt_addr_le_t *peer, struct bt_conn **connp);
  *  - @ref BT_HCI_ERR_REMOTE_LOW_RESOURCES
  *  - @ref BT_HCI_ERR_REMOTE_POWER_OFF
  *  - @ref BT_HCI_ERR_UNSUPP_REMOTE_FEATURE
- *  - @ref BT_HCI_ERR_PAIRING_NOT_SUPPORTED
+ *  - @ref BT_HCI_ERR_PAIRING_NOT_SUPPORTED (BR/EDR connections only)
  *  - @ref BT_HCI_ERR_UNACCEPT_CONN_PARAM
  */
 int bt_testlib_disconnect(struct bt_conn **connp, uint8_t reason);


### PR DESCRIPTION
## Description

Clarify that HCI status 0x29, "Pairing with Unit Key Not Supported",
is valid for BR/EDR connections only.

This keeps the existing stable API name while making the public
disconnect documentation and Bluetooth test helper documentation
consistent with the Bluetooth specification.

Fixes #98355

## Testing

Documentation/API-reference clarification only; no runtime behavior is changed.
GitHub CI will validate formatting and compliance.