### PR TITLE
debug: coredump: add optional CRC-32 integrity trailer

### DIFF
--- a/doc/services/debugging/coredump.rst
+++ b/doc/services/debugging/coredump.rst
@@ -43,6 +43,11 @@ Here are the choices regarding memory dump:
   _image_ram_start[] and _image_ram_end[]. This includes at least data, noinit,
   and BSS sections. This is the default.
 
+* ``DEBUG_COREDUMP_CRC``: append a CRC-32 integrity trailer to every core dump,
+  covering all preceding bytes, so a dump corrupted or truncated in transit or
+  storage can be detected by the host tooling before it is handed to the
+  debugger. See `CRC Trailer Block`_.
+
 Additional memory can be included in a dump (even with the "DEBUG_COREDUMP_MEMORY_DUMP_MIN"
 config selected) through one or more :ref:`coredump devices <coredump_device_api>`
 
@@ -263,7 +268,7 @@ File Format
 
 The core dump binary file consists of one file header, one
 architecture-specific block, zero or one threads metadata block(s),
-and multiple memory blocks. All numbers in
+multiple memory blocks, and an optional CRC trailer block. All numbers in
 the headers below are little endian.
 
 File Header
@@ -395,6 +400,39 @@ the memory region.
    * - Memory byte stream
      - ``uint8_t[]``
      - Contains the memory content between the start and end addresses.
+
+CRC Trailer Block
+-----------------
+
+When :kconfig:option:`CONFIG_DEBUG_COREDUMP_CRC` is enabled, a CRC trailer
+block is emitted as the very last block of the core dump. It carries a CRC-32
+(IEEE 802.3, as computed by :c:func:`crc32_ieee`) over every preceding byte of
+the dump - the file header and all architecture-specific, threads metadata,
+per-CPU snapshot and memory blocks - but not the trailer itself. Host tooling
+recomputes the CRC over the same range and compares, so a dump that is
+corrupted or truncated in transit (for example over the logging or UDP
+backends, which otherwise carry no integrity check) or in storage can be
+detected before it is handed to the debugger. When the option is disabled the
+on-disk format is unchanged and no trailer is written.
+
+.. list-table:: CRC Trailer Block
+   :widths: 2 1 7
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ID
+     - ``char``
+     - ``C`` to indicate this is a CRC trailer block.
+   * - Header version
+     - ``uint16_t``
+     - Identify the version of the header. This needs to be incremented
+       whenever the header struct is modified.
+   * - CRC-32
+     - ``uint32_t``
+     - CRC-32 (IEEE 802.3) computed over every byte of the core dump that
+       precedes this trailer.
 
 Adding New Target
 *****************

--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -161,6 +161,9 @@ struct coredump_cmd_copy_arg {
 #define COREDUMP_CPU_SNAPSHOT_HDR_ID	'F'
 #define COREDUMP_CPU_SNAPSHOT_HDR_VER	1
 
+#define COREDUMP_CRC_HDR_ID		'C'
+#define COREDUMP_CRC_HDR_VER		1
+
 /* Target code */
 enum coredump_tgt_code {
 	COREDUMP_TGT_UNKNOWN = 0,
@@ -255,6 +258,28 @@ struct coredump_cpu_snapshot_hdr_t {
 
 	/* The k_thread that was .current on that CPU when it was frozen */
 	uintptr_t	thread_ptr;
+} __packed;
+
+/*
+ * Integrity trailer (CONFIG_DEBUG_COREDUMP_CRC).
+ *
+ * When enabled, this is emitted as the very last block of the coredump. It
+ * carries a CRC-32 (IEEE 802.3, as computed by crc32_ieee()) over every byte
+ * of the dump that precedes it - i.e. the main header and all arch / threads
+ * metadata / per-CPU snapshot / memory blocks, but not the trailer itself.
+ * Host tooling recomputes the CRC over the same range and compares, so a
+ * dump corrupted or truncated in transit (logging/UDP) or in storage (flash)
+ * can be detected before it is fed to GDB.
+ */
+struct coredump_crc_hdr_t {
+	/* COREDUMP_CRC_HDR_ID */
+	char		id;
+
+	/* Header version */
+	uint16_t	hdr_version;
+
+	/* CRC-32 (IEEE) of all preceding coredump bytes */
+	uint32_t	crc;
 } __packed;
 
 typedef void (*coredump_backend_start_t)(void);

--- a/scripts/coredump/coredump_parser/log_parser.py
+++ b/scripts/coredump/coredump_parser/log_parser.py
@@ -6,6 +6,7 @@
 
 import logging
 import struct
+import zlib
 
 # Note: keep sync with C code
 COREDUMP_HDR_ID = b'ZE'
@@ -33,6 +34,13 @@ LOG_MEM_HDR_SIZE = struct.calcsize(LOG_MEM_HDR_STRUCT)
 COREDUMP_CPU_SNAPSHOT_HDR_ID = b'F'
 LOG_CPU_SNAPSHOT_HDR_STRUCT = "<cHHI"
 LOG_CPU_SNAPSHOT_HDR_SIZE = struct.calcsize(LOG_CPU_SNAPSHOT_HDR_STRUCT)
+
+# CRC-32 (IEEE) integrity trailer (CONFIG_DEBUG_COREDUMP_CRC). Emitted as the
+# last block; covers every preceding byte of the dump (not the trailer itself).
+COREDUMP_CRC_HDR_ID = b'C'
+COREDUMP_CRC_HDR_VER = 1
+LOG_CRC_HDR_STRUCT = "<cHI"
+LOG_CRC_HDR_SIZE = struct.calcsize(LOG_CRC_HDR_STRUCT)
 
 
 logger = logging.getLogger("parser")
@@ -71,6 +79,8 @@ class CoredumpLogFile:
         self.memory_regions = list()
         self.threads_metadata = {"hdr_ver": None, "data": None}
         self.cpu_snapshots = list()
+        # None: no CRC trailer present; True/False: verification result.
+        self.crc_valid = None
 
     def open(self):
         self.fd = open(self.logfile, "rb")
@@ -136,6 +146,40 @@ class CoredumpLogFile:
         self.cpu_snapshots.append(snapshot)
 
         logger.info("CPU snapshot: cpu=%d thread=0x%x (%d bytes)", cpu_id, thread_ptr, num_bytes)
+
+        return True
+
+    def parse_crc_section(self):
+        # Offset of the trailer itself == number of bytes it protects.
+        covered_len = self.fd.tell()
+
+        hdr = self.fd.read(LOG_CRC_HDR_SIZE)
+        _, hdr_ver, stored_crc = struct.unpack(LOG_CRC_HDR_STRUCT, hdr)
+
+        if hdr_ver != COREDUMP_CRC_HDR_VER:
+            logger.error(f"CRC block version: {hdr_ver}, expected {COREDUMP_CRC_HDR_VER}!")
+            return False
+
+        # Recompute CRC-32 (IEEE) over everything before the trailer. This
+        # matches Zephyr's crc32_ieee() / crc32_ieee_update(seed=0).
+        resume = self.fd.tell()
+        self.fd.seek(0)
+        covered = self.fd.read(covered_len)
+        self.fd.seek(resume)
+
+        calc_crc = zlib.crc32(covered) & 0xFFFFFFFF
+
+        if calc_crc != stored_crc:
+            logger.error(
+                f"Coredump CRC mismatch: stored 0x{stored_crc:08x}, "
+                f"computed 0x{calc_crc:08x} over {covered_len} bytes -- "
+                f"dump is corrupt or truncated!"
+            )
+            self.crc_valid = False
+            return False
+
+        self.crc_valid = True
+        logger.info(f"Coredump CRC OK: 0x{stored_crc:08x} over {covered_len} bytes")
 
         return True
 
@@ -223,6 +267,10 @@ class CoredumpLogFile:
             elif section_id == COREDUMP_CPU_SNAPSHOT_HDR_ID:
                 if not self.parse_cpu_snapshot_section():
                     logger.error("Cannot parse CPU snapshot section")
+                    return False
+            elif section_id == COREDUMP_CRC_HDR_ID:
+                if not self.parse_crc_section():
+                    logger.error("Coredump CRC verification failed")
                     return False
             else:
                 # Unknown section in log file

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -201,6 +201,18 @@ config DEBUG_COREDUMP_SMP_FREEZE_CPUS
 	  timeout (e.g. one that never booted, or is stuck with interrupts
 	  masked) is skipped and the dump proceeds without it.
 
+config DEBUG_COREDUMP_CRC
+	bool "Append CRC-32 integrity trailer to coredump"
+	select CRC
+	help
+	  Append a CRC-32 (IEEE 802.3) trailer block to every coredump, covering
+	  all preceding bytes of the dump. Host tooling
+	  (scripts/coredump/coredump_parser) recomputes and verifies it, so a
+	  dump corrupted or truncated in transit (logging / UDP backends, which
+	  otherwise have no integrity check) or in storage can be detected before
+	  it is handed to GDB. The trailer is backend-agnostic and adds a few
+	  bytes plus one CRC pass over the emitted data on the fatal path.
+
 config DEBUG_COREDUMP_DUMP_THREAD_PRIV_STACK
 	bool "Dump privilege stack of user threads"
 	default y

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -10,6 +10,9 @@
 #include <zephyr/debug/coredump.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+#include <zephyr/sys/crc.h>
+#endif
 
 #include "coredump_internal.h"
 #if defined(CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING)
@@ -42,6 +45,11 @@ static struct coredump_backend_api
 #if defined(CONFIG_COREDUMP_DEVICE)
 #include <zephyr/drivers/coredump.h>
 #define DT_DRV_COMPAT zephyr_coredump
+#endif
+
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+/* Running CRC-32 (IEEE) over every byte emitted for the current dump. */
+static uint32_t coredump_running_crc;
 #endif
 
 /*
@@ -99,8 +107,27 @@ static void dump_header(unsigned int reason)
 
 	hdr.tgt_code = sys_cpu_to_le16(arch_coredump_tgt_code_get());
 
+	/* Route through coredump_buffer_output() so the header is covered by
+	 * the CRC trailer (when CONFIG_DEBUG_COREDUMP_CRC is enabled).
+	 */
+	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));
+}
+
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+static void dump_crc_trailer(void)
+{
+	struct coredump_crc_hdr_t hdr = {
+		.id = COREDUMP_CRC_HDR_ID,
+		.hdr_version = sys_cpu_to_le16(COREDUMP_CRC_HDR_VER),
+		.crc = sys_cpu_to_le32(coredump_running_crc),
+	};
+
+	/* Write the trailer straight to the backend so the CRC it carries is
+	 * not folded into itself.
+	 */
 	backend_api->buffer_output((uint8_t *)&hdr, sizeof(hdr));
 }
+#endif /* CONFIG_DEBUG_COREDUMP_CRC */
 
 #if defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN) ||                                              \
 	defined(CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_THREADS)
@@ -332,6 +359,11 @@ void coredump(unsigned int reason, const struct arch_esf *esf,
 {
 	z_coredump_start();
 
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+	/* crc32_ieee_update() seeds from 0x0 to match crc32_ieee(). */
+	coredump_running_crc = 0U;
+#endif
+
 #ifdef CONFIG_DEBUG_COREDUMP_SMP_FREEZE_CPUS
 	/*
 	 * Freeze every other CPU as early as possible so their captured
@@ -372,6 +404,10 @@ void coredump(unsigned int reason, const struct arch_esf *esf,
 	arch_coredump_thaw_other_cpus();
 #endif
 
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+	dump_crc_trailer();
+#endif
+
 	z_coredump_end();
 }
 
@@ -392,7 +428,35 @@ void coredump_buffer_output(uint8_t *buf, size_t buflen)
 		return;
 	}
 
+#ifdef CONFIG_DEBUG_COREDUMP_CRC
+	/*
+	 * Some dumped regions are volatile - most notably the ISR/exception
+	 * stack this dump routine is itself running on. Reading the source
+	 * buffer once for the CRC and letting the backend read it again for
+	 * output would let those two reads observe different bytes, so the
+	 * CRC would not match the emitted stream. Copy each chunk into a
+	 * local snapshot and both CRC and emit from that same copy, so the
+	 * trailer always describes exactly what was written out.
+	 */
+	uint8_t tmp[32];
+	uint8_t *src = buf;
+	size_t remaining = buflen;
+
+	while (remaining > 0U) {
+		size_t chunk = MIN(remaining, sizeof(tmp));
+
+		(void)memcpy(tmp, src, chunk);
+		coredump_running_crc = crc32_ieee_update(coredump_running_crc, tmp, chunk);
+		backend_api->buffer_output(tmp, chunk);
+
+		src += chunk;
+		remaining -= chunk;
+	}
+
+	return;
+#else
 	backend_api->buffer_output(buf, buflen);
+#endif
 }
 
 void coredump_memory_dump(uintptr_t start_addr, uintptr_t end_addr)

--- a/tests/subsys/debug/coredump/tests.yaml
+++ b/tests/subsys/debug/coredump/tests.yaml
@@ -22,6 +22,33 @@ tests:
         - "E: #CD:4([dD])([0-9a-fA-F]+)"
         - "E: #CD:END#"
         - "k_sys_fatal_error_handler"
+  debug.coredump.logging_backend.crc:
+    tags: coredump
+    ignore_faults: true
+    ignore_qemu_crash: true
+    filter: CONFIG_ARCH_SUPPORTS_COREDUMP
+    platform_exclude: acrn_ehl_crb
+    arch_exclude:
+      - posix
+    extra_configs:
+      - CONFIG_DEBUG_COREDUMP_CRC=y
+    integration_platforms:
+      - qemu_cortex_a53
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Coredump: (.*)"
+        - ">>> ZEPHYR FATAL ERROR "
+        - "E: #CD:BEGIN#"
+        - "E: #CD:5([aA])45([0-9a-fA-F]+)"
+        - "E: #CD:41([0-9a-fA-F]+)"
+        - "E: #CD:4([dD])([0-9a-fA-F]+)"
+        # CRC trailer block: 'C' (0x43) + version + CRC-32
+        - "E: #CD:43([0-9a-fA-F]+)"
+        - "E: #CD:END#"
+        - "k_sys_fatal_error_handler"
+
   debug.coredump.logging_backend.userspace:
     tags: coredump
     ignore_faults: true


### PR DESCRIPTION
 This series adds an optional CRC-32 integrity trailer to Zephyr coredumps so that a corrupted or truncated dump can be detected before it is ever handed to GDB.

 Coredumps are frequently moved off-target over lossy or unreliable transports — the logging backend over a UART, the UDP network backend, or flash/in-memory storage that may be partially overwritten. Today there is no end-to-end integrity check: a dropped or flipped byte silently produces a malformed dump, and the failure only surfaces later as confusing GDB errors or wrong register/memory values.

 When CONFIG_DEBUG_COREDUMP_CRC is enabled, the device accumulates a CRC-32 (IEEE 802.3, matching zlib.crc32) over every byte of the dump — the file header, arch block, thread metadata, per-CPU snapshot blocks, and memory regions — and emits a small trailer block as the last block of the dump. The host-side parser recomputes the CRC over the received
 bytes and reports whether the dump is intact.

 The feature is off by default and fully backward compatible: when disabled, no trailer is emitted and the on-wire format is byte-for-byte unchanged, so existing host tooling continues to work.

 Design notes
  • CRC accumulation is done at a single choke point (coredump_buffer_output()), so it is backend-agnostic — logging, UDP, flash and in-memory backends all get integrity checking with no per-backend code.
  • The trailer block ('C' + version + uint32 CRC) is emitted outside the running CRC so it does not fold into its own checksum.
  • The CRC is computed over the exact bytes that are transmitted: each chunk is snapshotted into a local buffer, then both CRC'd and emitted from that same copy. This is required because some dumped regions (notably the ISR/exception stack the dump routine itself runs on) mutate between reads.

  Commits
  • debug: coredump: add optional CRC-32 integrity trailer — device-side Kconfig, trailer block definition, and CRC accumulation/emission.
  • scripts: coredump: verify CRC-32 integrity trailer — host parser recomputes and verifies the CRC (crc_valid), rejecting corrupt/truncated dumps.
  • tests: coredump: cover the CRC-32 integrity trailer — Twister scenario debug.coredump.logging_backend.crc on qemu_cortex_a53.
  • doc: coredump: document the CRC-32 integrity trailer — trailer format, coverage, and Kconfig option.

  Testing
  • QEMU (qemu_cortex_a53): non-SMP and SMP freeze/thaw dumps — crc_valid=True; new Twister scenario passes.
  • Hardware (versalnet_apu/amd_versalnet_apu/smp, 4× Cortex-A78AE): SMP THREADS coredump with per-CPU freeze/thaw snapshots — Twister PASS, host parser Coredump CRC OK: 
    0xf55e7dc1 over 70163 bytes, crc_valid=True, 3 'F' snapshot blocks.
  • Negative test: flipping one byte in the CRC-covered region is correctly detected (crc_valid=False) on both QEMU and hardware.

  Backward compatibility
  CONFIG_DEBUG_COREDUMP_CRC=n (default) → no trailer, unchanged format. Older parsers ignore/never see the trailer.
