### PR TITLE
dap: DAP_Delay's parameter is microseconds, not milliseconds

### DIFF
--- a/subsys/dap/cmsis_dap.c
+++ b/subsys/dap/cmsis_dap.c
@@ -243,9 +243,19 @@ static uint16_t dap_delay(struct dap_link_context *const ctx,
 {
 	uint16_t delay = sys_get_le16(&request[0]);
 
-	LOG_DBG("dap delay %u ms", delay);
+	LOG_DBG("dap delay %u us", delay);
 
-	k_busy_wait(delay * USEC_PER_MSEC);
+	/* The DAP_Delay parameter is in microseconds, so it must not be
+	 * scaled by USEC_PER_MSEC. Sleep once the delay is long enough for
+	 * sleeping to be accurate; below a millisecond, busy-waiting is the
+	 * only way to be accurate. The worst legal delay is 65535 us, so no
+	 * clamp is needed here.
+	 */
+	if (delay < USEC_PER_MSEC) {
+		k_busy_wait(delay);
+	} else {
+		k_usleep(delay);
+	}
 	response[0] = DAP_OK;
 
 	return 1U;


### PR DESCRIPTION
### Why

The CMSIS-DAP `DAP_Delay` command carries a 16-bit delay **in microseconds**. `dap_delay()` multiplies it by `USEC_PER_MSEC` before busy-waiting, so every delay is **1000× longer than the host asked for**.

A host requesting 10 ms — i.e. sending 10000 — is held for **9.93 s**. Measured, not inferred.

And, as with `DAP_SWJ_Pins`, `dap_link_execute_cmd()` is called straight from the USB class request handler in `subsys/dap/dap_backend_usb.c`, so that wait runs on the `usbd` thread, which dispatches endpoint completions for every function on the device. For those 9.93 s the device services nothing at all — not just DAP.

### The unit is microseconds

- ARM's CMSIS-DAP specification, [DAP_Delay](https://arm-software.github.io/CMSIS-DAP/latest/group__DAP__Delay.html): *"Delay: wait time in µs."*
- ARM's reference [`DAP.c`](https://github.com/ARM-software/CMSIS-DAP/blob/main/Firmware/Source/DAP.c) scales the parameter by `CPU_CLOCK/1000000U` — i.e. treats one unit as one microsecond — before calling `PIN_DELAY_SLOW()`.
- CMSIS-Pack debug sequences pass `10000` where they mean 10 ms.

The existing `LOG_DBG` string says `"dap delay %u ms"`, which is consistent with the same misreading; it is corrected here too.

### What this changes

- Treat the parameter as microseconds — drop the `USEC_PER_MSEC` scaling.
- **Sleep rather than busy-wait** once the delay is long enough for sleeping to be accurate. Below a millisecond, busy-waiting is the only way to be accurate, so that path is kept.
- **No clamp is added**, deliberately. The field is 16-bit, so the worst legal delay is 65535 µs and no host can make it longer; and a delay is a deliberate request that the reference implementation honours exactly. Clamping it would refuse legal, intended delays for no gain in bound.

### Supporting data

| | requested | delivered |
| --- | --- | --- |
| before | 10 ms (10000 µs) | 9.93 s (×993) |
| after | 65535 µs — the worst legal case | 65.65 ms |

After the fix, the worst legal `DAP_Delay` costs **0 bytes** on a concurrent 115200-baud CDC-ACM stream sharing the same USB device, measured on our composite probe firmware (CMSIS-DAP + UART bridge, FRDM-MCXA156 / FRDM-MCXA153) built on `subsys/dap`.

### Compatibility — please read

This is a behaviour change, not only a bug fix: every existing host's delays become 1000× shorter. That is what the host asked for, but it is worth stating plainly.

The reason we think it is safe is asymmetry. The current bug makes delays *longer* than requested, and a delay that is too long is functionally invisible — it shows up as slowness, never as a protocol failure. So no existing user can have come to depend on the overshoot for correctness; they can only have been paying for it. Anything that was working keeps working, faster.

We have kept this separate from #118729 (the `DAP_SWJ_Pins` bound) on purpose, precisely because this one has an argument attached and that one should not be held hostage to it.

### Testing

- `samples/subsys/dap` builds and links for `nrf52840dk/nrf52840`.
- `scripts/checkpatch.pl` clean.
- Bench: FRDM-MCXA156 and FRDM-MCXA153 probes against FRDM-MCXN947 and STM32H503 targets — pyOCD connect / halt / memory read / flash / resume unaffected; our full firmware test suite shows no regression against a control image without the change.
