### PR TITLE
drivers: clock_control: si32_pll: make set_rate() compliant with docs

### DIFF
--- a/drivers/clock_control/clock_control_si32_pll.c
+++ b/drivers/clock_control/clock_control_si32_pll.c
@@ -110,7 +110,7 @@ static int clock_control_si32_pll_set_rate(const struct device *dev, clock_contr
 
 	data->freq = *rate;
 
-	return 0;
+	return clock_control_si32_pll_on(dev, sys);
 }
 
 static DEVICE_API(clock_control, clock_control_si32_pll_api) = {


### PR DESCRIPTION
The documentation says that new clock rate is set and ready when clock_control_set_rate() returns, but the existing implementation just stored the new rate in driver data structure. To actually apply the new settings, clock_control_si32_pll_on() is called.