### PR TITLE
drivers: clock_control: stm32h5: add flash programming delay

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h5.c
+++ b/drivers/clock_control/clock_stm32_ll_h5.c
@@ -902,6 +902,24 @@ int stm32_clock_control_init(const struct device *dev)
 		LL_RCC_SetTIMPrescaler(LL_RCC_TIM_PRESCALER_TWICE);
 	}
 
+	/* Set programming delay for the read latency */
+	switch (LL_FLASH_GetLatency()) {
+	case LL_FLASH_LATENCY_0:
+	case LL_FLASH_LATENCY_1:
+		MODIFY_REG(FLASH->ACR, FLASH_ACR_WRHIGHFREQ, 0U);
+		break;
+
+	case LL_FLASH_LATENCY_2:
+	case LL_FLASH_LATENCY_3:
+		MODIFY_REG(FLASH->ACR, FLASH_ACR_WRHIGHFREQ, FLASH_ACR_WRHIGHFREQ_0);
+		break;
+
+	case LL_FLASH_LATENCY_4:
+	case LL_FLASH_LATENCY_5:
+		MODIFY_REG(FLASH->ACR, FLASH_ACR_WRHIGHFREQ, FLASH_ACR_WRHIGHFREQ_1);
+		break;
+	}
+
 	/* Update CMSIS variable */
 	SystemCoreClock = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
 


### PR DESCRIPTION
WRHIGHFREQ in FLASH_ACR controls the delay between flash signals during program operations and has to match the configured read latency, as described in RM0481 rev 5, Table 48. Nothing programs it today: it is left at its reset value of 01, which is only valid up to 3 wait states. Above that the programming timings are too tight and program operations are not reliable, which is reachable on any board running the flash above ~4 wait states.

Derive the field from the latency selected by LL_SetFlashLatency().