### PR TITLE
drivers: timer: cmsdk_apb_timer: add support for wuc

### DIFF
--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/drivers/wuc.h>
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/spinlock.h>
@@ -179,6 +180,11 @@ static int sys_clock_driver_init(void)
 {
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 	const struct tmr_cmsdk_apb_cfg *cfg = &cfg_inst0;
+	const struct wuc_dt_spec wuc = WUC_DT_SPEC_GET_OR(TIMER_NODE, {0});
+
+	if ((wuc.dev != NULL) && (wuc_enable_wakeup_source_dt(&wuc) != 0)) {
+		return -EIO;
+	}
 
 	data->last_elapsed = 0;
 	data->load = CYC_PER_TICK;

--- a/dts/bindings/counter/arm,cmsdk-timer.yaml
+++ b/dts/bindings/counter/arm,cmsdk-timer.yaml
@@ -2,7 +2,7 @@ description: ARM CMSDK timer
 
 compatible: "arm,cmsdk-timer"
 
-include: base.yaml
+include: [base.yaml, wuc-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
This allows to configure the CMSDK Timer as a wakeup source.