### PR TITLE
samples: hci_usb: replace dead "ble" depends_on tag with "bluetooth"

### DIFF
--- a/samples/bluetooth/hci_usb/tests.yaml
+++ b/samples/bluetooth/hci_usb/tests.yaml
@@ -5,7 +5,16 @@ tests:
     harness: bluetooth
     depends_on:
       - usbd
-      - ble
+      - bluetooth
+    # The AIROC H4 vendor setup calls bt_hci_cmd_send_sync(), which is part of
+    # the host and so is not built with CONFIG_BT_HCI_RAW.
+    platform_exclude:
+      - kit_pse84_ai/pse846gps2dbzc4a/m33
+      - kit_pse84_ai/pse846gps2dbzc4a/m55
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_pse84_eval/pse846gps2dbzc4a/m55
+    integration_platforms:
+      - nrf52840dk/nrf52840
     tags:
       - usb
       - bluetooth

--- a/samples/subsys/usb/legacy/hci_usb/tests.yaml
+++ b/samples/subsys/usb/legacy/hci_usb/tests.yaml
@@ -4,7 +4,7 @@ tests:
   sample.usb.bluetooth.hci_usb.legacy:
     depends_on:
       - usb_device
-      - ble
+      - bluetooth
     build_only: true
     tags:
       - usb


### PR DESCRIPTION
Commit 682f2e0430d1 ("boards: replace "ble" supported tag with "bluetooth"") renamed the board tag but missed these two samples, whose `depends_on` has since matched no board target, filtering both scenarios out of every twister run and leaving `subsys/usb/device_next/class/bt_hci.c` without build coverage; the four AIROC targets are excluded because their H4 vendor setup calls host functions that `CONFIG_BT_HCI_RAW` leaves out.
