### PR TITLE
dap: bound and yield in the DAP_SWJ_Pins wait

### DIFF
--- a/subsys/dap/Kconfig
+++ b/subsys/dap/Kconfig
@@ -17,6 +17,24 @@ config CMSIS_DAP_PACKET_COUNT
 	help
 	  Maximum packet buffers for request and response data.
 
+config CMSIS_DAP_SWJ_PINS_MAX_WAIT_MS
+	int "Upper bound for the DAP_SWJ_Pins wait, in milliseconds"
+	default 3000
+	range 1 10000
+	help
+	  DAP_SWJ_Pins takes a 32-bit microsecond wait from the host, so a
+	  conformant host may legally ask the probe to wait over an hour.
+	  That wait is served on the thread that dispatches endpoint
+	  completions, so for its whole duration no other USB function of
+	  the device is serviced.
+
+	  The default matches the ARM CMSIS-DAP reference implementation,
+	  which caps this wait at 3 000 000 us in DAP.c. Composite devices
+	  that share the transport with other functions should set it far
+	  lower: a device buffering one 512-byte ring of a 115200-baud
+	  stream loses data after about 44 ms of stall, and 40 ms measured
+	  clean where 50 ms did not.
+
 config CMSIS_DAP_PROBE_VENDOR
 	string "Probe vendor"
 	default "Zephyr"

--- a/subsys/dap/cmsis_dap.c
+++ b/subsys/dap/cmsis_dap.c
@@ -270,7 +270,7 @@ static uint16_t dap_swj_pins(struct dap_link_context *const ctx,
 	uint8_t value = request[0];
 	uint8_t select = request[1];
 	uint32_t wait = sys_get_le32(&request[2]);
-	k_timepoint_t end = sys_timepoint_calc(K_USEC(wait));
+	k_timepoint_t end;
 	uint8_t state;
 
 	if (!atomic_test_bit(&ctx->state, DAP_STATE_CONNECTED)) {
@@ -279,20 +279,44 @@ static uint16_t dap_swj_pins(struct dap_link_context *const ctx,
 		return 1U;
 	}
 
+	/* Bound the host-supplied wait. This runs on the cooperative thread
+	 * that dispatches every endpoint completion, so the wait is not the
+	 * caller's to spend: nothing else on the device is serviced while it
+	 * elapses. The field is 32-bit microseconds, so a conformant host may
+	 * legally ask for over an hour; the reference implementation caps it
+	 * at 3 s.
+	 */
+	wait = MIN(wait, (uint32_t)CONFIG_CMSIS_DAP_SWJ_PINS_MAX_WAIT_MS * USEC_PER_MSEC);
+	end = sys_timepoint_calc(K_USEC(wait));
+
 	/* Skip if nothing selected. */
 	if (select) {
 		(void)swdp_set_pins(ctx->dev, select, value);
 	}
 
-	do {
+	for (;;) {
 		(void)swdp_get_pins(ctx->dev, &state);
-		LOG_INF("select 0x%02x, value 0x%02x, wait %u, state 0x%02x",
+		LOG_DBG("select 0x%02x, value 0x%02x, wait %u, state 0x%02x",
 			select, value, wait, state);
 		if ((value & select) == (state & select)) {
 			LOG_DBG("swdp_get_pins succeeded before timeout");
 			break;
 		}
-	} while (!sys_timepoint_expired(end));
+		/* Check expiry before sleeping so the common wait == 0 request,
+		 * which every stock host issues to set and read pins, stays a
+		 * single read with no sleep, as in the reference implementation.
+		 */
+		if (sys_timepoint_expired(end)) {
+			break;
+		}
+		/* Yield between polls. A cooperative thread that never sleeps
+		 * never yields, so spinning here starves every other thread for
+		 * the whole wait, at 100% CPU, for no gain: the pins are read
+		 * over a bit-banged transport and cannot change faster than
+		 * this.
+		 */
+		k_usleep(100);
+	}
 
 	response[0] = state;
 


### PR DESCRIPTION
### Why

`DAP_SWJ_Pins` lets the host say "set these pins, then wait until they read back". That wait is a 32-bit microsecond field, so a perfectly conformant host is allowed to ask the probe to wait **up to 71 minutes**.

Two things go wrong while it runs:

1. **The whole USB device stops responding.** `dap_link_execute_cmd()` is called directly from the USB class request handler in `subsys/dap/dap_backend_usb.c`, so this loop runs on the `usbd` thread — the thread that dispatches endpoint completions for *every* function on the device. On a probe that is only CMSIS-DAP nobody notices. On a composite device that also exposes, say, a CDC-ACM port, that port is dead for the whole wait.
2. **It spins at 100% CPU.** The loop polls without ever sleeping, and `usbd` is a cooperative thread, so a loop that never sleeps also never yields. Nothing else on the system runs at all.

This is not a corner case. Any time a host waits on a pin that does not reach the expected level — a target that does not release nRESET, for instance — the loop runs the host's full timeout.

We found it on our own composite probe firmware (CMSIS-DAP + a CDC-ACM UART bridge on one USB device, FRDM-MCXA156 / FRDM-MCXA153) built on this driver and `subsys/dap`.

### What this changes

- **Clamp** the wait to a new `CONFIG_CMSIS_DAP_SWJ_PINS_MAX_WAIT_MS`. The default is **3000**, which is the same cap ARM's reference implementation applies in [`DAP.c`](https://github.com/ARM-software/CMSIS-DAP/blob/main/Firmware/Source/DAP.c) (`if (wait > 3000000U) { wait = 3000000U; }`, in the timestamp-clock path). So out of the box nothing changes for any wait a reference probe would have honoured. Composite devices that share the transport can set it far lower.
- **Yield** — `k_usleep(100)` between polls. The pins are read over a bit-banged transport and cannot change faster than that, so the sleep costs no responsiveness.
- Expiry is checked **before** the sleep, so the common `wait == 0` request — what every stock host issues simply to set and read pins — stays a single read with no sleep, exactly as in the reference implementation.
- The per-iteration `LOG_INF` becomes `LOG_DBG`. At one line per poll it is itself a source of stall, and it is a debug aid rather than an info-level event.

### Supporting data

Measured on the probe firmware described above, with a CDC-ACM bridge carrying a 115200-baud stream on the same USB device. "Bytes lost" is data dropped from that stream while a single `DAP_SWJ_Pins` request is in flight.

| stall | bytes lost |
| --- | --- |
| 40 ms | **0** |
| 50 ms | 64 ← knee |
| 200 ms | 1 760 |
| 1000 ms | 10 752 |

The knee lands where the arithmetic puts it: a 512-byte ring at 11 520 B/s holds 44.4 ms.

**CPU cost of not yielding**, from idle-thread cycle counts read over SWD on two images differing only in the `k_usleep()`:

| | idle |
| --- | --- |
| spinning (before) | 2.7% |
| sleeping (after) | 88.1% |

**With the clamp applied**, a request asking for the 32-bit maximum returns in **40.5 ms** with pin state intact, and costs **0 bytes** on the concurrent bridge stream (worst observed HID latency 30.9 ms, against 1994 ms before).

Worth noting that the two halves do different work: yielding alone recovers about 58% of the loss at a 200 ms stall, because `sysworkq` drains the ring while the thread sleeps. So **yielding reduces loss, bounding removes it** — which is why this patch does both.

### A note on the response

The clamp is deliberately not visible to the host. The `DAP_SWJ_Pins` response carries pin state and has no field for "I stopped waiting early", so the device stays truthful about what it actually observed and is silently non-literal about duration. Inventing a wire signal for it would be a larger conformance departure than the clamp itself.

### Relationship to #117238 / #114549

Independent, and the files do not overlap — those change `sw_set_pins()`/`sw_get_pins()` in `drivers/dp/swdp_bitbang.c`; this changes the loop in `subsys/dap/cmsis_dap.c` that calls them.

They do interact in one direction worth mentioning: this loop's exit condition is `(value & select) == (state & select)`, so it depends on set and get agreeing about level convention. While they disagree — the bug #117238 reports — the compare can never match for the affected bit, and every such request runs the host's full timeout instead of returning early. That makes the unbounded wait easier to hit today, and it is a reason to bound it regardless of which convention #117238 settles on.

### Testing

- `samples/subsys/dap` builds and links for `nrf52840dk/nrf52840`.
- `scripts/checkpatch.pl` clean.
- Bench: FRDM-MCXA156 and FRDM-MCXA153 probes against FRDM-MCXN947 and STM32H503 targets — pyOCD connect / halt / memory read / flash / resume unaffected; our full firmware test suite shows no regression against a control image without the change.
