### PR TITLE
bluetooth: audio: guard PA sync FILTER_DUPLICATE with ADI feature

### DIFF
--- a/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -382,10 +382,21 @@ static int pa_sync_with_past(struct bt_conn *conn,
 static int pa_sync_without_past(const bt_addr_le_t *addr, uint8_t adv_sid, uint16_t pa_interval)
 {
 	struct bt_le_per_adv_sync_param param = {0};
+	struct bt_le_local_features feature;
 	int err;
 
+	err = bt_le_get_local_features(&feature);
+	if (err != 0) {
+		LOG_ERR("Failed to get local features: %d", err);
+		return err;
+	}
+
 	bt_addr_le_copy(&param.addr, addr);
-	param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	if (BT_FEAT_LE_PER_ADV_ADI_SUPP(feature.features)) {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	} else {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_NONE;
+	}
 	param.sid = adv_sid;
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(pa_interval);
@@ -626,6 +637,7 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 {
 	const struct bt_le_scan_recv_info *info = user_data;
 	struct bt_le_per_adv_sync_param param = {0};
+	struct bt_le_local_features feature;
 	struct bt_uuid_16 adv_uuid;
 	uint32_t broadcast_id;
 	int err;
@@ -651,8 +663,18 @@ static bool scan_check_and_sync_broadcast(struct bt_data *data, void *user_data)
 	LOG_INF("Found broadcaster with ID 0x%06X and addr %s and sid 0x%02X\n", broadcast_id,
 		bt_addr_le_str(info->addr), info->sid);
 
+	err = bt_le_get_local_features(&feature);
+	if (err != 0) {
+		LOG_ERR("Failed to get local features: %d", err);
+		return false;
+	}
+
 	bt_addr_le_copy(&param.addr, info->addr);
-	param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	if (BT_FEAT_LE_PER_ADV_ADI_SUPP(feature.features)) {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	} else {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_NONE;
+	}
 	param.sid = info->sid;
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(info->interval);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -2341,7 +2341,14 @@ static bool scan_check_and_get_broadcast_values(struct bt_data *data, void *user
 static void pa_sync_broadcast_sink(const struct bt_le_scan_recv_info *info)
 {
 	struct bt_le_per_adv_sync_param create_params = {0};
+	struct bt_le_local_features feature;
 	int err;
+
+	err = bt_le_get_local_features(&feature);
+	if (err != 0) {
+		bt_shell_error("Failed to get local features: %d", err);
+		return;
+	}
 
 	err = bt_le_scan_stop();
 	if (err != 0) {
@@ -2349,7 +2356,11 @@ static void pa_sync_broadcast_sink(const struct bt_le_scan_recv_info *info)
 	}
 
 	bt_addr_le_copy(&create_params.addr, info->addr);
-	create_params.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	if (BT_FEAT_LE_PER_ADV_ADI_SUPP(feature.features)) {
+		create_params.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	} else {
+		create_params.options = BT_LE_PER_ADV_SYNC_OPT_NONE;
+	}
 	create_params.sid = info->sid;
 	create_params.skip = PA_SYNC_SKIP;
 	create_params.timeout = interval_to_sync_timeout(info->interval);

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -246,12 +246,23 @@ static int pa_sync_no_past(struct scan_delegator_sync_state *state, uint16_t pa_
 {
 	const struct bt_bap_scan_delegator_recv_state *recv_state;
 	struct bt_le_per_adv_sync_param param = { 0 };
+	struct bt_le_local_features feature;
 	int err;
+
+	err = bt_le_get_local_features(&feature);
+	if (err != 0) {
+		bt_shell_info("Failed to get local features: %d", err);
+		return err;
+	}
 
 	recv_state = state->recv_state;
 
 	bt_addr_le_copy(&param.addr, &recv_state->addr);
-	param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	if (BT_FEAT_LE_PER_ADV_ADI_SUPP(feature.features)) {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE;
+	} else {
+		param.options = BT_LE_PER_ADV_SYNC_OPT_NONE;
+	}
 	param.sid = recv_state->adv_sid;
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(pa_interval);


### PR DESCRIPTION
The bap_broadcast_sink sample was previously fixed to only set BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE when the controller supports the Periodic Advertising ADI Support feature. Several other broadcast sink/assistant code paths still set this option unconditionally.

BT_LE_PER_ADV_SYNC_OPT_FILTER_DUPLICATE requires the controller to support the Periodic Advertising ADI Support feature. On controllers that do not support it (e.g. external HCI controllers such as NXP IW612), bt_le_per_adv_sync_create() rejects the option and returns -ENOTSUP, so the periodic advertising sync is never created.

Apply the same fix as bap_broadcast_sink to the remaining paths: check BT_FEAT_LE_PER_ADV_ADI_SUPP via bt_le_get_local_features() and fall back to BT_LE_PER_ADV_SYNC_OPT_NONE when the feature is not supported.

Updated PA sync creation paths:
- cap_acceptor: pa_sync_without_past() - PA sync when PAST is not used
- cap_acceptor: scan_check_and_sync_broadcast() - PA sync from scan
- shell/bap: pa_sync_broadcast_sink() - PA sync from scan results
- shell/bap_scan_delegator: pa_sync_no_past() - PA sync without PAST