### PR TITLE
boards: seeed: xiao_nrf54lm20a: fix nPM1300 regulator configuration

### DIFF
--- a/boards/seeed/xiao_nrf54lm20a/Kconfig.defconfig
+++ b/boards/seeed/xiao_nrf54lm20a/Kconfig.defconfig
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Seeed Technology Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_XIAO_NRF54LM20A_NRF54LM20A_CPUAPP
+
+# The nPM1300 charger raises the VBUS current limit (500 mA) during its
+# init. Until then the PMIC is limited to its power-up default (100 mA).
+# LDO1 powers the 3.3 V rail and its soft-start inrush exceeds 100 mA,
+# so the regulator init must not run before the charger has raised the
+# limit, otherwise the PMIC enters over-current protection and the board
+# brown-outs in a boot loop.
+#
+# 1. I2C (CONFIG_I2C_INIT_PRIORITY, default 50)
+# 2. NPM13xx MFD (CONFIG_MFD_INIT_PRIORITY, default 80)
+# 3. NPM13xx charger (CONFIG_SENSOR_INIT_PRIORITY, default 90)
+# 4. NPM13xx regulators (defaults 85/86)
+#
+# The charger driver lives under the sensor subsystem, so SENSOR must be
+# enabled for the VBUS current limit to be programmed at all.
+
+if !MCUBOOT
+
+config SENSOR
+	default y
+
+config REGULATOR
+	default y
+
+endif # !MCUBOOT
+
+if REGULATOR_NPM13XX
+
+config REGULATOR_NPM13XX_COMMON_INIT_PRIORITY
+	default 91
+
+config REGULATOR_NPM13XX_INIT_PRIORITY
+	default 92
+
+endif # REGULATOR_NPM13XX
+
+endif # BOARD_XIAO_NRF54LM20A_NRF54LM20A_CPUAPP

--- a/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/seeed/xiao_nrf54lm20a/nrf54lm20a_cpuapp_common.dtsi
@@ -107,6 +107,16 @@
 	status = "okay";
 };
 
+/* The temperature sensor gets its high-frequency clock from the XO. */
+&xo {
+	status = "okay";
+};
+
+/* The GRTC system timer references the LFCLK when it is disabled. */
+&lfclk {
+	status = "okay";
+};
+
 &bt_hci_controller {
 	status = "okay";
 };

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "xiao_nrf54lm20a_nrf54lm20a-pinctrl.dtsi"
+#include <zephyr/dt-bindings/regulator/npm13xx.h>
 
 / {
 	leds {
@@ -67,7 +68,7 @@
 
 			pmic_charger: charger {
 				compatible = "nordic,npm1300-charger";
-				term-microvolt = <4150000>;
+				term-microvolt = <4200000>;
 				term-warm-microvolt = <4000000>;
 				current-microamp = <150000>;
 				dischg-limit-microamp = <1000000>;
@@ -80,11 +81,33 @@
 			regulators {
 				compatible = "nordic,npm1300-regulator";
 
-				LDO1 {
-					regulator-min-microvolt = <1800000>;
-					regulator-max-microvolt = <1800000>;
+				/*
+				 * BUCK2 supplies VSYS_3V3, which powers both the nRF54
+				 * application core and the on-board SAMD11 USB debugger.
+				 * Keep this rail enabled; disabling it also removes power
+				 * from the USB debugger.
+				 */
+				vsys_3v3: BUCK2 {
+					regulator-always-on;
+					regulator-min-microvolt = <3300000>;
+					regulator-max-microvolt = <3300000>;
+				};
+
+				imu_vdd: dmic_vdd: LDO1 {
+					regulator-init-microvolt = <3300000>;
+					regulator-min-microvolt = <3300000>;
+					regulator-max-microvolt = <3300000>;
+					regulator-initial-mode = <NPM13XX_LDSW_MODE_LDO>;
+					regulator-allowed-modes = <NPM13XX_LDSW_MODE_LDO>;
 					regulator-boot-on;
 				};
+			};
+
+			pmic_leds: leds {
+				compatible = "nordic,npm1300-led";
+				nordic,led0-mode = "error";
+				nordic,led1-mode = "host";
+				nordic,led2-mode = "host";
 			};
 		};
 	};


### PR DESCRIPTION
## What

Fixes the nPM1300 PMIC configuration of the XIAO nRF54LM20A, which currently declares a 1.8 V LDO1 while the rail actually supplies 3.3 V (IMU + PDM microphone):

- **LDO1**: 1.8 V → 3.3 V in LDO mode, with the full regulator property set (init-microvolt, initial/allowed-modes, boot-on) and `imu_vdd`/`dmic_vdd` labels
- **BUCK2** (`vsys_3v3`): new always-on node — it supplies VSYS_3V3, which powers both the application core and the on-board SAMD11 USB debugger
- **Charger**: terminate at 4.2 V instead of 4.15 V
- **PMIC LEDs**: configure modes (error/host/host)

## Why the init priorities change

The nPM1300 charger raises the VBUS current limit (100 mA power-up default → 500 mA) during its init. LDO1's soft-start inrush on the 3.3 V rail exceeds 100 mA, so with the default regulator priorities (85/86) it powers up *before* the charger has raised the limit — the PMIC enters over-current protection and the board brown-out boot-loops.

The fix (same approach as `nrf93m1dk`): order the regulators after the charger by raising `REGULATOR_NPM13XX_COMMON_INIT_PRIORITY`/`REGULATOR_NPM13XX_INIT_PRIORITY` to 91/92 (charger sits at `SENSOR_INIT_PRIORITY` = 90). Since the charger driver lives under the sensor subsystem, `SENSOR` and `REGULATOR` are enabled by default so the limit is actually programmed.

Enabling `SENSOR` pulls in the temperature driver, which needs `&xo`; `&lfclk` is then required by `sys_clock_disable()`. Both clock nodes are enabled.

## Notes

- Not verified on hardware yet; validated by building `hello_world` and inspecting `.config`/`zephyr.dts`.
- Slight overlap with #116064 (clock fixes): this PR only adds the `&xo`/`&lfclk` nodes required to compile; the remaining clock work stays in #116064.