### PR TITLE
kernel: cache-align per-CPU state on SMP

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -201,7 +201,7 @@ struct _cpu {
 
 	/* Per CPU architecture specifics */
 	struct _cpu_arch arch;
-};
+} Z_CACHE_ALIGN_SMP;
 
 typedef struct _cpu _cpu_t;
 

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -245,6 +245,19 @@
  */
 #define Z_DECL_ALIGN(type) __aligned(__alignof(type)) type
 
+/**
+ * @brief Align an object or type to a data-cache line on cached SMP systems.
+ *
+ * Uses CONFIG_DCACHE_LINE_SIZE, or leaves natural alignment on uniprocessor
+ * and cacheless systems. For arrays, apply this to the element type to align
+ * every element rather than only the array's starting address.
+ */
+#if defined(CONFIG_SMP) && defined(CONFIG_DCACHE)
+#define Z_CACHE_ALIGN_SMP __aligned(CONFIG_DCACHE_LINE_SIZE)
+#else
+#define Z_CACHE_ALIGN_SMP
+#endif
+
 /* Check if a pointer is aligned for against a specific byte boundary  */
 #define IS_PTR_ALIGNED_BYTES(ptr, bytes) ((((uintptr_t)ptr) % bytes) == 0)
 


### PR DESCRIPTION
Create the common Z_CACHE_ALIGN_SMP macro in the common toolchain header and use it to align CPU records to CONFIG_DCACHE_LINE_SIZE on cached SMP systems, avoiding false sharing between records. Keep natural alignment on uniprocessor and cacheless configurations.

Internal ARMv8 SMP microbenchmarks show 1.18% lower latency and 0.67% higher throughput. These are geometric means of per-case median after/before ratios. The measured CPU records grow from 80 to 128 bytes.

Assisted-by: Codex:GPT-5