### PR TITLE
subsys: shell: count messages dropped while log backend disabled

### DIFF
--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -42,8 +42,14 @@ void z_shell_log_backend_enable(const struct shell_log_backend *backend,
 		fifo_reset(backend);
 		log_backend_enable(backend->backend, ctx, init_log_level);
 		log_output_ctx_set(backend->log_output, ctx);
-		backend->control_block->dropped_cnt = 0;
 		backend->control_block->state = SHELL_LOG_BACKEND_ENABLED;
+		/*
+		 * Do not reset dropped_cnt here: messages processed while the
+		 * backend was disabled are now also counted (see process()),
+		 * and z_shell_log_backend_process() already atomically reads
+		 * and clears dropped_cnt the next time it runs, right after
+		 * this call, so they get reported instead of silently lost.
+		 */
 	}
 }
 
@@ -274,7 +280,15 @@ static void process(const struct log_backend *const backend,
 		break;
 
 	case SHELL_LOG_BACKEND_DISABLED:
-		__fallthrough;
+		/*
+		 * Count messages lost while the backend is disabled (e.g.
+		 * not yet started, or toggled off) the same way buffer-full
+		 * drops are counted above, so they get reported via
+		 * log_output_dropped_process() once the backend is enabled
+		 * instead of disappearing with no trace.
+		 */
+		dropped(backend, 1);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
## Summary

The shell's log backend (`shell_log_backend.c`) starts in `SHELL_LOG_BACKEND_DISABLED`
and is only enabled once `shell_start()` runs — normally whenever the shell thread
first gets scheduled, via `CONFIG_SHELL_AUTOSTART`. Any `printk()`/`LOG_*` message
that reaches `process()` before that happens currently falls into the
`SHELL_LOG_BACKEND_DISABLED` case and is silently discarded, with **no counter
incremented and no way for the user to ever know something was lost**.

This is asymmetric with the existing deferred-mode buffer-full path, which already
calls `dropped()` and gets reported via `log_output_dropped_process()` once the
backend is enabled ("N messages dropped"). This PR extends the same accounting to
the disabled case.

We hit this concretely: an app-level `SYS_INIT(..., APPLICATION, 0)` boot banner was
reliably lost on one sample's thin boot and reliably preserved on a heavier one,
purely depending on whether anything in `POST_KERNEL` init happened to block long
enough for the (lowest-priority) shell thread to get scheduled before `APPLICATION`
level ran. Total silence made this very slow to diagnose - this PR doesn't remove
the race (see the linked discussion issue for that), but makes it observable.

## Change

- `process()`: the `SHELL_LOG_BACKEND_DISABLED` case now calls `dropped(backend, 1)`,
  same as the existing buffer-full path.
- `z_shell_log_backend_enable()`: no longer resets `dropped_cnt` to 0.
  `z_shell_log_backend_process()` already atomically reads-and-clears it the next
  time it runs (right after enable, from the shell thread's own loop), so the count
  is reported instead of clobbered before it can be. This also means log output
  manually toggled off/on via the shell's log-toggle command now reports what was
  missed while off, consistent with the buffer-full case.

## Test plan

- [x] `samples/subsys/shell/shell_module` builds cleanly for `native_sim` with this
      change (145/145 objects, including `shell_log_backend.c.obj`).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)