### PR TITLE
boards: nxp: mimxrt1064_evk: use SoC internal SPI flash controller

### DIFF
--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -27,7 +27,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &ext_flash_ctrl;
+		zephyr,flash-controller = &soc_flash_ctrl;
 		zephyr,flash = &w25q32jvwj0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;


### PR DESCRIPTION
The MIMXRT1064 integrates a dedicated on-die SPI flash memory, so the board's boot/XIP flash is driven by the SoC-internal flash controller rather than the external FlexSPI controller. Point the zephyr,flash-controller chosen node at &soc_flash_ctrl.

It was set wrongly by b1afb494b0c3b34534772bed0f10a3a61502dee5