### PR TITLE
boards: shields: nxp_m2_wifi_bt: set regulatory region to US

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -67,7 +67,7 @@ endchoice
 if WIFI_NM_HOSTAPD_AP
 
 config WIFI_NM_HOSTAPD_REGULATORY_REGION
-	default "WW"
+	default "US"
 
 endif # WIFI_NM_HOSTAPD_AP
 


### PR DESCRIPTION
The default hostapd regulatory region for NXP M2 Wi-Fi/BT
shields was set to 'WW' (worldwide), which uses conservative
transmit power limits. This can cause FTM (Fine Timing
Measurement) session failures on IW612 when operating as
a SoftAP responder, because the reduced power is insufficient
for reliable FTM frame exchange.

Change the default to 'US' to allow higher transmit power,
which improves SoftAP FTM reliability and avoids session
failures during 802.11mc/az distance measurements.

Fixes: https://jira.sw.nxp.com/browse/WSW-76854