### PR TITLE
boards: infineon: kit_pse84_ai: add RRAM support

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
@@ -17,3 +17,4 @@ supported:
   - pinctrl
   - bluetooth
   - wifi
+  - flash

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m55.dts
@@ -125,3 +125,8 @@ uart4: &scb4 {
 &mxcrypto_crypto {
 	status = "okay";
 };
+
+&rram0 {
+	reg = <0x02000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x02000000 DT_SIZE_K(512)>;
+};

--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_memory_map.dtsi
@@ -183,4 +183,63 @@
 			};
 		};
 	};
+
+	/* RRAM memory (512 KB) assignment
+	 *   0x00000 - 0x10FFF : reserved-extended-boot (68 KB)
+	 *   0x11000 - 0x50FFF : boot_partition (256 KB) - MCUBoot bootloader
+	 *   0x51000 - 0x62FFF : storage_rram (72 KB)
+	 *   0x63000 - 0x7FFFF : reserved-security (116 KB)
+	 */
+	rram_controller: rram_controller@42200000 {
+		compatible = "infineon,rram-controller";
+		reg = <0x42200000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		status = "okay";
+
+		rram0: rram0@22000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x22000000 DT_SIZE_K(512)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x22000000 DT_SIZE_K(512)>;
+			write-block-size = <16>;
+			erase-block-size = <16>;
+			status = "okay";
+
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
+
+				reserved_extended_boot: reserved@0 {
+					compatible = "zephyr,mapped-partition";
+					label = "reserved-extended-boot";
+					reg = <0x0 0x11000>;
+					read-only;
+				};
+
+				boot_partition: boot_partition@11000 {
+					compatible = "zephyr,mapped-partition";
+					label = "mcuboot";
+					reg = <0x11000 0x40000>;
+					read-only;
+				};
+
+				storage_partition_rram: storage_rram@51000 {
+					compatible = "zephyr,mapped-partition";
+					label = "storage-rram";
+					reg = <0x51000 0x12000>;
+				};
+
+				reserved_security: reserved@63000 {
+					compatible = "zephyr,mapped-partition";
+					label = "reserved-security";
+					reg = <0x63000 0x1d000>;
+					read-only;
+				};
+			};
+		};
+	};
 };

--- a/tests/drivers/flash/common/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.conf
+++ b/tests/drivers/flash/common/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_TEST_DRIVER_FLASH_SIZE=524288

--- a/tests/drivers/flash/common/tests.yaml
+++ b/tests/drivers/flash/common/tests.yaml
@@ -330,8 +330,10 @@ tests:
       - CONFIG_TEST_DRIVER_FLASH_SIZE=524288
     platform_allow:
       - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
+      - kit_pse84_ai/pse846gps2dbzc4a/m33/ns
     integration_platforms:
       - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
+      - kit_pse84_ai/pse846gps2dbzc4a/m33/ns
   drivers.flash.common.infineon_ext_flash:
     filter: CONFIG_FLASH_HAS_DRIVER_ENABLED
       and dt_label_compat_enabled("storage_partition", "zephyr,mapped-partition")


### PR DESCRIPTION
This PR introduces RRAM memory support for the kit_pse84_ai board, mirroring the architecture and configuration established for the kit_pse84_eval board in PR #108532.