### PR TITLE
arch: arm64: prevent unaligned SIMD accesses in pre-MMU code with clang

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -66,6 +66,29 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   zephyr_cc_option(-moverride=tune=no_ldp_stp_qregs)
 endif()
 
+# Clang has no equivalent of the tuning parameter above, and that parameter
+# would not be sufficient here in any case: it suppresses ldp/stp pairs, but a
+# single unaligned 128-bit access such as "stur q0, [x9, #-0x10]" is still
+# emitted.
+#
+# This matters because the early boot code in this library runs before
+# z_arm64_mm_init() enables the MMU. Until that point every access is treated as
+# Device-nGnRnE, which the architecture requires to be naturally aligned
+# regardless of SCTLR_ELx.A (cleared in reset.S). An unaligned 128-bit access
+# therefore raises an alignment fault (data abort, ESR_ELx.DFSC 0b100001) before
+# the console is up, which presents as a silent hang.
+#
+# -mstrict-align prevents the compiler from emitting any access it cannot prove
+# is naturally aligned. zephyr_library_compile_options() is used rather than
+# zephyr_cc_option() so that the flag applies only to this library: the latter
+# appends to zephyr_interface and would restrict the whole image, including code
+# that runs with the MMU enabled. Assembly is unaffected, so the FPU context
+# save/restore in fpu.S continues to use the Qn registers.
+
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  zephyr_library_compile_options(-mstrict-align)
+endif()
+
 add_subdirectory_ifdef(CONFIG_XEN xen)
 
 if(CONFIG_GEN_SW_ISR_TABLE)


### PR DESCRIPTION
Fixes #118671

### Problem

On AArch64, all accesses before the MMU is enabled are treated as
Device-nGnRnE, which the architecture requires to be naturally aligned. This is
independent of `SCTLR_ELx.A` — clearing the A bit (done in
`arch/arm64/core/reset.S`) relaxes alignment checking for Normal memory only; it
does not make unaligned Device accesses legal.

Reference: [https://support.arm.com/documentation/ka005452/1-0/](url)

The C code running in that window lives in this library (`reset.c` →
`z_prep_c()` in `prep_c.c` → `mmu.c`). Clang is free to lower struct assignments
and small copies there into 128-bit SIMD accesses. If such an access is not
16-byte aligned, it faults (data abort, `ESR_ELx.DFSC = 0b100001`) before the
console exists, so the symptom is a silent hang.

`arch/arm64/core/CMakeLists.txt` already guards against this instruction class
for GCC via `-moverride=tune=no_ldp_stp_qregs`. There is no clang equivalent —
clang rejects that argument outright:

    clang: error: unknown argument: '-moverride=tune=no_ldp_stp_qregs'

and it would be insufficient regardless, since it only suppresses `ldp/stp`
*pairs* while a single unaligned `stur q0, [x9, #-0x10]` still faults.

### Fix

Apply `-mstrict-align` to this library when compiling with clang.

`zephyr_library_compile_options()` is used deliberately instead of
`zephyr_cc_option()`: the latter appends to `zephyr_interface` and applies
image-wide, which would needlessly restrict code running with the MMU enabled.
This library is the only one containing pre-MMU C code.

`-mstrict-align` only forbids accesses the compiler cannot prove naturally
aligned; NEON arithmetic is retained. It does not affect assembly, so the FPU
context save/restore in `fpu.S` continues to use the Qn registers.

### Evidence

A 32-byte struct copy to a 16-byte-misaligned address, `-O2`:

    ldp q0, q1, [x8]
    stp q0, q1, [x8]        <-- 128-bit store, address is 8 mod 16

With `-mstrict-align`, the same source compiles to scalar `stp x` pairs.
128-bit register references in the object drop from 2 to 0.

### Testing

- Verified the code generation change on aarch64 at `-O2`.
- Carried downstream on a Qualcomm aarch64 platform, where the unfixed build
  hangs before console output and the fixed build boots.
- `qemu_cortex_a53` configures and builds.
