### PR TITLE
maintainers: Add Øyvind as zcbor maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7667,7 +7667,9 @@ West:
     - libraries.uoscore.oscore_tests
 
 "West project: zcbor":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - oyvindronningstad
   collaborators:
     - de-nordic
   files:


### PR DESCRIPTION
    Sets zcbor as maintained, assigned to the upstream zcbor
    maintainer, Øyvind

FAO @oyvindronningstad