### PR TITLE
drivers: gpio: Add GPIO disable functionality to MAX32 driver

### DIFF
--- a/drivers/gpio/gpio_max32.c
+++ b/drivers/gpio/gpio_max32.c
@@ -86,6 +86,16 @@ static int api_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flag
 	gpio_cfg.port = cfg->regs;
 	gpio_cfg.mask = BIT(pin);
 
+	/* GPIO_DISCONNECTED leaves the pad floating with input buffer, interrupt and wakeup off */
+	if ((flags & (GPIO_INPUT | GPIO_OUTPUT)) == 0) {
+		ret = MXC_GPIO_Disable(cfg->regs, gpio_cfg.mask);
+		if (ret != 0) {
+			return -ENOTSUP;
+		}
+
+		return 0;
+	}
+
 	if (flags & GPIO_PULL_UP) {
 		gpio_cfg.pad = MXC_GPIO_PAD_PULL_UP;
 	} else if (flags & GPIO_PULL_DOWN) {
@@ -100,11 +110,9 @@ static int api_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_flag
 
 	if (flags & GPIO_OUTPUT) {
 		gpio_cfg.func = MXC_GPIO_FUNC_OUT;
-	} else if (flags & GPIO_INPUT) {
-		gpio_cfg.func = MXC_GPIO_FUNC_IN;
 	} else {
+		/* Disconnected already returned above, so this can only be GPIO_INPUT */
 		gpio_cfg.func = MXC_GPIO_FUNC_IN;
-		gpio_cfg.pad = MXC_GPIO_PAD_NONE;
 	}
 
 	if (flags & MAX32_GPIO_VSEL_VDDIOH) {

--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 7b845b62c15a2ec75e67f4eb95f23790aa607c61
+      revision: 489885cdfa668870f95b00ded1cc56ac52cdf5c4
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
This PR updates hal_adi revision to get BM changes about GPIO disable functionality and adds disable support to the MAX32 GPIO driver.