### PR TITLE
drivers: crypto: fix races on session guards

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -822,10 +822,11 @@ static int ataes132a_session_free(const struct device *dev,
 				  struct cipher_ctx *session)
 {
 	struct ataes132a_driver_state *state = session->drv_sessn_state;
+	struct ataes132a_device_data *data = dev->data;
 
-	ARG_UNUSED(dev);
-
+	k_sem_take(&data->device_sem, K_FOREVER);
 	state->in_use = false;
+	k_sem_give(&data->device_sem);
 
 	return 0;
 }
@@ -837,12 +838,9 @@ static int ataes132a_session_setup(const struct device *dev,
 {
 	uint8_t key_id = *((uint8_t *)ctx->key.handle);
 	const struct ataes132a_device_config *cfg = dev->config;
+	struct ataes132a_device_data *data = dev->data;
 	uint8_t config;
 
-	if (ataes132a_state[key_id].in_use) {
-		LOG_ERR("Session in progress");
-		return -EINVAL;
-	}
 	if (mode == CRYPTO_CIPHER_MODE_CCM &&
 	    ctx->mode_params.ccm_info.tag_len != 16U) {
 		LOG_ERR("ATAES132A support 16 byte tag only.");
@@ -853,15 +851,6 @@ static int ataes132a_session_setup(const struct device *dev,
 		LOG_ERR("ATAES132A support 12 byte nonce only.");
 		return -EINVAL;
 	}
-
-	ataes132a_state[key_id].in_use = true;
-	read_reg_i2c(&cfg->i2c, ATAES_KEYCFG_REG(key_id), &config);
-	ataes132a_state[key_id].key_config = config;
-	read_reg_i2c(&cfg->i2c, ATAES_CHIPCONFIG_REG, &config);
-	ataes132a_state[key_id].chip_config = config;
-
-	ctx->drv_sessn_state = &ataes132a_state[key_id];
-	ctx->device = dev;
 
 	if (algo != CRYPTO_CIPHER_ALGO_AES) {
 		LOG_ERR("ATAES132A unsupported algorithm");
@@ -905,6 +894,31 @@ static int ataes132a_session_setup(const struct device *dev,
 		}
 	}
 
+	/*
+	 * Claim the key slot only once every parameter has been validated,
+	 * so that no error path leaves it marked as in use. The check and
+	 * the update are done under the device semaphore, otherwise two
+	 * threads could both find the slot free and claim it.
+	 */
+	k_sem_take(&data->device_sem, K_FOREVER);
+
+	if (ataes132a_state[key_id].in_use) {
+		k_sem_give(&data->device_sem);
+		LOG_ERR("Session in progress");
+		return -EINVAL;
+	}
+
+	ataes132a_state[key_id].in_use = true;
+
+	k_sem_give(&data->device_sem);
+
+	read_reg_i2c(&cfg->i2c, ATAES_KEYCFG_REG(key_id), &config);
+	ataes132a_state[key_id].key_config = config;
+	read_reg_i2c(&cfg->i2c, ATAES_CHIPCONFIG_REG, &config);
+	ataes132a_state[key_id].chip_config = config;
+
+	ctx->drv_sessn_state = &ataes132a_state[key_id];
+	ctx->device = dev;
 	ctx->ops.cipher_mode = mode;
 
 	return 0;

--- a/drivers/crypto/crypto_intel_sha.c
+++ b/drivers/crypto/crypto_intel_sha.c
@@ -16,16 +16,24 @@ LOG_MODULE_REGISTER(SHA);
 
 static struct sha_session sha_sessions[SHA_MAX_SESSIONS];
 
+/* Serializes the allocation and the release of the session slots above. */
+static K_MUTEX_DEFINE(sha_sessions_lock);
+
 static int intel_sha_get_unused_session_idx(void)
 {
 	int i;
 
+	k_mutex_lock(&sha_sessions_lock, K_FOREVER);
+
 	for (i = 0; i < SHA_MAX_SESSIONS; i++) {
 		if (!sha_sessions[i].in_use) {
 			sha_sessions[i].in_use = true;
+			k_mutex_unlock(&sha_sessions_lock);
 			return i;
 		}
 	}
+
+	k_mutex_unlock(&sha_sessions_lock);
 	return -1;
 }
 
@@ -305,8 +313,11 @@ static int intel_sha_device_free(const struct device *dev, struct hash_ctx *ctx)
 	(void)memset((void *)self->dfsha, 0, sizeof(struct sha_hw_regs));
 	(void)memset(&session->sha_ctx, 0, sizeof(struct sha_context));
 	(void)memset(&session->state, 0, sizeof(union sha_state));
-	session->in_use = false;
 	session->algo = 0;
+
+	k_mutex_lock(&sha_sessions_lock, K_FOREVER);
+	session->in_use = false;
+	k_mutex_unlock(&sha_sessions_lock);
 	return 0;
 }
 

--- a/drivers/crypto/crypto_mchp_sha_g1.c
+++ b/drivers/crypto/crypto_mchp_sha_g1.c
@@ -163,6 +163,7 @@ static struct crypto_mchp_sha_session *crypto_mchp_sha_get_unused_session(void)
 	k_sem_take(&mchp_sha_session_sem, K_FOREVER);
 	for (int i = 0; i < ARRAY_SIZE(mchp_sha_sessions); i++) {
 		if (!mchp_sha_sessions[i].in_use) {
+			mchp_sha_sessions[i].in_use = true;
 			session = &mchp_sha_sessions[i];
 			break;
 		}

--- a/drivers/crypto/crypto_npcx_sha.c
+++ b/drivers/crypto/crypto_npcx_sha.c
@@ -67,16 +67,24 @@ struct npcx_sha_session {
 
 struct npcx_sha_session npcx_sessions[NPCX_SHA_MAX_SESSION];
 
+/* Serializes the allocation and the release of the session slots above. */
+static K_MUTEX_DEFINE(npcx_sessions_lock);
+
 static int npcx_get_unused_session_index(void)
 {
 	int i;
 
+	k_mutex_lock(&npcx_sessions_lock, K_FOREVER);
+
 	for (i = 0; i < NPCX_SHA_MAX_SESSION; i++) {
 		if (!npcx_sessions[i].in_use) {
 			npcx_sessions[i].in_use = true;
+			k_mutex_unlock(&npcx_sessions_lock);
 			return i;
 		}
 	}
+
+	k_mutex_unlock(&npcx_sessions_lock);
 
 	return -1;
 }
@@ -178,7 +186,10 @@ static int npcx_hash_session_free(const struct device *dev, struct hash_ctx *ctx
 	NPCX_NCL_SHA->reset(npcx_ctx->handle);
 	NPCX_NCL_SHA->power(npcx_ctx->handle, 0);
 	NPCX_NCL_SHA->finalize_context(npcx_ctx->handle);
+
+	k_mutex_lock(&npcx_sessions_lock, K_FOREVER);
 	npcx_session->in_use = false;
+	k_mutex_unlock(&npcx_sessions_lock);
 
 	return 0;
 }

--- a/drivers/crypto/crypto_nrf_ecb.c
+++ b/drivers/crypto/crypto_nrf_ecb.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <zephyr/crypto/crypto.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
 #include <hal/nrf_ecb.h>
 
 #define DT_DRV_COMPAT nordic_nrf_ecb
@@ -24,7 +25,7 @@ struct ecb_data {
 
 struct nrf_ecb_drv_state {
 	struct ecb_data data;
-	bool in_use;
+	atomic_t in_use;
 };
 
 static struct nrf_ecb_drv_state drv_state;
@@ -70,7 +71,7 @@ static int nrf_ecb_driver_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	nrf_ecb_data_pointer_set(NRF_ECB, &drv_state.data);
-	drv_state.in_use = false;
+	atomic_clear(&drv_state.in_use);
 	return 0;
 }
 
@@ -103,12 +104,10 @@ static int nrf_ecb_session_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (drv_state.in_use) {
+	if (!atomic_cas(&drv_state.in_use, 0, 1)) {
 		LOG_ERR("Peripheral in use");
 		return -EBUSY;
 	}
-
-	drv_state.in_use = true;
 
 	ctx->ops.block_crypt_hndlr = do_ecb_encrypt;
 	ctx->ops.cipher_mode = mode;
@@ -127,7 +126,7 @@ static int nrf_ecb_session_free(const struct device *dev,
 	ARG_UNUSED(dev);
 	ARG_UNUSED(sessn);
 
-	drv_state.in_use = false;
+	atomic_clear(&drv_state.in_use);
 
 	return 0;
 }


### PR DESCRIPTION
Several crypto drivers check and set their `in_use` session flag without holding
a lock, so two threads can be handed the same session; mchp_sha_g1 never sets the
flag at all. Guard the check-then-set in each affected driver, one commit each.