### PR TITLE
STM32: boards: st: nucleo_g071rb: fix ADC overrun regression by increasing prescaler

### DIFF
--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -158,7 +158,7 @@
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
-	st,adc-prescaler = <4>;
+	st,adc-prescaler = <8>;
 	status = "okay";
 	vref-mv = <3300>;
 };


### PR DESCRIPTION
Commit be27dd7d939c changed interrupt/thread-switch latency. 

It looks like that extra latency delays how quickly the ADC driver services sample-ready events.
At the previous st,adc-prescaler = 4 (16 MHz ADC clock), conversions complete faster than the data register can now be drained in time, causing an overrun.





**Problem**

tests/drivers/adc/adc_api/drivers.adc (test_adc_repeated_samplings) fails on nucleo_g071rb with:

```
  E: ADC overrun error occurred. Use DMA, reduce clock source
     frequency, increase prescaler value or increase sampling times.

```