### PR TITLE
drivers: sensor: adxl367: fix ODR ordering and make init self-test optional

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -1008,6 +1008,11 @@ static int adxl367_probe(const struct device *dev)
 	data->act_proc_mode = ADXL367_LOOPED;
 #endif
 
+	ret = adxl367_set_output_rate(dev, cfg->odr);
+	if (ret != 0) {
+		return ret;
+	}
+
 	ret = adxl367_self_test(dev);
 	if (ret != 0) {
 		return ret;
@@ -1044,11 +1049,6 @@ static int adxl367_probe(const struct device *dev)
 	}
 
 	ret = adxl367_set_inactivity_time(dev, cfg->inactivity_time);
-	if (ret != 0) {
-		return ret;
-	}
-
-	ret = adxl367_set_output_rate(dev, cfg->odr);
 	if (ret != 0) {
 		return ret;
 	}

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -1013,9 +1013,11 @@ static int adxl367_probe(const struct device *dev)
 		return ret;
 	}
 
-	ret = adxl367_self_test(dev);
-	if (ret != 0) {
-		return ret;
+	if (cfg->self_test_enable) {
+		ret = adxl367_self_test(dev);
+		if (ret != 0) {
+			return ret;
+		}
 	}
 
 	ret = adxl367_temp_read_en(dev, cfg->temp_en);
@@ -1150,7 +1152,8 @@ static int adxl367_init(const struct device *dev)
 		.fifo_config.fifo_samples = 128,					\
 		.fifo_config.fifo_read_mode = ADXL367_14B_CHID,				\
 		.op_mode = ADXL367_MEASURE,						\
-		.chip_id = chipid,
+		.chip_id = chipid,							\
+		.self_test_enable = DT_INST_PROP(inst, self_test_enable),
 
 /*
  * Instantiation macros used when a device is on a SPI bus.

--- a/drivers/sensor/adi/adxl367/adxl367.h
+++ b/drivers/sensor/adi/adxl367/adxl367.h
@@ -393,6 +393,7 @@ struct adxl367_dev_config {
 	bool autosleep;
 	bool low_noise;
 	bool temp_en;
+	bool self_test_enable;
 
 	struct adxl367_activity_threshold activity_th;
 	struct adxl367_activity_threshold inactivity_th;

--- a/dts/bindings/sensor/adi,adxl367-common.yaml
+++ b/dts/bindings/sensor/adi,adxl367-common.yaml
@@ -60,6 +60,14 @@ properties:
       - 2
       - 3
 
+  self-test-enable:
+    type: boolean
+    description: |
+      Run self-test on initialization.
+
+      Note: Enabling this property adds approximately 640ms delay during
+      device initialization.
+
 examples:
   - |
     #include <zephyr/dt-bindings/sensor/adxl367.h>


### PR DESCRIPTION
This PR contains two related changes to the ADXL367 driver's initialization path:

1. **Program ODR before running self-test.**
   `adxl367_self_test()` derives its `4 / ODR` settling delay from `cfg->odr`,
   but in the old probe flow `adxl367_set_output_rate()` was called *after* the
   self-test, so the device was still running at its reset-default rate
   (100 Hz) while the driver waited an interval derived from the DT-configured
   ODR. For `cfg->odr` ≤ 100 Hz this only meant a longer-than-needed wait, but
   for 200 Hz and 400 Hz the delay was shorter than `4 / 100 Hz`, which could
   cause the self-test to read stale acceleration and spuriously fail.
   Moving `adxl367_set_output_rate()` to run right after `adxl367_reset()`
   makes the self-test delay match the actual hardware ODR.

2. **Make the self-test at init opt-in via a new `self-test-enable` DT
   property.**
   Previously `adxl367_probe()` ran `adxl367_self_test()` unconditionally,
   which adds a noticeable delay to boot (~320 ms at the 12.5 Hz ODR).
   The new boolean property lets applications that do not need the self-test
   skip that cost. This mirrors the semantics already used by the sibling
   `adi,adxl355` driver, which uses the same property name.