### PR TITLE
Bluetooth: Classic: AVCTP/AVRCP: Do not wait for RX buffers in the workqueue

### DIFF
--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -450,10 +450,15 @@ static int avctp_recv_fragmented(struct bt_avctp *avctp, struct net_buf *buf)
 			goto failed;
 		}
 
-		avctp->reassembly_buf = net_buf_alloc(avctp->rx_pool, K_FOREVER);
+		/* This runs in the Bluetooth RX workqueue, which is also the only
+		 * context that releases reassembly buffers, so waiting here could
+		 * never be satisfied. Drop the fragment instead and let the peer
+		 * time out.
+		 */
+		avctp->reassembly_buf = net_buf_alloc(avctp->rx_pool, K_NO_WAIT);
 		if (avctp->reassembly_buf == NULL) {
-			LOG_ERR("Failed to allocate reassembly buffer");
-			return -ENOMEM;
+			LOG_ERR("Failed to allocate reassembly buffer (tid=%u, cr=%u)", tid, cr);
+			goto failed;
 		}
 
 		__ASSERT_NO_MSG(avctp->reassembly_buf->user_data_size >= sizeof(*hdr_reassembly));

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -2918,7 +2918,11 @@ static struct net_buf *browsing_avrcp_l2cap_alloc_buf(struct bt_avctp *session)
 {
 	struct net_buf *buf;
 
-	buf = net_buf_alloc(&avctp_browsing_rx_pool, K_FOREVER);
+	/* Called from the Bluetooth RX workqueue, which is also the context that
+	 * releases these buffers once an SDU has been delivered, so waiting here
+	 * could never be satisfied.
+	 */
+	buf = net_buf_alloc(&avctp_browsing_rx_pool, K_NO_WAIT);
 	if (buf == NULL) {
 		LOG_ERR("Failed to allocate buffer");
 	}


### PR DESCRIPTION
The AVCTP reassembly buffer and the AVRCP browsing channel RX buffers are allocated with `K_FOREVER` from the Bluetooth RX workqueue, which is also the only context that releases them. Once the respective pool runs dry, such a wait can never be satisfied and all HCI receive processing stops. Same class of problem as #116642, which fixed the AVDTP allocations.

Both allocations now use `K_NO_WAIT`. For AVCTP a failed allocation drops the fragment and keeps the channel up, like every other reassembly failure in that function (the old failure path returned `-ENOMEM`, which makes L2CAP tear the channel down). For the browsing channel L2CAP handles a `NULL` from the buffer callback by disconnecting that channel, which the application can re-establish.

Compile-tested only (`tests/bluetooth/shell` with `prj_br.conf` on `native_sim`); neither path has test coverage in the tree.
