### PR TITLE
drivers: wifi: nxp: propagate scan type for full-band scans

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -1060,6 +1060,23 @@ static int nxp_wifi_scan(const struct device *dev,
 
 	wlan_scan_params_v2.num_channels = i;
 
+	/* Propagate scan type for full-band scans where no explicit
+	 * channel list is provided and the loop above is skipped.
+	 */
+	if (i == 0U) {
+		if (params->scan_type == WIFI_SCAN_TYPE_PASSIVE) {
+			wlan_scan_params_v2.chan_list[0].scan_type =
+				MLAN_SCAN_TYPE_PASSIVE;
+			wlan_scan_params_v2.chan_list[0].scan_time =
+				params->dwell_time_passive;
+		} else {
+			wlan_scan_params_v2.chan_list[0].scan_type =
+				MLAN_SCAN_TYPE_ACTIVE;
+			wlan_scan_params_v2.chan_list[0].scan_time =
+				params->dwell_time_active;
+		}
+	}
+
 	if (params->bands & (1 << WIFI_FREQ_BAND_2_4_GHZ)) {
 		wlan_scan_params_v2.chan_list[0].radio_type = 0 | BAND_SPECIFIED;
 	}

--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -1080,7 +1080,7 @@ static int nxp_wifi_scan(const struct device *dev,
 	if (params->bands & (1 << WIFI_FREQ_BAND_2_4_GHZ)) {
 		wlan_scan_params_v2.chan_list[0].radio_type = 0 | BAND_SPECIFIED;
 	}
-#ifdef CONFIG_5GHz_SUPPORT
+#ifdef CONFIG_NXP_WIFI_5GHz_SUPPORT
 	if (params->bands & (1 << WIFI_FREQ_BAND_5_GHZ)) {
 		if (wlan_scan_params_v2.chan_list[0].radio_type & BAND_SPECIFIED) {
 			wlan_scan_params_v2.chan_list[0].radio_type = 0;


### PR DESCRIPTION
Two fixes for the NXP Wi-Fi scan path:

1. Propagate scan type for full-band scans: when a passive scan
is requested without an explicit channel list, the per-channel
scan_type assignment loop is skipped because band_chan[0].channel
is zero. This leaves chan_list[].scan_type at
MLAN_SCAN_TYPE_UNCHANGED (0), so the requested scan type is not
propagated to the lower layer for non-DFS channels.

2. Use correct Kconfig symbol CONFIG_NXP_WIFI_5GHz_SUPPORT
instead of the internal CONFIG_5GHz_SUPPORT alias.

Signed-off-by: Maochen Wang <maochen.wang@nxp.com>