### PR TITLE
drivers: gpio: xlnx_axi: add port_get_direction support

### DIFF
--- a/drivers/gpio/gpio_xlnx_axi.c
+++ b/drivers/gpio/gpio_xlnx_axi.c
@@ -198,6 +198,28 @@ static int gpio_xlnx_axi_port_toggle_bits(const struct device *dev, gpio_port_pi
 	return 0;
 }
 
+#ifdef CONFIG_GPIO_GET_DIRECTION
+static int gpio_xlnx_axi_port_get_direction(const struct device *dev, gpio_port_pins_t map,
+					    gpio_port_pins_t *inputs, gpio_port_pins_t *outputs)
+{
+	const struct gpio_xlnx_axi_config *config = dev->config;
+	const struct gpio_xlnx_axi_data *data = dev->data;
+
+	map &= config->common.port_pin_mask;
+
+	/* TRI register: bit=1 means INPUT (tristated), bit=0 means OUTPUT (driven) */
+	if (inputs != NULL) {
+		*inputs = map & data->tri;
+	}
+
+	if (outputs != NULL) {
+		*outputs = map & ~data->tri;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 /**
  * Enables interrupts for the given pins on the channel
@@ -373,6 +395,9 @@ static DEVICE_API(gpio, gpio_xlnx_axi_driver_api) = {
 	.port_set_bits_raw = gpio_xlnx_axi_port_set_bits_raw,
 	.port_clear_bits_raw = gpio_xlnx_axi_port_clear_bits_raw,
 	.port_toggle_bits = gpio_xlnx_axi_port_toggle_bits,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = gpio_xlnx_axi_port_get_direction,
+#endif /* CONFIG_GPIO_GET_DIRECTION */
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
 	.pin_interrupt_configure = gpio_xlnx_axi_pin_interrupt_configure,
 	.manage_callback = gpio_xlnx_axi_manage_callback,


### PR DESCRIPTION
Implements port_get_direction under CONFIG_GPIO_GET_DIRECTION, reporting each pin's direction from the shadow copy of the TRI register held in device data - a set bit means tristated (input), a cleared bit means driven (output) - masked against the port pin mask.
Test Details:
validated the new port_get_direction() using existing gpio_get_direction test suite, run on KCU105 board 