### PR TITLE
drivers: sensor: emul: drop empty configuration structs

### DIFF
--- a/drivers/sensor/adi/adltc2990/adltc2990_emul.c
+++ b/drivers/sensor/adi/adltc2990/adltc2990_emul.c
@@ -26,9 +26,6 @@ struct adltc2990_emul_data {
 	uint8_t reg[ADLTC2990_NUM_REGS];
 };
 
-struct adltc2990_emul_cfg {
-};
-
 void adltc2990_emul_set_reg(const struct emul *target, uint8_t reg_addr, const uint8_t *val)
 {
 	struct adltc2990_emul_data *data = target->data;
@@ -129,9 +126,8 @@ static const struct i2c_emul_api adltc2990_emul_api_i2c = {
 };
 
 #define ADLTC2990_EMUL(n)                                                                          \
-	const struct adltc2990_emul_cfg adltc2990_emul_cfg_##n;                                    \
 	struct adltc2990_emul_data adltc2990_emul_data_##n;                                        \
-	EMUL_DT_INST_DEFINE(n, adltc2990_emul_init, &adltc2990_emul_data_##n,                      \
-			    &adltc2990_emul_cfg_##n, &adltc2990_emul_api_i2c, NULL)
+	EMUL_DT_INST_DEFINE(n, adltc2990_emul_init, &adltc2990_emul_data_##n, NULL,                \
+			    &adltc2990_emul_api_i2c, NULL)
 
 DT_INST_FOREACH_STATUS_OKAY(ADLTC2990_EMUL)

--- a/drivers/sensor/adi/adt7420/adt7420_emul.c
+++ b/drivers/sensor/adi/adt7420/adt7420_emul.c
@@ -25,9 +25,6 @@ struct adt7420_emul_data {
 	bool resolution_16_bit;
 };
 
-struct adt7420_emul_cfg {
-};
-
 void adt7420_emul_set_reg(const struct emul *target, uint8_t reg,
 			  const uint8_t *val)
 {
@@ -187,10 +184,8 @@ static const struct emul_sensor_driver_api adt7420_emul_backend_api = {
 };
 
 #define ADT7420_EMUL_DEFINE(inst)                                                                  \
-	const struct adt7420_emul_cfg adt7420_emul_cfg_##inst;                                     \
 	struct adt7420_emul_data adt7420_emul_data_##inst;                                         \
-	EMUL_DT_INST_DEFINE(inst, adt7420_emul_init, &adt7420_emul_data_##inst,                    \
-			    &adt7420_emul_cfg_##inst, &adt7420_emul_api_i2c,                       \
-			    &adt7420_emul_backend_api);
+	EMUL_DT_INST_DEFINE(inst, adt7420_emul_init, &adt7420_emul_data_##inst, NULL,              \
+			    &adt7420_emul_api_i2c, &adt7420_emul_backend_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ADT7420_EMUL_DEFINE)

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_emul.c
@@ -25,9 +25,6 @@ struct akm09918c_emul_data {
 	uint8_t reg[NUM_REGS];
 };
 
-struct akm09918c_emul_cfg {
-};
-
 void akm09918c_emul_set_reg(const struct emul *target, uint8_t reg_addr, const uint8_t *val,
 			    size_t count)
 {
@@ -214,10 +211,8 @@ static const struct emul_sensor_driver_api akm09918c_emul_sensor_driver_api = {
 };
 
 #define AKM09918C_EMUL(n)                                                                          \
-	const struct akm09918c_emul_cfg akm09918c_emul_cfg_##n;                                    \
 	struct akm09918c_emul_data akm09918c_emul_data_##n;                                        \
-	EMUL_DT_INST_DEFINE(n, akm09918c_emul_init, &akm09918c_emul_data_##n,                      \
-			    &akm09918c_emul_cfg_##n, &akm09918c_emul_api_i2c,                      \
-			    &akm09918c_emul_sensor_driver_api)
+	EMUL_DT_INST_DEFINE(n, akm09918c_emul_init, &akm09918c_emul_data_##n, NULL,                \
+			    &akm09918c_emul_api_i2c, &akm09918c_emul_sensor_driver_api)
 
 DT_INST_FOREACH_STATUS_OKAY(AKM09918C_EMUL)

--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -29,9 +29,6 @@ struct bma4xx_emul_data {
 	uint8_t regs[BMA4XX_NUM_REGS];
 };
 
-struct bma4xx_emul_cfg {
-};
-
 void bma4xx_emul_set_reg(const struct emul *target, uint8_t reg_addr, const uint8_t *val,
 			 size_t count)
 {
@@ -324,8 +321,7 @@ static struct i2c_emul_api bma4xx_emul_api_i2c = {
 
 #define INIT_BMA4XX(n)                                                                             \
 	static struct bma4xx_emul_data bma4xx_emul_data_##n = {};                                  \
-	static const struct bma4xx_emul_cfg bma4xx_emul_cfg_##n = {};                              \
-	EMUL_DT_INST_DEFINE(n, bma4xx_emul_init, &bma4xx_emul_data_##n, &bma4xx_emul_cfg_##n,      \
+	EMUL_DT_INST_DEFINE(n, bma4xx_emul_init, &bma4xx_emul_data_##n, NULL,                      \
 			    &bma4xx_emul_api_i2c, &bma4xx_emul_sensor_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INIT_BMA4XX)

--- a/drivers/sensor/bosch/bmm350/bmm350_emul.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_emul.c
@@ -30,9 +30,6 @@ struct bmm350_emul_data {
 	uint8_t reg[BMM350_EMUL_NUM_REGS];
 };
 
-struct bmm350_emul_cfg {
-};
-
 static void bmm350_emul_reset(const struct emul *target)
 {
 	struct bmm350_emul_data *data = target->data;
@@ -190,9 +187,8 @@ static const struct i2c_emul_api bmm350_emul_api_i2c = {
 };
 
 #define BMM350_EMUL_DEFINE(n)                                                                      \
-	static const struct bmm350_emul_cfg bmm350_emul_cfg_##n;                                   \
 	static struct bmm350_emul_data bmm350_emul_data_##n;                                       \
-	EMUL_DT_INST_DEFINE(n, bmm350_emul_init, &bmm350_emul_data_##n, &bmm350_emul_cfg_##n,      \
+	EMUL_DT_INST_DEFINE(n, bmm350_emul_init, &bmm350_emul_data_##n, NULL,                      \
 			    &bmm350_emul_api_i2c, NULL)
 
 /*

--- a/drivers/sensor/f75303/f75303_emul.c
+++ b/drivers/sensor/f75303/f75303_emul.c
@@ -22,9 +22,6 @@ struct f75303_emul_data {
 	uint8_t reg[NUM_REGS];
 };
 
-struct f75303_emul_cfg {
-};
-
 static void f75303_emul_set_reg(const struct emul *target, uint8_t reg, uint8_t val)
 {
 	struct f75303_emul_data *data = target->data;
@@ -166,11 +163,9 @@ static const struct emul_sensor_driver_api f75303_emul_api_sensor = {
 };
 
 
-#define F75303_EMUL(n)								\
-	const struct f75303_emul_cfg f75303_emul_cfg_##n;			\
-	struct f75303_emul_data f75303_emul_data_##n;				\
-	EMUL_DT_INST_DEFINE(n, f75303_emul_init, &f75303_emul_data_##n,		\
-			    &f75303_emul_cfg_##n, &f75303_emul_api_i2c,		\
-			    &f75303_emul_api_sensor);
+#define F75303_EMUL(n)                                                                             \
+	struct f75303_emul_data f75303_emul_data_##n;                                              \
+	EMUL_DT_INST_DEFINE(n, f75303_emul_init, &f75303_emul_data_##n, NULL,                      \
+			    &f75303_emul_api_i2c, &f75303_emul_api_sensor);
 
 DT_INST_FOREACH_STATUS_OKAY(F75303_EMUL)

--- a/drivers/sensor/tdk/icm4268x/icm4268x_emul.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_emul.c
@@ -23,17 +23,6 @@ struct icm4268x_emul_data {
 	uint8_t reg[NUM_REGS];
 };
 
-struct icm4268x_emul_cfg {
-#if defined(CONFIG_CPP)
-       /* Empty struct has size 0 in C, size 1 in C++. Force them to be the same. */
-	uint8_t unused_cpp_size_compatibility;
-#endif
-};
-
-#if defined(CONFIG_CPP)
-BUILD_ASSERT(sizeof(struct icm4268x_emul_cfg) >= 1);
-#endif
-
 void icm4268x_emul_set_reg(const struct emul *target, uint8_t reg_addr, const uint8_t *val,
 			   size_t count)
 {
@@ -417,12 +406,11 @@ static const struct emul_sensor_driver_api icm4268x_emul_sensor_driver_api = {
 };
 
 #define ICM4268X_EMUL_DEFINE(n, api)                                                               \
-	EMUL_DT_INST_DEFINE(n, icm4268x_emul_init, &icm4268x_emul_data_##n,                        \
-			    &icm4268x_emul_cfg_##n, &api, &icm4268x_emul_sensor_driver_api)
+	EMUL_DT_INST_DEFINE(n, icm4268x_emul_init, &icm4268x_emul_data_##n, NULL, &api,            \
+			    &icm4268x_emul_sensor_driver_api)
 
 #define ICM4268X_EMUL_SPI(n)                                                                       \
 	static struct icm4268x_emul_data icm4268x_emul_data_##n;                                   \
-	static const struct icm4268x_emul_cfg icm4268x_emul_cfg_##n;                               \
 	ICM4268X_EMUL_DEFINE(n, icm4268x_emul_spi_api)
 
 DT_INST_FOREACH_STATUS_OKAY(ICM4268X_EMUL_SPI)


### PR DESCRIPTION
Seven sensor emulators declared an empty `struct <dev>_emul_cfg` and passed its address to `EMUL_DT_INST_DEFINE()` even though nothing ever reads `emul->cfg`. An empty struct is a GNU extension, not valid ISO C, and `icm4268x` additionally carried a dummy member under `CONFIG_CPP` to keep `sizeof()` consistent between C and C++.

Drop the structs and their instances and pass `NULL` for `cfg_ptr`, as `ltc4286`, `sb_tsi`, `bmp581` and `bmi323` already do. Four of the seven also declared their instance non-`static` at file scope, so this removes a leaked symbol per instance as well.