### PR TITLE
drivers: usb: uhc_dwc2: reserve event bits for every host channel

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -36,12 +36,12 @@ enum uhc_dwc2_event {
 	UHC_DWC2_EVENT_PORT_OVERCURRENT,
 	/* A queued transfer has been marked for cancellation */
 	UHC_DWC2_EVENT_DEQUEUE,
-	/* Port has pending channel event */
-	UHC_DWC2_EVENT_PORT_PEND_CHANNEL,
 	/* USB host stack requested suspend */
 	UHC_DWC2_EVENT_SUSPEND,
 	/* USB host stack requested resume or device initiated Remote Wakeup */
 	UHC_DWC2_EVENT_RESUME,
+	/* First of MAX_CHANNELS pending channel event bits, keep last */
+	UHC_DWC2_EVENT_PORT_PEND_CHANNEL,
 };
 
 enum uhc_dwc2_channel_event {


### PR DESCRIPTION
`UHC_DWC2_EVENT_PORT_PEND_CHANNEL` is the base of a range of `MAX_CHANNELS` event bits, one per host channel, so it has to be the last enumerator of `enum uhc_dwc2_event`. It sat in the middle instead, and on a controller with more than one host channel the channel bits collide with `UHC_DWC2_EVENT_SUSPEND`, `UHC_DWC2_EVENT_RESUME` and `UHC_DWC2_EVENT_DEQUEUE`.

Move it to the end, and say so in the comment.

Found on an STM32N6570-DK, whose controller has 16 host channels. 