### PR TITLE
tests: lib: c_lib: thrd: hold the mutex in the cnd_wait() caller

### DIFF
--- a/tests/lib/c_lib/thrd/src/cnd.c
+++ b/tests/lib/c_lib/thrd/src/cnd.c
@@ -70,6 +70,8 @@ static int test_cnd_thread_fn(void *arg)
 	struct timespec time_point;
 	struct libc_cnd_fixture *const fixture = arg;
 
+	zassert_equal(thrd_success, mtx_lock(&fixture->mutex));
+
 	if (fixture->do_timedwait) {
 		zassume_ok(sys_clock_gettime(SYS_CLOCK_REALTIME, &time_point));
 		timespec_add_ms(&time_point, WAIT_TIME_MS);
@@ -83,7 +85,7 @@ static int test_cnd_thread_fn(void *arg)
 		zassert_equal(thrd_success, cnd_signal(&fixture->cond));
 	}
 
-	(void)mtx_unlock(&fixture->mutex);
+	zassert_equal(thrd_success, mtx_unlock(&fixture->mutex));
 
 	return res;
 }
@@ -91,8 +93,6 @@ static int test_cnd_thread_fn(void *arg)
 static void tst_cnd_common(struct libc_cnd_fixture *fixture, size_t wait_ms, bool th2, int exp1,
 			   int exp2)
 {
-	zassert_equal(thrd_success, mtx_lock(&fixture->mutex));
-
 	zassert_equal(thrd_success, thrd_create(&fixture->thrd1, test_cnd_thread_fn, fixture));
 	if (th2) {
 		zassert_equal(thrd_success,
@@ -106,8 +106,6 @@ static void tst_cnd_common(struct libc_cnd_fixture *fixture, size_t wait_ms, boo
 	} else {
 		zassert_equal(thrd_success, cnd_signal(&fixture->cond));
 	}
-
-	zassert_equal(thrd_success, mtx_unlock(&fixture->mutex));
 
 	zassert_equal(thrd_success, thrd_join(fixture->thrd1, &fixture->res1));
 	if (th2) {


### PR DESCRIPTION
`tests/lib/c_lib/thrd` exercised `cnd_wait()` / `cnd_timedwait()` with the mutex held by the wrong thread. The main thread locked `fixture->mutex`, created the waiter thread(s), slept, signalled or broadcast, and only then unlocked. The waiters called `cnd_wait(&cond, &mutex)` without ever locking the mutex themselves.

C11 §7.26.3.5 (`cnd_timedwait`) and §7.26.3.6 (`cnd_wait`) require the mutex to be locked by the calling thread; POSIX says the same for `pthread_cond_wait()` and allows `EPERM` when it is not.

The test passed anyway because of how the implementation happens to behave:

1. `pthread_cond_wait()` → `k_condvar_wait()` calls `k_mutex_unlock()` and ignores its return value, so the `-EPERM` for a non-owner is lost;
2. the waiter pends on the condvar and is woken by the signal;
3. it then calls `k_mutex_lock()`, which simply blocks until the main thread's `mtx_unlock()`;
4. the waiter's own trailing `mtx_unlock()` was `(void)`-cast, so nothing in the test could notice.

Any condition-variable implementation that checks ownership on entry, which POSIX explicitly permits and which futex-backed condition variables (where the wait is a compare-and-block on the mutex word) inherently do, fails this test. That is how it surfaced.

This PR makes the test follow the standard: the waiter locks the mutex before `cnd_wait()` / `cnd_timedwait()` and asserts its `mtx_unlock()` result; the main thread no longer holds the mutex around `thrd_create()`, the sleep and the signal. The broadcast case is unchanged in spirit: each woken waiter still re-signals for the next one while holding the mutex.

No implementation change; the test's expectations (`thrd_success`, `thrd_timedout`) are the same as before.
