### PR TITLE
boards: nxp: lpcxpresso54628: add CTIMER support

### DIFF
--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.dts
@@ -131,3 +131,23 @@ zephyr_udc0: &usbhs {
 		int1-gpios = <&gpio3 4 GPIO_ACTIVE_LOW>;
 	};
 };
+
+&ctimer0 {
+	status = "okay";
+};
+
+&ctimer1 {
+	status = "okay";
+};
+
+&ctimer2 {
+	status = "okay";
+};
+
+&ctimer3 {
+	status = "okay";
+};
+
+&ctimer4 {
+	status = "okay";
+};

--- a/boards/nxp/lpcxpresso54628/lpcxpresso54628.yaml
+++ b/boards/nxp/lpcxpresso54628/lpcxpresso54628.yaml
@@ -14,6 +14,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - counter
   - gpio
   - uart
 vendor: nxp

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -722,6 +722,17 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 #endif /* defined(CONFIG_CAN_NXP_LPC_MCAN) */
 
 #if defined(CONFIG_COUNTER_MCUX_CTIMER) || defined(CONFIG_PWM_MCUX_CTIMER)
+#if defined(CONFIG_SOC_SERIES_LPC54XXX)
+	case MCUX_CTIMER0_CLK:
+	case MCUX_CTIMER1_CLK:
+	case MCUX_CTIMER2_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_CoreSysClk);
+		break;
+	case MCUX_CTIMER3_CLK:
+	case MCUX_CTIMER4_CLK:
+		*rate = CLOCK_GetAsyncApbClkFreq();
+		break;
+#else
 	case MCUX_CTIMER0_CLK:
 		*rate = CLOCK_GetCTimerClkFreq(0);
 		break;
@@ -746,6 +757,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 	case MCUX_CTIMER7_CLK:
 		*rate = CLOCK_GetCTimerClkFreq(7);
 		break;
+#endif /* defined(CONFIG_SOC_SERIES_LPC54XXX) */
 #endif
 #if defined(CONFIG_COUNTER_NXP_MRT) || defined(CONFIG_SOC_SERIES_RW6XX) \
 		|| defined(CONFIG_PWM_MCUX_SCTIMER)

--- a/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc546xx.dtsi
@@ -343,6 +343,66 @@
 			clocks = <&syscon MCUX_SDIF_CLK>;
 			status = "disabled";
 		};
+
+		ctimer0: ctimer@40008000 {
+			compatible = "nxp,lpc-ctimer";
+			reg = <0x40008000 0x1000>;
+			interrupts = <10 0>;
+			clocks = <&syscon MCUX_CTIMER0_CLK>;
+			clk-source = <0>;
+			mode = <0>;
+			input = <0>;
+			prescale = <0>;
+			status = "disabled";
+		};
+
+		ctimer1: ctimer@40009000 {
+			compatible = "nxp,lpc-ctimer";
+			reg = <0x40009000 0x1000>;
+			interrupts = <11 0>;
+			clocks = <&syscon MCUX_CTIMER1_CLK>;
+			clk-source = <0>;
+			mode = <0>;
+			input = <0>;
+			prescale = <0>;
+			status = "disabled";
+		};
+
+		ctimer2: ctimer@40028000 {
+			compatible = "nxp,lpc-ctimer";
+			reg = <0x40028000 0x1000>;
+			interrupts = <36 0>;
+			clocks = <&syscon MCUX_CTIMER2_CLK>;
+			clk-source = <0>;
+			mode = <0>;
+			input = <0>;
+			prescale = <0>;
+			status = "disabled";
+		};
+
+		ctimer3: ctimer@40048000 {
+			compatible = "nxp,lpc-ctimer";
+			reg = <0x40048000 0x1000>;
+			interrupts = <13 0>;
+			clocks = <&syscon MCUX_CTIMER3_CLK>;
+			clk-source = <0>;
+			mode = <0>;
+			input = <0>;
+			prescale = <0>;
+			status = "disabled";
+		};
+
+		ctimer4: ctimer@40049000 {
+			compatible = "nxp,lpc-ctimer";
+			reg = <0x40049000 0x1000>;
+			interrupts = <37 0>;
+			clocks = <&syscon MCUX_CTIMER4_CLK>;
+			clk-source = <0>;
+			mode = <0>;
+			input = <0>;
+			prescale = <0>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
## Description

Adds the five standard counter/timers on LPC546xx and enables them on
lpcxpresso54628. No new driver: `counter_mcux_ctimer.c` already handles this
IP, so this is devicetree plus the clock rate the syscon driver has to report
for it.

`clock_control_mcux_syscon.c` answers `MCUX_CTIMERn_CLK` with
`CLOCK_GetCTimerClkFreq(n)`, which has no LPC54xxx equivalent: the part has no
per-timer clock select register, so the MCUX helper does not exist. CTIMER0-2
run from the main clock; CTIMER3 and CTIMER4 are behind the asynchronous APB
bridge, whose source is selected separately, so they are reported from
`CLOCK_GetAsyncApbClkFreq()`.

Both SoCs in `SOC_SERIES_LPC54XXX` are laid out this way: CTIMER3/CTIMER4 take
their clock enable from `ASYNCAPBCLKCTRL` on LPC54114 (UM10914 table 185) and
on LPC54628 (UM10912 table 237), and neither has a `CTIMERCLKSEL` register.
That arm of the switch had never been compiled for this series, since no
LPC54xxx SoC declared a `nxp,lpc-ctimer` node.

### Testing

On LPCXpresso54628 hardware:

- `tests/drivers/counter/counter_basic_api`: 7 pass, 4 skip, 0 fail, all five
  CTIMERs exercised in every passing case. The skips are capability-gated
  cases the driver does not advertise.
- Reported rate matches measurement over a 10 ms busy-wait on all five, both
  bus domains: 220000000 Hz reported, 220029800 to 220046600 Hz measured.
- `samples/hello_world` builds warning-free, and each commit builds on its
  own. The touched shared file still builds clean for
  `lpcxpresso54114/lpc54114/m4`, `lpcxpresso55s69/lpc55s69/cpu0` and
  `mimxrt685_evk/mimxrt685s/cm33`.
- `check_compliance.py` clean.