### PR TITLE
net: sockets: translate POSIX fcntl constants to ZVFS in zsock_fcntl()

### DIFF
--- a/lib/libc/arcmwdt/include/fcntl.h
+++ b/lib/libc/arcmwdt/include/fcntl.h
@@ -8,21 +8,36 @@
 #define ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_FCNTL_H_
 
 #include_next <fcntl.h>
+#include <zephyr/sys/fdtable.h>
 
 #define F_DUPFD 0
-#define F_GETFL 3
-#define F_SETFL 4
+#if defined(F_GETFL) && F_GETFL != ZVFS_F_GETFL
+#undef F_GETFL
+#endif
+#ifndef F_GETFL
+#define F_GETFL ZVFS_F_GETFL
+#endif
+
+#if defined(F_SETFL) && F_SETFL != ZVFS_F_SETFL
+#undef F_SETFL
+#endif
+#ifndef F_SETFL
+#define F_SETFL ZVFS_F_SETFL
+#endif
 
 /*
  * MWDT fcntl.h doesn't provide O_NONBLOCK, however it provides other file IO
  * definitions. Let's define O_NONBLOCK and check that it doesn't overlap with
  * any other file IO defines.
  */
+#if defined(O_NONBLOCK) && O_NONBLOCK != ZVFS_O_NONBLOCK
+#undef O_NONBLOCK
+#endif
 #ifndef O_NONBLOCK
-  #define O_NONBLOCK 0x4000
-  #if O_NONBLOCK & (O_RDONLY | O_WRONLY | O_RDWR | O_NDELAY | O_CREAT | O_APPEND | O_TRUNC | O_EXCL)
-    #error "O_NONBLOCK conflicts with other O_*** file IO defines!"
-  #endif
+  #define O_NONBLOCK ZVFS_O_NONBLOCK
+#endif
+#if O_NONBLOCK & (O_RDONLY | O_WRONLY | O_RDWR | O_NDELAY | O_CREAT | O_APPEND | O_TRUNC | O_EXCL)
+  #error "O_NONBLOCK conflicts with other O_*** file IO defines!"
 #endif
 
 #endif /* ZEPHYR_LIB_LIBC_ARCMWDT_INCLUDE_FCNTL_H_ */

--- a/lib/libc/armstdc/include/fcntl.h
+++ b/lib/libc/armstdc/include/fcntl.h
@@ -7,14 +7,16 @@
 #ifndef ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_FCNTL_H_
 #define ZEPHYR_LIB_LIBC_ARMSTDC_INCLUDE_FCNTL_H_
 
+#include <zephyr/sys/fdtable.h>
+
 #define O_CREAT    0x0200
 #define O_APPEND   0x0400
 #define O_EXCL     0x0800
-#define O_NONBLOCK 0x4000
+#define O_NONBLOCK ZVFS_O_NONBLOCK
 
 #define F_DUPFD 0
-#define F_GETFL 3
-#define F_SETFL 4
+#define F_GETFL ZVFS_F_GETFL
+#define F_SETFL ZVFS_F_SETFL
 
 int open(const char *name, int flags, ...);
 

--- a/lib/libc/newlib/include/fcntl.h
+++ b/lib/libc/newlib/include/fcntl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_FCNTL_H_
+#define ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_FCNTL_H_
+
+#include_next <fcntl.h>
+
+#include <zephyr/sys/fdtable.h>
+
+#if defined(F_GETFL) && F_GETFL != ZVFS_F_GETFL
+#undef F_GETFL
+#endif
+#ifndef F_GETFL
+#define F_GETFL ZVFS_F_GETFL
+#endif
+
+#if defined(F_SETFL) && F_SETFL != ZVFS_F_SETFL
+#undef F_SETFL
+#endif
+#ifndef F_SETFL
+#define F_SETFL ZVFS_F_SETFL
+#endif
+
+#if defined(O_NONBLOCK) && O_NONBLOCK != ZVFS_O_NONBLOCK
+#undef O_NONBLOCK
+#endif
+#ifndef O_NONBLOCK
+#define O_NONBLOCK ZVFS_O_NONBLOCK
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_NEWLIB_INCLUDE_FCNTL_H_ */

--- a/lib/libc/picolibc/include/fcntl.h
+++ b/lib/libc/picolibc/include/fcntl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_FCNTL_H_
+#define ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_FCNTL_H_
+
+#include_next <fcntl.h>
+
+#include <zephyr/sys/fdtable.h>
+
+#if defined(F_GETFL) && F_GETFL != ZVFS_F_GETFL
+#undef F_GETFL
+#endif
+#ifndef F_GETFL
+#define F_GETFL ZVFS_F_GETFL
+#endif
+
+#if defined(F_SETFL) && F_SETFL != ZVFS_F_SETFL
+#undef F_SETFL
+#endif
+#ifndef F_SETFL
+#define F_SETFL ZVFS_F_SETFL
+#endif
+
+#if defined(O_NONBLOCK) && O_NONBLOCK != ZVFS_O_NONBLOCK
+#undef O_NONBLOCK
+#endif
+#ifndef O_NONBLOCK
+#define O_NONBLOCK ZVFS_O_NONBLOCK
+#endif
+
+#endif /* ZEPHYR_LIB_LIBC_PICOLIBC_INCLUDE_FCNTL_H_ */

--- a/samples/net/sockets/echo_service/src/main.c
+++ b/samples/net/sockets/echo_service/src/main.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_echo_server_svc_sample, LOG_LEVEL_DBG);
 

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -7,6 +7,21 @@
  */
 
 /* Zephyr headers */
+#include <fcntl.h>
+#include <zephyr/sys/fdtable.h>
+
+#ifndef F_GETFL
+#define F_GETFL ZVFS_F_GETFL
+#endif
+
+#ifndef F_SETFL
+#define F_SETFL ZVFS_F_SETFL
+#endif
+
+#ifndef O_NONBLOCK
+#define O_NONBLOCK ZVFS_O_NONBLOCK
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
@@ -767,9 +782,30 @@ int z_impl_zsock_fcntl_impl(int sock, int cmd, int flags)
 	const struct socket_op_vtable *vtable;
 	struct k_mutex *lock;
 	void *obj;
+	int zvfs_cmd = cmd;
+	int zvfs_flags = flags;
 	int ret;
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(socket, fcntl, sock, cmd, flags);
+
+	if (cmd == F_GETFL) {
+#if F_GETFL != ZVFS_F_GETFL
+		LOG_WRN_ONCE("zsock_fcntl() called with F_GETFL; use ZVFS_F_GETFL instead");
+#endif
+		zvfs_cmd = ZVFS_F_GETFL;
+	} else if (cmd == F_SETFL) {
+#if F_SETFL != ZVFS_F_SETFL
+		LOG_WRN_ONCE("zsock_fcntl() called with F_SETFL; use ZVFS_F_SETFL instead");
+#endif
+		zvfs_cmd = ZVFS_F_SETFL;
+		if (flags & O_NONBLOCK) {
+#if O_NONBLOCK != ZVFS_O_NONBLOCK
+			LOG_WRN_ONCE("zsock_fcntl() called with O_NONBLOCK; "
+				     "use ZVFS_O_NONBLOCK instead");
+#endif
+			zvfs_flags |= ZVFS_O_NONBLOCK;
+		}
+	}
 
 	obj = get_sock_vtable(sock, &vtable, &lock);
 	if (obj == NULL) {
@@ -781,7 +817,7 @@ int z_impl_zsock_fcntl_impl(int sock, int cmd, int flags)
 	(void)k_mutex_lock(lock, K_FOREVER);
 
 	ret = zvfs_fdtable_call_ioctl((const struct fd_op_vtable *)vtable,
-				   obj, cmd, flags);
+				   obj, zvfs_cmd, zvfs_flags);
 
 	k_mutex_unlock(lock);
 

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -15,6 +15,7 @@ struct rtio;
 struct rtio_sqe;
 struct rtio_cqe;
 struct rtio_iodev_sqe;
+struct zvfs_pollfd;
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 

--- a/tests/net/socket/tls/src/main.c
+++ b/tests/net/socket/tls/src/main.c
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 


### PR DESCRIPTION
`zsock_fcntl()` passes the `cmd` and `flags` it receives straight through to the socket backends, which compare them against `ZVFS_F_GETFL`, `ZVFS_F_SETFL` and `ZVFS_O_NONBLOCK` from `<zephyr/sys/fdtable.h>`. Callers, however, use whatever `F_GETFL`, `F_SETFL` and `O_NONBLOCK` their C library's `<fcntl.h>` defines. That only works as long as the two sets of values happen to agree:

| libc | `O_NONBLOCK` | source |
|---|---|---|
| minimal, arcmwdt | 0x4000 | ZVFS value (based on newlib) |
| newlib, picolibc | 0x4000 | newlib value |
| host libc on native_sim (`CONFIG_NATIVE_LIBC`) | 04000 | glibc |

With the host libc, `fcntl(sock, F_SETFL, O_NONBLOCK)` therefore silently leaves the socket blocking.

This came up while decoupling the POSIX API from the native networking API.

- minimal libc and arcmwdt define `O_NONBLOCK`, `F_GETFL` and `F_SETFL` as their `ZVFS_` counterparts instead of literal copies;
- newlib and picolibc get `<fcntl.h>` shims that `#include_next` the toolchain header and pin those three names to the `ZVFS_` values, keeping the toolchain's other `O_*` flags;
- `zsock_fcntl()` maps `F_GETFL`, `F_SETFL` and `O_NONBLOCK` to their `ZVFS_` values before reaching the vtable, and warns once (only compiled in when the values differ, i.e. with the host libc) that callers should use the `ZVFS_` names;
- the samples and tests that call `fcntl()` define `_POSIX_C_SOURCE` for themselves rather than relying on the global definition.

No behaviour changes for libcs whose values already matched; the ZVFS values become the single source of truth.

### Transition plan

The `F_GETFL` / `F_SETFL` / `O_NONBLOCK` mapping in `zsock_fcntl()` is a compatibility step, not the end state. The native socket API takes `ZVFS_F_GETFL`, `ZVFS_F_SETFL` and `ZVFS_O_NONBLOCK`; the POSIX names belong to the POSIX `fcntl()`, which translates them to the `ZVFS_` values on its side (see [`lib/posix/fd_mgmt/fcntl.c` in posix-next](https://github.com/cfriedt/posix-next/blob/main/lib/posix/fd_mgmt/fcntl.c)). Once the remaining in-tree `zsock_fcntl()` callers that use the POSIX spellings (currently only `tests/net/socket/service`) have been switched to the `ZVFS_` names, a follow-up PR removes the mapping and the warning from `zsock_fcntl()`. The warning is there so that any other such caller shows up before that happens.

### Preparatory commit

`sockets.c` now includes `<zephyr/sys/fdtable.h>` first, which pulls `kernel.h` → `tracing.h` → `tracing_ctf.h` while `fdtable.h` is still being processed, so `tracing_ctf.h`'s `sys_trace_socket_poll_*()` prototypes saw an undeclared `struct zvfs_pollfd` with `CONFIG_TRACING_CTF` (`net.socket.{tcp,udp}.tracing` on native_sim). The first commit forward-declares the struct next to the existing rtio forward declarations so the header no longer depends on include order.
