### PR TITLE
boards: shields: x_nucleo_iks4a1: fix Mode 5 Qvar controller

### DIFF
--- a/boards/shields/x_nucleo_iks4a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks4a1/doc/index.rst
@@ -124,11 +124,11 @@ The board configuration is:
  - J4: 9-10 (DIL_SDx = SENS_SDA)
  - J5: 9-10 (DIL_SDx = SENS_SDA)
 
-Mode 5: LSM6DSO16IS as Qvar controller
+Mode 5: LSM6DSV16X as Qvar controller
 ======================================
 
 In this configuration, it is possible to use the equipped Qvar swipe electrode
-(by plugging it on JP6 and JP7 connectors) through the LSM6DSO16IS.
+(by plugging it on JP6 and JP7 connectors) through the LSM6DSV16X.
 
 The board configuration is:
 


### PR DESCRIPTION
The Mode 5 description currently identifies LSM6DSO16IS as the Qvar controller. 

However, J4/J5 in Mode 5 route QVAR1/QVAR2 to HUB1. The X-NUCLEO-IKS4A1 schematic identifies HUB1 as U4 (LSM6DSV16X), and the LSM6DSV16X datasheet defines its pin 2/3 functions as SDx/AH1/QVAR1 and SCx/AH2/QVAR2. 

LSM6DSV16X also contains the Qvar functionality. Correct the Mode 5 controller name accordingly.