### PR TITLE
net: tcp: report received data with SACK

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -124,9 +124,36 @@ void net_tcp_conn_accepted(struct net_context *child_ctx)
 	k_mutex_unlock(&conn->lock);
 }
 
+static uint8_t tcp_send_options_len(struct tcp *conn);
+
 static uint32_t tcp_get_seq(struct net_buf *buf)
 {
 	return *(uint32_t *)net_buf_user_data(buf);
+}
+
+/*
+ * Out of order data is only held when the receive queue is enabled, and
+ * without it there is never a block to report.
+ */
+static inline bool tcp_sack_supported(void)
+{
+	return CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT > 0;
+}
+
+/*
+ * One SACK block, when out of order data is held. The queue keeps a single
+ * contiguous run, so one block is all there ever is to report.
+ */
+static bool tcp_sack_block(struct tcp *conn, uint32_t *left, uint32_t *right)
+{
+	if (!conn->sack_perm || conn->queue_recv_data == NULL) {
+		return false;
+	}
+
+	*left = tcp_get_seq(conn->queue_recv_data);
+	*right = *left + net_buf_frags_len(conn->queue_recv_data);
+
+	return true;
 }
 
 static void tcp_set_seq(struct net_buf *buf, uint32_t seq)
@@ -1143,6 +1170,7 @@ static bool tcp_options_check(struct tcp_options *recv_options,
 
 	recv_options->mss_found = false;
 	recv_options->wnd_found = false;
+	recv_options->sack_perm_found = false;
 
 	for ( ; options && len >= 1; options += opt_len, len -= opt_len) {
 		opt = options[0];
@@ -1190,6 +1218,14 @@ static bool tcp_options_check(struct tcp_options *recv_options,
 
 			recv_options->window = opt;
 			recv_options->wnd_found = true;
+			break;
+		case NET_TCP_SACK_PERM_OPT:
+			if (opt_len != NET_TCP_SACK_PERM_SIZE) {
+				result = false;
+				goto end;
+			}
+
+			recv_options->sack_perm_found = true;
 			break;
 		default:
 			continue;
@@ -1413,11 +1449,7 @@ static int tcp_header_add(struct tcp *conn, struct net_pkt *pkt, uint8_t flags,
 
 	UNALIGNED_PUT(conn->src.sin.sin_port, UNALIGNED_MEMBER_ADDR(th, th_sport));
 	UNALIGNED_PUT(conn->dst.sin.sin_port, UNALIGNED_MEMBER_ADDR(th, th_dport));
-	th->th_off = 5;
-
-	if (conn->send_options.mss_found) {
-		th->th_off++;
-	}
+	th->th_off = 5 + (tcp_send_options_len(conn) / 4U);
 
 	UNALIGNED_PUT(flags, &th->th_flags);
 	UNALIGNED_PUT(net_htons(conn->recv_win), UNALIGNED_MEMBER_ADDR(th, th_win));
@@ -1495,6 +1527,89 @@ static int net_tcp_set_mss_opt(struct tcp *conn, struct net_pkt *pkt)
 	UNALIGNED_PUT(net_htonl(recv_mss), (uint32_t *)mss);
 
 	return net_pkt_set_data(pkt, &mss_opt_access);
+}
+
+/*
+ * Bytes of TCP options this packet will carry. Used both to size the header
+ * and to keep the payload within the MSS.
+ */
+static uint8_t tcp_send_options_len(struct tcp *conn)
+{
+	uint8_t len = 0;
+
+	if (conn->send_options.mss_found) {
+		len += NET_TCP_MSS_SIZE + 2;
+	}
+
+	if (conn->send_options.sack_perm_found) {
+		len += 2 + NET_TCP_SACK_PERM_SIZE;
+	} else {
+		uint32_t left, right;
+
+		if (tcp_sack_block(conn, &left, &right)) {
+			len += 2 + 2 + NET_TCP_SACK_BLOCK_SIZE;
+		}
+	}
+
+	return len;
+}
+
+struct tcp_sack_option {
+	uint8_t nop[2];
+	uint8_t kind;
+	uint8_t len;
+	uint32_t left;
+	uint32_t right;
+} __packed;
+
+static int net_tcp_set_sack_opt(struct tcp *conn, struct net_pkt *pkt)
+{
+	NET_PKT_DATA_ACCESS_DEFINE(sack_access, struct tcp_sack_option);
+	struct tcp_sack_option *opt;
+	uint32_t left, right;
+
+	if (!tcp_sack_block(conn, &left, &right)) {
+		return 0;
+	}
+
+	opt = net_pkt_get_data(pkt, &sack_access);
+	if (!opt) {
+		return -ENOBUFS;
+	}
+
+	opt->nop[0] = NET_TCP_NOP_OPT;
+	opt->nop[1] = NET_TCP_NOP_OPT;
+	opt->kind = NET_TCP_SACK_OPT;
+	opt->len = 2 + NET_TCP_SACK_BLOCK_SIZE;
+	UNALIGNED_PUT(net_htonl(left), UNALIGNED_MEMBER_ADDR(opt, left));
+	UNALIGNED_PUT(net_htonl(right), UNALIGNED_MEMBER_ADDR(opt, right));
+
+	return net_pkt_set_data(pkt, &sack_access);
+}
+
+struct tcp_sack_perm_option {
+	uint8_t nop[2];
+	uint8_t kind;
+	uint8_t len;
+} __packed;
+
+static int net_tcp_set_sack_perm_opt(struct net_pkt *pkt)
+{
+	NET_PKT_DATA_ACCESS_DEFINE(sack_opt_access, struct tcp_sack_perm_option);
+	struct tcp_sack_perm_option *opt;
+
+	opt = net_pkt_get_data(pkt, &sack_opt_access);
+	if (!opt) {
+		return -ENOBUFS;
+	}
+
+	/* Two NOPs keep the option list aligned to a 4 byte word. */
+	opt->nop[0] = NET_TCP_NOP_OPT;
+	opt->nop[1] = NET_TCP_NOP_OPT;
+	opt->kind = NET_TCP_SACK_PERM_OPT;
+	opt->len = NET_TCP_SACK_PERM_SIZE;
+
+	return net_pkt_set_data(pkt, &sack_opt_access);
 }
 
 static bool is_destination_local(struct net_pkt *pkt)
@@ -1640,6 +1755,20 @@ static int tcp_out_ext(struct tcp *conn, uint8_t flags, size_t data_len, uint32_
 
 	if (conn->send_options.mss_found) {
 		ret = net_tcp_set_mss_opt(conn, pkt);
+		if (ret < 0) {
+			tcp_pkt_unref(pkt);
+			goto out;
+		}
+	}
+
+	if (conn->send_options.sack_perm_found) {
+		ret = net_tcp_set_sack_perm_opt(pkt);
+		if (ret < 0) {
+			tcp_pkt_unref(pkt);
+			goto out;
+		}
+	} else {
+		ret = net_tcp_set_sack_opt(conn, pkt);
 		if (ret < 0) {
 			tcp_pkt_unref(pkt);
 			goto out;
@@ -1888,7 +2017,7 @@ static int tcp_send_data(struct tcp *conn)
 	int ret = 0;
 	int len;
 
-	len = MIN(tcp_unsent_len(conn), conn_mss(conn));
+	len = MIN(tcp_unsent_len(conn), conn_mss(conn) - tcp_send_options_len(conn));
 	if (len < 0) {
 		ret = len;
 		goto out;
@@ -3176,10 +3305,15 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
 
 			/* Make sure our MSS is also sent in the ACK */
 			conn->send_options.mss_found = true;
+			conn->send_options.sack_perm_found =
+				tcp_sack_supported() &&
+				conn->recv_options.sack_perm_found;
+			conn->sack_perm = conn->send_options.sack_perm_found;
 			conn->isn_peer = th_seq(th);
 			conn_ack(conn, th_seq(th) + 1); /* capture peer's isn */
 			tcp_out(conn, SYN | ACK);
 			conn->send_options.mss_found = false;
+			conn->send_options.sack_perm_found = false;
 			conn_seq(conn, + 1);
 			next = TCP_SYN_RECEIVED;
 
@@ -3289,6 +3423,11 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt,
 		 */
 		if (FL(&fl, &, SYN | ACK, th && th_ack(th) == conn->seq)) {
 			k_work_cancel_delayable(&conn->send_data_timer);
+			/* We offered SACK in the SYN; the peer agreed if it
+			 * came back in the SYN-ACK.
+			 */
+			conn->sack_perm = tcp_sack_supported() &&
+				conn->recv_options.sack_perm_found;
 			conn->isn_peer = th_seq(th);
 			conn_ack(conn, th_seq(th) + 1);
 			if (len) {
@@ -4048,6 +4187,7 @@ static int tcp_start_handshake(struct tcp *conn)
 	k_mutex_lock(&conn->lock, K_FOREVER);
 	tcp_check_sock_options(conn);
 	conn->send_options.mss_found = true;
+	conn->send_options.sack_perm_found = tcp_sack_supported();
 	ret = tcp_out_ext(conn, SYN, 0 /* no data */, conn->seq);
 	if (ret < 0) {
 		k_mutex_unlock(&conn->lock);
@@ -4056,6 +4196,7 @@ static int tcp_start_handshake(struct tcp *conn)
 	tcp_setup_retransmission(conn);
 
 	conn->send_options.mss_found = false;
+	conn->send_options.sack_perm_found = false;
 	conn_seq(conn, + 1);
 	conn_state(conn, TCP_SYN_SENT);
 	tcp_conn_ref(conn);

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -372,7 +372,7 @@ static inline int net_tcp_put(struct net_context *context, bool force_close)
 }
 #endif
 
-#define NET_TCP_MAX_OPT_SIZE  8
+#define NET_TCP_MAX_OPT_SIZE  12
 
 #if defined(CONFIG_NET_TEST) && defined(CONFIG_NET_NATIVE_TCP)
 /** @brief Test hook to intercept TCP TX packets. Only for unit tests. */

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -229,6 +229,12 @@ union tcp_endpoint {
 #define NET_TCP_NOP_OPT          1
 #define NET_TCP_MSS_OPT          2
 #define NET_TCP_WINDOW_SCALE_OPT 3
+#define NET_TCP_SACK_PERM_OPT    4
+#define NET_TCP_SACK_OPT         5
+
+/* SACK permitted, and one block: kind, len, left edge, right edge. */
+#define NET_TCP_SACK_PERM_SIZE   2
+#define NET_TCP_SACK_BLOCK_SIZE  8
 
 /* TCP Option sizes */
 #define NET_TCP_END_SIZE          1
@@ -241,6 +247,7 @@ struct tcp_options {
 	uint16_t window;
 	bool mss_found : 1;
 	bool wnd_found : 1;
+	bool sack_perm_found : 1;
 };
 
 #ifdef CONFIG_NET_TCP_CONGESTION_AVOIDANCE
@@ -354,6 +361,8 @@ struct tcp { /* TCP connection */
 	bool tcp_nodelay : 1;
 	bool addr_ref_done : 1;
 	bool rst_received : 1;
+	/* Both ends offered SACK during the handshake. */
+	bool sack_perm : 1;
 };
 
 #define _flags(_fl, _op, _mask, _cond)					\

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -439,6 +439,86 @@ fail:
 	return -EINVAL;
 }
 
+/*
+ * Walk the option list of a received segment. Reports whether SACK permitted
+ * was offered, and the edges of the first SACK block if one is present.
+ */
+static int read_tcp_options(struct net_pkt *pkt, struct tcphdr *th,
+			    bool *sack_perm, uint32_t *left, uint32_t *right)
+{
+	uint8_t opts[40];
+	size_t len = (th->th_off - 5) * 4;
+	size_t i = 0;
+	int ret;
+
+	*sack_perm = false;
+	if (left != NULL) {
+		*left = 0;
+		*right = 0;
+	}
+
+	if (len == 0) {
+		return 0;
+	}
+
+	if (len > sizeof(opts)) {
+		return -EINVAL;
+	}
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_overwrite(pkt, true);
+
+	ret = net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) +
+			   net_pkt_ip_opts_len(pkt) + sizeof(struct tcphdr));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_read(pkt, opts, len);
+	if (ret < 0) {
+		return ret;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	while (i < len) {
+		uint8_t kind = opts[i];
+		uint8_t opt_len;
+
+		if (kind == NET_TCP_END_OPT) {
+			break;
+		}
+
+		if (kind == NET_TCP_NOP_OPT) {
+			i++;
+			continue;
+		}
+
+		if (i + 1 >= len) {
+			return -EINVAL;
+		}
+
+		opt_len = opts[i + 1];
+		if (opt_len < 2 || i + opt_len > len) {
+			return -EINVAL;
+		}
+
+		if (kind == NET_TCP_SACK_PERM_OPT && opt_len == 2) {
+			*sack_perm = true;
+		} else if (kind == NET_TCP_SACK_OPT && left != NULL &&
+			   opt_len >= 2 + 8) {
+			*left = net_ntohl(UNALIGNED_GET(
+				(uint32_t *)&opts[i + 2]));
+			*right = net_ntohl(UNALIGNED_GET(
+				(uint32_t *)&opts[i + 6]));
+		}
+
+		i += opt_len;
+	}
+
+	return 0;
+}
+
 /* TX intercept hook used by test_contiguous_tx. It exercises the tcp_send_cb
  * branch of tcp_out_ext(), records how the data segment was assembled, and
  * then hands the packet to the normal send path. The hook takes ownership of
@@ -500,10 +580,40 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	switch (test_case_no) {
 	case TEST_CLIENT_IPV4:
 	case TEST_CLIENT_IPV6:
+		if (th.th_flags & SYN) {
+			bool sack_perm;
+
+			zassert_ok(read_tcp_options(pkt, &th, &sack_perm,
+						    NULL, NULL),
+				   "Cannot read TCP options");
+			/* We only offer SACK when we can hold data out of
+			 * order to report.
+			 */
+			zassert_equal(sack_perm,
+				      CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT > 0,
+				      "SACK permitted in the SYN does not "
+				      "match whether the receive queue is on");
+		}
 		handle_client_test(net_pkt_family(pkt), &th);
 		break;
-	case TEST_SERVER_IPV4:
 	case TEST_SERVER_WITH_OPTIONS_IPV4:
+		if ((th.th_flags & SYN) && (th.th_flags & ACK)) {
+			bool sack_perm;
+
+			zassert_ok(read_tcp_options(pkt, &th, &sack_perm,
+						    NULL, NULL),
+				   "Cannot read TCP options");
+			/* Without the receive queue there is never a block
+			 * to report, so SACK is not offered back.
+			 */
+			zassert_equal(sack_perm,
+				      CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT > 0,
+				      "SACK permitted in the SYN-ACK does not "
+				      "match whether the receive queue is on");
+		}
+		handle_server_test(net_pkt_family(pkt), &th);
+		break;
+	case TEST_SERVER_IPV4:
 	case TEST_SERVER_IPV6:
 		handle_server_test(net_pkt_family(pkt), &th);
 		break;
@@ -2145,6 +2255,29 @@ static void handle_server_recv_out_of_order(struct net_pkt *pkt)
 		      "Not all pending data received. "
 		      "Expected ACK %u but got %u",
 		      expected_ack, net_ntohl(th.th_ack));
+
+	/* An ACK that leaves a hole behind carries a SACK block covering
+	 * the data held out of order; once the hole is filled it does not.
+	 */
+	if (th.th_off > 5) {
+		bool sack_perm;
+		uint32_t left, right;
+
+		zassert_ok(read_tcp_options(pkt, &th, &sack_perm,
+					    &left, &right),
+			   "Cannot read TCP options");
+
+		if (left != 0 || right != 0) {
+			zassert_true(net_tcp_seq_greater(left,
+							 net_ntohl(th.th_ack)),
+				     "SACK block starts at or below the ACK: "
+				     "left %u ack %u", left,
+				     net_ntohl(th.th_ack));
+			zassert_true(net_tcp_seq_greater(right, left),
+				     "SACK block is empty or reversed: "
+				     "left %u right %u", left, right);
+		}
+	}
 
 	test_sem_give();
 


### PR DESCRIPTION
## What

Zephyr's TCP does not implement SACK, so one lost segment leaves the
sender guessing: it sees duplicate ACKs but not which data arrived
behind the hole, and can only resend from the hole onwards and wait.

The receive side already holds out of order data on
`conn->queue_recv_data` with its sequence number, so an ACK can name it.
This offers SACK permitted in the handshake when the peer does, and
attaches that block to the ACKs sent while a hole is open.

## Scope

Receive side only - incoming blocks are not parsed, so as a sender this
stack is unchanged. Always one block, since `queue_recv_data` holds a
single contiguous run and drops anything that would not be sequential
with it; RFC 2018 allows fewer than four. Gated on
`CONFIG_NET_TCP_RECV_QUEUE_TIMEOUT`, since with the queue off there is
nothing to report.

## Measurements

`samples/net/zperf` on an MIMXRT1170-EVK receiving TCP over a direct 1G
link dropping about 0.3% of segments. `NET_BUF_DATA_SIZE=1536`,
`NET_TCP_MAX_RECV_WINDOW_SIZE=65535`, and `ETH_NXP_ENET_RX_BUFFERS=48`,
which needs the range in `Kconfig.nxp_enet` widened locally - 16 entries
of 1536 bytes cannot absorb a 64 KB window. Three runs each,
receiver-side figures:

```
offered   without SACK              with SACK
  150M    20.3 / 73.4 / 82.8        123.3 / 129.9 / 137.8 Mbps
  300M    11.4 / 64.8 / 81.7        131.5 / 137.6 / 146.2 Mbps
```

Medians 73.4 -> 129.9 and 64.8 -> 137.6, and the spread falls from more
than 4x to 1.1x: without SACK the 0.3% loss was costing seven duplicate ACKs
and a fast retransmit each time, and how many a run hit decided
its result. On the wire the board sends 4269 blocks over 8 seconds, the
left edge above the cumulative ACK and the right edge advancing as the
hole fills.

## Testing

`tests/net/tcp` and `tests/net/socket/tcp` pass, 267 cases. Added checks
that the SYN-ACK echoes SACK permitted, and that a block generated while
data is held out of order sits above the cumulative ACK and is not
empty. Both fail with the option handling disabled.

Hardware also confirms the board offers SACK permitted when it connects
out. Block generation as a client is not covered - `zperf tcp upload`
only receives ACKs, so no hole opens.

## Notes

Found while chasing why a driver change did not show in throughput
(#118211). #118607 turned up on the way.

