### PR TITLE
modem: cellular: dial only once registered

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1768,10 +1768,16 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 							 enum modem_cellular_event evt)
 {
 	const struct modem_cellular_config *config = data->dev->config;
+	int ret;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_cellular_run_script(data, config->vendor->scripts.dial);
+		ret = modem_cellular_run_script(data, config->vendor->scripts.dial);
+		if (ret < 0) {
+			LOG_WRN("dial script %s, rearming timer",
+				ret == -EBUSY ? "busy" : "failed");
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		}
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -804,6 +804,24 @@ static void modem_cellular_stop_timer(struct modem_cellular_data *data)
 	k_work_cancel_delayable(&data->timeout_work);
 }
 
+/* A script result reaches the state machine as a bare event, so a state that
+ * transitions while a script is still running would otherwise consume the
+ * previous state's result as its own. Remember which state started the script
+ * so the dispatcher can tell them apart.
+ */
+static int modem_cellular_run_script(struct modem_cellular_data *data,
+				     const struct modem_chat_script *script)
+{
+	int ret;
+
+	ret = modem_chat_run_script_async(&data->chat, script);
+	if (ret == 0) {
+		data->script_state = data->state;
+	}
+
+	return ret;
+}
+
 static void modem_cellular_timeout_handler(struct k_work *item)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(item);
@@ -1140,7 +1158,7 @@ static void modem_cellular_set_baudrate_event_handler(struct modem_cellular_data
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.set_baudrate);
+		modem_cellular_run_script(data, config->vendor->scripts.set_baudrate);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
@@ -1271,7 +1289,7 @@ static void modem_cellular_run_init_script_event_handler(struct modem_cellular_d
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_BUS_OPENED:
 		modem_chat_attach(&data->chat, data->uart_pipe);
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.init);
+		modem_cellular_run_script(data, config->vendor->scripts.init);
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -1383,7 +1401,7 @@ static void modem_cellular_open_dlci1_event_handler(struct modem_cellular_data *
 	case MODEM_CELLULAR_EVENT_DLCI1_OPENED:
 		if (dlci_script) {
 			modem_chat_attach(&data->chat, data->dlci1_pipe);
-			modem_chat_run_script_async(&data->chat, dlci_script);
+			modem_cellular_run_script(data, dlci_script);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_OPEN_DLCI2);
 		}
@@ -1463,7 +1481,7 @@ static void modem_cellular_open_dlci2_event_handler(struct modem_cellular_data *
 	case MODEM_CELLULAR_EVENT_DLCI2_OPENED:
 		if (dlci_script) {
 			modem_chat_attach(&data->chat, data->dlci2_pipe);
-			modem_chat_run_script_async(&data->chat, dlci_script);
+			modem_cellular_run_script(data, dlci_script);
 		} else {
 			modem_cellular_open_dlci2_next(data);
 		}
@@ -1550,7 +1568,7 @@ static void modem_cellular_run_board_init_script_event_handler(struct modem_cell
 {
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, &data->board_init_script);
+		modem_cellular_run_script(data, &data->board_init_script);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
 		modem_cellular_script_success(data);
@@ -1586,7 +1604,7 @@ static void modem_cellular_run_apn_script_event_handler(struct modem_cellular_da
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		modem_chat_attach(&data->chat, data->dlci1_pipe);
-		modem_chat_run_script_async(&data->chat, &data->apn_script);
+		modem_cellular_run_script(data, &data->apn_script);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
 		modem_cellular_script_success(data);
@@ -1626,7 +1644,7 @@ static void modem_cellular_run_network_script_event_handler(struct modem_cellula
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.network);
+		modem_cellular_run_script(data, config->vendor->scripts.network);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1703,7 +1721,7 @@ static void modem_cellular_await_dial_event_handler(struct modem_cellular_data *
 			data->periodic_timeout_skipped = true;
 			break;
 		}
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		modem_cellular_run_script(data, config->vendor->scripts.periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_PERIODIC_KICK:
@@ -1715,7 +1733,7 @@ static void modem_cellular_await_dial_event_handler(struct modem_cellular_data *
 			break;
 		}
 		data->periodic_timeout_skipped = false;
-		if (modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic) <
+		if (modem_cellular_run_script(data, config->vendor->scripts.periodic) <
 		    0) {
 			LOG_WRN("periodic kick busy, rearming timer");
 			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
@@ -1753,7 +1771,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.dial);
+		modem_cellular_run_script(data, config->vendor->scripts.dial);
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1795,7 +1813,7 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		/* Restart immediately, if we are waiting to retry the dial-script */
 		if (!modem_chat_is_running(&data->chat)) {
 			modem_cellular_stop_timer(data);
-			modem_chat_run_script_async(&data->chat, config->vendor->scripts.dial);
+			modem_cellular_run_script(data, config->vendor->scripts.dial);
 		}
 		break;
 	case MODEM_CELLULAR_EVENT_HANGUP:
@@ -1851,7 +1869,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 			data->periodic_timeout_skipped = true;
 			break;
 		}
-		modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		modem_cellular_run_script(data, config->vendor->scripts.periodic);
 		break;
 
 	case MODEM_CELLULAR_EVENT_PERIODIC_KICK:
@@ -1863,7 +1881,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 			break;
 		}
 		data->periodic_timeout_skipped = false;
-		if (modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic) <
+		if (modem_cellular_run_script(data, config->vendor->scripts.periodic) <
 		    0) {
 			LOG_WRN("periodic kick busy, rearming timer");
 			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
@@ -1945,7 +1963,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 			data->periodic_timeout_skipped = true;
 			break;
 		}
-		ret = modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		ret = modem_cellular_run_script(data, config->vendor->scripts.periodic);
 		if (ret < 0) {
 			LOG_WRN("periodic %s %s, rearming timer", "timer",
 				ret == -EBUSY ? "busy" : "failed");
@@ -1962,7 +1980,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 			break;
 		}
 		data->periodic_timeout_skipped = false;
-		ret = modem_chat_run_script_async(&data->chat, config->vendor->scripts.periodic);
+		ret = modem_cellular_run_script(data, config->vendor->scripts.periodic);
 		if (ret < 0) {
 			LOG_WRN("periodic %s %s, rearming timer", "kick",
 				ret == -EBUSY ? "busy" : "failed");
@@ -2127,7 +2145,7 @@ static int modem_cellular_on_run_shutdown_script_state_enter(struct modem_cellul
 	const struct modem_cellular_config *config = data->dev->config;
 
 	modem_chat_attach(&data->chat, data->cmd_pipe);
-	return modem_chat_run_script_async(&data->chat, config->vendor->scripts.shutdown);
+	return modem_cellular_run_script(data, config->vendor->scripts.shutdown);
 }
 
 static void modem_cellular_run_shutdown_script_event_handler(struct modem_cellular_data *data,
@@ -2415,6 +2433,15 @@ static void modem_cellular_event_handler(struct modem_cellular_data *data,
 	state = data->state;
 
 	modem_cellular_log_event(evt);
+
+	if ((evt == MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS ||
+	     evt == MODEM_CELLULAR_EVENT_SCRIPT_FAILED) &&
+	    data->script_state != data->state) {
+		LOG_DBG("script result from %s dropped in %s",
+			modem_cellular_state_str(data->script_state),
+			modem_cellular_state_str(data->state));
+		return;
+	}
 
 	switch (data->state) {
 	case MODEM_CELLULAR_STATE_IDLE:

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -315,10 +315,10 @@ static void modem_cellular_enter_state_network_or_dial(struct modem_cellular_dat
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
-	if (modem_cellular_has_network_script(config)) {
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT);
-	} else if (IS_ENABLED(CONFIG_MODEM_CELLULAR_ON_DEMAND_CONNECT)) {
+	if (IS_ENABLED(CONFIG_MODEM_CELLULAR_ON_DEMAND_CONNECT)) {
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_DIAL);
+	} else if (modem_cellular_has_network_script(config)) {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT);
 	} else {
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
 	}
@@ -1641,10 +1641,16 @@ static void modem_cellular_run_network_script_event_handler(struct modem_cellula
 {
 	const struct modem_cellular_config *config =
 		(const struct modem_cellular_config *)data->dev->config;
+	int ret;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		modem_cellular_run_script(data, config->vendor->scripts.network);
+		ret = modem_cellular_run_script(data, config->vendor->scripts.network);
+		if (ret < 0) {
+			LOG_WRN("network script %s, rearming timer",
+				ret == -EBUSY ? "busy" : "failed");
+			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
+		}
 		break;
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
@@ -1695,7 +1701,11 @@ static void modem_cellular_await_dial_event_handler(struct modem_cellular_data *
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_DIAL:
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		if (modem_cellular_has_network_script(config)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_NETWORK_SCRIPT);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
@@ -2052,12 +2062,12 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
-		if (modem_cellular_has_network_script(config) &&
-		    !modem_cellular_is_registered(data)) {
-			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_REGISTERED);
-		} else if (IS_ENABLED(CONFIG_MODEM_CELLULAR_ON_DEMAND_CONNECT) &&
-			   !net_if_is_admin_up(modem_ppp_get_iface(config->ppp))) {
+		if (IS_ENABLED(CONFIG_MODEM_CELLULAR_ON_DEMAND_CONNECT) &&
+		    !net_if_is_admin_up(modem_ppp_get_iface(config->ppp))) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_DIAL);
+		} else if (modem_cellular_has_network_script(config) &&
+			   !modem_cellular_is_registered(data)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_REGISTERED);
 		} else {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_DIAL_SCRIPT);
 		}
@@ -3009,18 +3019,6 @@ int modem_cellular_init(const struct device *dev)
 
 	__ASSERT_NO_MSG(config->vendor->scripts.init != NULL);
 	__ASSERT_NO_MSG(config->vendor->scripts.dial != NULL);
-
-	/* On-demand connect drives the dial off the PPP interface admin state. A
-	 * modem whose vendor configuration provides a network chat script instead
-	 * waits for registration and dials as soon as it registers, ignoring that
-	 * state, so the data call would come up unprompted regardless of the
-	 * option. Reject the combination here rather than dial unexpectedly.
-	 */
-	if (IS_ENABLED(CONFIG_MODEM_CELLULAR_ON_DEMAND_CONNECT) &&
-	    modem_cellular_has_network_script(config)) {
-		LOG_ERR("on-demand connect is unsupported by modems with a network chat script");
-		return -ENOTSUP;
-	}
 
 	k_mutex_init(&data->api_lock);
 	k_work_init_delayable(&data->timeout_work, modem_cellular_timeout_handler);

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg2x_g.c
@@ -82,11 +82,16 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg2x_g_set_baudrate_chat_script,
 			 modem_cellular_chat_callback_handler, 10);
 #endif
 
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg2x_g_network_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match));
+MODEM_CHAT_SCRIPT_DEFINE(quectel_eg2x_g_network_chat_script,
+			 quectel_eg2x_g_network_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 10);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg2x_g_dial_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT(
 				"AT+CGACT=0," STRINGIFY(CONFIG_MODEM_CELLULAR_PDP_CONTEXT_ID),
 				allow_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP(
 				"ATD*99***" STRINGIFY(CONFIG_MODEM_CELLULAR_PDP_CONTEXT_ID) "#",
 				connect_match));
@@ -168,6 +173,7 @@ static const struct modem_cellular_vendor_config quectel_eg2x_g_vendor = {
 		.set_baudrate = &quectel_eg2x_g_set_baudrate_chat_script,
 #endif
 		.init = &quectel_eg2x_g_init_chat_script,
+		.network = &quectel_eg2x_g_network_chat_script,
 		.dial = &quectel_eg2x_g_dial_chat_script,
 		.periodic = &quectel_eg2x_g_periodic_chat_script,
 	},

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -181,6 +181,8 @@ struct modem_cellular_data {
 #endif
 
 	enum modem_cellular_state state;
+	/** State that started the currently running chat script */
+	enum modem_cellular_state script_state;
 	const struct device *dev;
 	struct k_work_delayable timeout_work;
 

--- a/tests/drivers/modem/cellular_on_demand_connect/src/main.c
+++ b/tests/drivers/modem/cellular_on_demand_connect/src/main.c
@@ -521,6 +521,11 @@ static void *common_setup(void)
 	k_mutex_init(&pump_lock);
 	k_event_init(&emu_events);
 
+	/* The driver dials only once registered, so the emulated modem reports
+	 * registration unless a test withholds it.
+	 */
+	atomic_set(&emu_registered, 1);
+
 	zassert_true(device_is_ready(modem), "modem device not ready");
 	zassert_true(device_is_ready(modem_uart), "emulated UART not ready");
 

--- a/tests/drivers/modem/cellular_on_demand_connect/src/main.c
+++ b/tests/drivers/modem/cellular_on_demand_connect/src/main.c
@@ -150,14 +150,15 @@ static void dlci1_respond(const char *line)
 	} else if (strcmp(line, "AT+CSQ") == 0) {
 		atomic_inc(&csq_count);
 		dce_send(dce_dlci1_pipe, "+CSQ: 20,99\r\nOK\r\n");
-	} else if (strcmp(line, "AT+CEREG?") == 0 && atomic_get(&emu_registered)) {
-		/* <n>,<stat> with stat 1: registered, home LTE network. The driver
-		 * picks this up through its unsolicited +CEREG match and raises
-		 * MODEM_CELLULAR_EVENT_REGISTERED.
-		 */
-		dce_send(dce_dlci1_pipe, "+CEREG: 1,1\r\nOK\r\n");
+	} else if (strcmp(line, "AT+CEREG?") == 0) {
+		/* <n>,<stat>: stat 1 registered on the home LTE network, stat 0 not. */
+		if (atomic_get(&emu_registered)) {
+			dce_send(dce_dlci1_pipe, "+CEREG: 1,1\r\nOK\r\n");
+		} else {
+			dce_send(dce_dlci1_pipe, "+CEREG: 1,0\r\nOK\r\n");
+		}
 	} else {
-		/* AT+CREG?, AT+CEREG?, AT+CGREG?, AT+QENG="servingcell" */
+		/* AT+CREG?, AT+CGREG?, AT+QENG="servingcell" */
 		dce_send(dce_dlci1_pipe, "OK\r\n");
 	}
 }
@@ -847,6 +848,29 @@ ZTEST(cellular_on_demand_connect, test_08_periodic_survives_pause_resume_while_p
 	zassert_equal(MODEM_CELLULAR_STATE_AWAIT_DIAL, modem_fsm_state(),
 		      "periodic activity moved the FSM out of AWAIT_DIAL, state is %d",
 		      modem_fsm_state());
+}
+
+/* Admitting the interface must not dial until the module reports registration. */
+ZTEST(cellular_on_demand_connect, test_09_dial_waits_for_registration)
+{
+	int dials;
+	int csq;
+
+	park_in_await_dial();
+	atomic_set(&emu_registered, 0);
+	csq = atomic_get(&csq_count);
+	zassert_true(wait_for_csq(csq + 1, 4 * CONFIG_MODEM_CELLULAR_PERIODIC_SCRIPT_MS),
+		     "periodic script did not poll while parked");
+	dials = atomic_get(&atd_count);
+
+	admit_iface();
+	k_msleep(3 * CONFIG_MODEM_CELLULAR_PERIODIC_SCRIPT_MS);
+	zassert_equal(dials, atomic_get(&atd_count),
+		      "modem dialled before registering, state is %d", modem_fsm_state());
+
+	atomic_set(&emu_registered, 1);
+	zassert_true(wait_for_atd(dials + 1, 20000),
+		     "registration did not release the dial, state is %d", modem_fsm_state());
 }
 
 static void *suite_setup(void)


### PR DESCRIPTION
The EG2x dial script raises the radio and dials tens of milliseconds later, so a module that has to search answers CONNECT with no PDN behind it and PPP runs over nothing. Vendors with a network script already wait for registration; the EG2x has none, and `modem_cellular_init` rejects one alongside on-demand connect. Run the network script on a dial request instead of in place of it and drop that rejection: the admin state gates whether to dial, the script gates when.
