### PR TITLE
libc: common: adjust the libc thrd once_flag type to be the same size

### DIFF
--- a/lib/libc/common/include/machine/_threads.h
+++ b/lib/libc/common/include/machine/_threads.h
@@ -18,7 +18,7 @@ typedef int mtx_t;
 typedef int thrd_t;
 typedef int tss_t;
 typedef struct {
-	char flag;
+	unsigned long flag;
 } once_flag;
 
 #ifdef __cplusplus


### PR DESCRIPTION
adjust the libc thrd once_flag type to be the same size as Zephyr's
pthread_once_t, which is the size of atomic_c. Currently, that is the size
of a long, but that's only the case because Zephyr's sys/atomic.h API does
not use C11 generics (which would allow us to use uint8_t atomic
operations, etc).
