### PR TITLE
drivers: audio: cs43l22: select GPIO (instead of depending on it)

### DIFF
--- a/drivers/audio/Kconfig.cs43l22
+++ b/drivers/audio/Kconfig.cs43l22
@@ -5,7 +5,7 @@ config AUDIO_CODEC_CS43L22
 	bool "Cirrus CS43L22 driver"
 	default y
 	select I2C
-	depends on GPIO
+	select GPIO
 	depends on DT_HAS_CIRRUS_CS43L22_ENABLED
 	help
 	  Enable the driver for the Cirrus CS43L22 low Power, stereo DAC


### PR DESCRIPTION
The CS43L22 is at the moment only used in two boards in-tree:
- stm32f4_disco
- stm32l476g_disco

These two boards are based on STM32, and recently GPIO was disabled by default on these series (see #109468). Therefore, any application using audio output would need to explicitely select GPIO, otherwise the CS43L22 audio codec is simply not selectable.

For other peripherals, GPIO is already pulled in as needed (see #110259, #112742, #112881). Because the CS43L22 *needs* GPIO, it makes more sense to simply select it.

This fixes samples/drivers/i2s/i2s_codec for stm32f4_disco.