### PR TITLE
drivers: bluetooth: userchan: size RX frame buffer from ACL RX size

### DIFF
--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -48,6 +48,12 @@ static unsigned short bt_dev_index;
 
 #define TCP_ADDR_BUFF_SIZE 16
 #define UNIX_ADDR_BUFF_SIZE 4096
+
+/* Fit the largest packet the host can receive (H4 type + ACL header + ACL RX
+ * payload), with the historical 512-byte buffer as a floor.
+ */
+#define RX_FRAME_ACL_SIZE (1U + BT_HCI_ACL_HDR_SIZE + CONFIG_BT_BUF_ACL_RX_SIZE)
+#define RX_FRAME_SIZE     MAX(512, RX_FRAME_ACL_SIZE)
 enum hci_connection_type {
 	HCI_USERCHAN,
 	HCI_TCP,
@@ -256,7 +262,7 @@ static void rx_thread(void *p1, void *p2, void *p3)
 	long frame_size = 0;
 
 	while (1) {
-		static uint8_t frame[512];
+		static uint8_t frame[RX_FRAME_SIZE];
 		struct net_buf *buf;
 		size_t buf_tailroom;
 		size_t buf_add_len;


### PR DESCRIPTION
## Problem

The `userchan` HCI driver's `rx_thread` assembles a whole HCI packet in a single static `frame` buffer before handing it to the host. That buffer was hardcoded to **512 bytes**.

A full ACL data packet can exceed this. The host's receive buffer is `CONFIG_BT_BUF_ACL_RX_SIZE` bytes (defaults up to 1300 for Classic), and an A2DP media packet fills it. When such a packet arrives:

```
<err> bt_driver: HCI Packet is too big for frame (512 bytes). Dropping data
<err> bt_conn: Unexpected L2CAP continuation
```

The driver drops the packet, the host sees a truncated stream and rejects it, and **no A2DP media is ever received**.

## Fix

Size the frame buffer from the host's configured ACL RX size instead of a fixed 512:

```c
#define RX_FRAME_ACL_SIZE (1U + BT_HCI_ACL_HDR_SIZE + CONFIG_BT_BUF_ACL_RX_SIZE)
#define RX_FRAME_SIZE     MAX(512, RX_FRAME_ACL_SIZE)
```

- An H4 type octet + ACL header + full ACL RX payload.
- Never below the historical 512-byte floor, so smaller configurations are unaffected.

## Testing

Verified on `native_sim` with a real Bluetooth dongle (HCI User Channel):

- **Before:** A2DP media reception failed with the errors above; zero SBC media packets received.
- **After:** an A2DP SBC stream from a phone is received continuously — packets both below (498 B) and above (581 B) the old 512-byte limit — with no dropped-frame or L2CAP continuation errors. HFP hands-free call setup/teardown during playback also works.
- Compile-tested: `samples/bluetooth/classic/a2dp_sink` builds clean for `native_sim` on current `main`.