### PR TITLE
modem: ppp: report a link death on an in-band NO CARRIER

### DIFF
--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -237,6 +237,7 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 				ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
 				atomic_set_bit(&ppp->state, MODEM_PPP_STATE_DEAD_BIT);
 				net_if_carrier_off(ppp->iface);
+				ppp_mgmt_raise_phase_dead_event(ppp->iface);
 			}
 			break;
 		}

--- a/tests/drivers/modem/cellular_on_demand_connect/src/main.c
+++ b/tests/drivers/modem/cellular_on_demand_connect/src/main.c
@@ -876,6 +876,32 @@ ZTEST(cellular_on_demand_connect, test_09_ppp_dead_while_awaiting_registration)
 		     modem_fsm_state());
 }
 
+/* An in-band NO CARRIER is how a module reports the network dropping the call.
+ * modem_ppp parses it off the PPP channel, so the DCE emits it verbatim.
+ */
+ZTEST(cellular_on_demand_connect, test_10_in_band_no_carrier_while_awaiting_registration)
+{
+	int dials;
+	int csq;
+
+	park_in_await_dial();
+	atomic_set(&emu_registered, 0);
+	csq = atomic_get(&csq_count);
+	zassert_true(wait_for_csq(csq + 1, 4 * CONFIG_MODEM_CELLULAR_PERIODIC_SCRIPT_MS),
+		     "periodic script did not poll while parked");
+
+	admit_iface();
+	zassert_true(wait_for_state(MODEM_CELLULAR_STATE_AWAIT_REGISTERED, 20000),
+		     "modem did not rest in AWAIT_REGISTERED, state is %d", modem_fsm_state());
+	dials = atomic_get(&atd_count);
+
+	dce_send(dce_dlci2_pipe, "\r\nNO CARRIER\r\n");
+
+	zassert_true(wait_for_atd(dials + 1, 20000),
+		     "in-band NO CARRIER in AWAIT_REGISTERED did not re-dial, state is %d",
+		     modem_fsm_state());
+}
+
 static void *suite_setup(void)
 {
 	common_setup();


### PR DESCRIPTION
An in-band NO CARRIER drops the carrier, and on an interface that is not up that tells nobody: net_if notifies only on a transition into or out of `NET_IF_OPER_UP`, so while a PPP interface is still dormant the carrier drop is silent, the PPP L2 never changes phase, and no `NET_EVENT_PPP_PHASE_DEAD` reaches a driver waiting on one. The L2 cannot cover that window itself, since its phase is already `PPP_DEAD` and `ppp_change_phase` returns early on an unchanged phase; notifying on dormant-to-down in net_if and clearing dormant at dial success both leave the failure unchanged for the same reason. So the event is raised where the death is detected
