### PR TITLE
stm32: Add AES crypto support for HAL2 based SoCs (stm32c5xx)

### DIFF
--- a/boards/st/nucleo_c542rc/nucleo_c542rc.dts
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.dts
@@ -136,6 +136,14 @@
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &clk48 {
 	clocks = <&rcc STM32_SRC_PSIDIV3 CK48_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
@@ -10,6 +10,7 @@ supported:
   - arduino_i2c
   - arduino_serial
   - arduino_spi
+  - crypto
   - gpio
   - i2c
   - spi

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -249,3 +249,11 @@ zephyr_udc0: &usb {
 	phys = <&can_phy0>;
 	status = "okay";
 };
+
+&aes {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -13,6 +13,7 @@ supported:
   - arduino_spi
   - can
   - crc
+  - crypto
   - dac
   - entropy
   - gpio

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -147,6 +147,14 @@
 	status = "okay";
 };
 
+&hash {
+	status = "okay";
+};
+
+&aes {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.yaml
@@ -14,6 +14,7 @@ supported:
   - can
   - counter
   - crc
+  - crypto
   - dac
   - dma
   - entropy

--- a/drivers/crypto/Kconfig.stm32
+++ b/drivers/crypto/Kconfig.stm32
@@ -7,8 +7,9 @@ menuconfig CRYPTO_STM32
 	bool "STM32 Cryptographic Accelerator driver"
 	default y
 	depends on DT_HAS_ST_STM32_AES_ENABLED || DT_HAS_ST_STM32_CRYP_ENABLED
-	select USE_STM32_HAL_CRYP
-	select USE_STM32_HAL_CRYP_EX
+	select USE_STM32_HAL_AES if STM32_HAL2
+	select USE_STM32_HAL_CRYP if !STM32_HAL2
+	select USE_STM32_HAL_CRYP_EX if !STM32_HAL2
 	select RESET
 	help
 	  Enable STM32 HAL-based Cryptographic Accelerator driver.

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -81,8 +81,13 @@ static int crypto_stm32_ct_memcmp(const void *a, const void *b, size_t n)
 
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
 
+#ifdef CONFIG_STM32_HAL2
+#define HAL_CRYP_INIT_FN(handle)	HAL_AES_Init((handle), (handle)->instance)
+#define HAL_CRYP_DEINIT_FN(handle)	HAL_AES_DeInit(handle), HAL_OK
+#else
 #define HAL_CRYP_INIT_FN(handle)	HAL_CRYP_Init(handle)
 #define HAL_CRYP_DEINIT_FN(handle)	HAL_CRYP_DeInit(handle)
+#endif /* CONFIG_STM32_HAL2 */
 
 /**
  * @brief Function pointer type for AES encryption/decryption operations.
@@ -128,9 +133,14 @@ typedef stm32_status_t (*hal_cryp_aes_op_func_t)(hal_crypt_handle_t *hcryp, uint
 #define CAST_VEC(x) (uint32_t *)(x)
 #endif
 
-static void set_iv_ctr(crypt_config_t *config, uint32_t *iv)
+static void set_iv_ctr(crypt_config_t *config, uint32_t *iv, size_t iv_length)
 {
+#ifdef CONFIG_STM32_HAL2
+	config->iv = iv;
+	config->iv_length = iv_length;
+#else
 	config->pInitVect = CAST_VEC(iv);
+#endif /* CONFIG_STM32_HAL2 */
 }
 
 static int copy_words_adjust_endianness(uint8_t *dst_buf, int dst_len, const uint8_t *src_buf,
@@ -152,6 +162,41 @@ static int copy_words_adjust_endianness(uint8_t *dst_buf, int dst_len, const uin
 	return 0;
 }
 
+#ifdef CONFIG_STM32_HAL2
+static int hal2_set_config(struct crypto_stm32_data *const data, crypt_config_t *config)
+{
+	switch (config->mode) {
+	case CRYPTO_CIPHER_MODE_ECB:
+		if (HAL_AES_ECB_SetConfig(&data->hcryp) != HAL_OK) {
+			LOG_ERR("Configuration error");
+			return -EIO;
+		}
+		break;
+	case CRYPTO_CIPHER_MODE_CBC:
+		if (HAL_AES_CBC_SetConfig(&data->hcryp, config->iv) != HAL_OK) {
+			LOG_ERR("Configuration error");
+			return -EIO;
+		}
+		break;
+	case CRYPTO_CIPHER_MODE_CTR:
+		if (HAL_AES_CTR_SetConfig(&data->hcryp, config->iv) != HAL_OK) {
+			LOG_ERR("Configuration error");
+			return -EIO;
+		}
+		break;
+	default:
+		break;
+	}
+
+	if (HAL_AES_SetDataSwapping(&data->hcryp, HAL_AES_DATA_SWAPPING_BYTE) != HAL_OK)
+	{
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_STM32_HAL2 */
+
 static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in_buf, int in_len,
 		      uint8_t *out_buf)
 {
@@ -163,6 +208,12 @@ static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in
 	 * called below.
 	 */
 	memcpy(&data->hcryp.Init, &session->config, sizeof(session->config));
+#elif defined(CONFIG_STM32_HAL2)
+	int ret = hal2_set_config(data, &session->config);
+
+	if (ret < 0) {
+		return ret;
+	}
 #else
 	if (HAL_CRYP_SetConfig(&data->hcryp, &session->config) != HAL_OK) {
 		LOG_ERR("Configuration error");
@@ -182,15 +233,23 @@ static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in
 static stm32_status_t hal_encrypt(hal_crypt_handle_t *hcryp, uint8_t *pPlainData, uint16_t Size,
 				  uint8_t *pCypherData, uint32_t Timeout)
 {
+#ifdef CONFIG_STM32_HAL2
+	return HAL_AES_Encrypt(hcryp, pPlainData, Size, pCypherData, Timeout);
+#else
 	return HAL_CRYP_Encrypt(hcryp, (uint32_t *)pPlainData, Size, (uint32_t *)pCypherData,
 				Timeout);
+#endif /* CONFIG_STM32_HAL2 */
 }
 
 static stm32_status_t hal_decrypt(hal_crypt_handle_t *hcryp, uint8_t *pCypherData, uint16_t Size,
 				  uint8_t *pPlainData, uint32_t Timeout)
 {
+#ifdef CONFIG_STM32_HAL2
+	return HAL_AES_Decrypt(hcryp, pCypherData, Size, pPlainData, Timeout);
+#else
 	return HAL_CRYP_Decrypt(hcryp, (uint32_t *)pCypherData, Size, (uint32_t *)pPlainData,
 				Timeout);
+#endif /* CONFIG_STM32_HAL2 */
 }
 #endif
 
@@ -259,7 +318,7 @@ static int crypto_stm32_cbc_encrypt(struct cipher_ctx *ctx,
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
-	set_iv_ctr(&session->config, vec);
+	set_iv_ctr(&session->config, vec, BLOCK_LEN_BYTES);
 
 	if ((ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
 		/* Prefix IV to ciphertext unless CAP_NO_IV_PREFIX is set. */
@@ -291,7 +350,7 @@ static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
-	set_iv_ctr(&session->config, vec);
+	set_iv_ctr(&session->config, vec, BLOCK_LEN_BYTES);
 
 	if ((ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
 		in_offset = 16;
@@ -323,7 +382,7 @@ static int crypto_stm32_ctr_encrypt(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	set_iv_ctr(&session->config, ctr);
+	set_iv_ctr(&session->config, ctr, ivlen);
 
 	k_sem_take(&data->device_sem, K_FOREVER);
 
@@ -351,7 +410,7 @@ static int crypto_stm32_ctr_decrypt(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	set_iv_ctr(&session->config, ctr);
+	set_iv_ctr(&session->config, ctr, ivlen);
 
 	k_sem_take(&data->device_sem, K_FOREVER);
 
@@ -471,7 +530,7 @@ static int crypto_stm32_gcm(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn,
 
 	iv[3] = 2U;
 
-	set_iv_ctr(&session->config, iv);
+	set_iv_ctr(&session->config, iv, BLOCK_LEN_WORDS);
 
 	if ((apkt->ad == NULL) || (apkt->ad_len == 0U)) {
 		session->config.Header = NULL;
@@ -768,7 +827,11 @@ static int crypto_stm32_get_unused_session_index(const struct device *dev)
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 static bool hal_cryp_state_is_reset(hal_crypt_handle_t *hcryp)
 {
+#ifdef CONFIG_STM32_HAL2
+	return hcryp->global_state == HAL_AES_STATE_RESET;
+#else
 	return hcryp->State == HAL_CRYP_STATE_RESET;
+#endif /* CONFIG_STM32_HAL2 */
 }
 #endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) */
 
@@ -836,30 +899,34 @@ static int crypto_stm32_session_setup(const struct device *dev,
 	if (op_type == CRYPTO_CIPHER_OP_ENCRYPT) {
 		switch (mode) {
 		case CRYPTO_CIPHER_MODE_ECB:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_ECB;
 #endif
 			ctx->ops.block_crypt_hndlr = crypto_stm32_ecb_encrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CBC:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CBC;
 #endif
 			ctx->ops.cbc_crypt_hndlr = crypto_stm32_cbc_encrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CTR:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CTR;
 #endif
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_encrypt;
 			break;
 #if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
 		case CRYPTO_CIPHER_MODE_GCM:
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_GCM;
+#endif
 			ctx->ops.gcm_crypt_hndlr = crypto_stm32_gcm_encrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CCM:
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CCM;
+#endif
 			ctx->ops.ccm_crypt_hndlr = crypto_stm32_ccm_encrypt;
 			break;
 #endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
@@ -869,30 +936,34 @@ static int crypto_stm32_session_setup(const struct device *dev,
 	} else {
 		switch (mode) {
 		case CRYPTO_CIPHER_MODE_ECB:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_ECB;
 #endif
 			ctx->ops.block_crypt_hndlr = crypto_stm32_ecb_decrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CBC:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CBC;
 #endif
 			ctx->ops.cbc_crypt_hndlr = crypto_stm32_cbc_decrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CTR:
-#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CTR;
 #endif
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_decrypt;
 			break;
 #if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
 		case CRYPTO_CIPHER_MODE_GCM:
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_GCM;
+#endif
 			ctx->ops.gcm_crypt_hndlr = crypto_stm32_gcm_decrypt;
 			break;
 		case CRYPTO_CIPHER_MODE_CCM:
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) && !defined(CONFIG_STM32_HAL2)
 			session->config.Algorithm = CRYP_AES_CCM;
+#endif
 			ctx->ops.ccm_crypt_hndlr = crypto_stm32_ccm_decrypt;
 			break;
 #endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
@@ -907,6 +978,15 @@ static int crypto_stm32_session_setup(const struct device *dev,
 		return -EIO;
 	}
 
+#ifdef CONFIG_STM32_HAL2
+	if (HAL_AES_SetNormalKey(&CRYPTO_STM32_DATA(dev)->hcryp, ctx->keylen, session->key) !=
+	    HAL_OK)
+	{
+		return -EIO;
+	}
+
+	session->config.mode = mode;
+#else
 	switch (ctx->keylen) {
 	case 16U:
 		session->config.KeySize = CRYP_KEYSIZE_128B;
@@ -927,6 +1007,7 @@ static int crypto_stm32_session_setup(const struct device *dev,
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 	session->config.DataWidthUnit = CRYP_DATAWIDTHUNIT_BYTE;
 #endif
+#endif /* CONFIG_STM32_HAL2 */
 
 	ctx->drv_sessn_state = session;
 	ctx->device = dev;
@@ -1007,7 +1088,11 @@ static DEVICE_API(crypto, crypto_enc_funcs) = {
 
 static struct crypto_stm32_data crypto_stm32_dev_data = {
 	.hcryp = {
+#ifdef CONFIG_STM32_HAL2
+		.instance = (hal_aes_t)DT_INST_REG_ADDR(0),
+#else
 		.Instance = (STM32_CRYPTO_TYPEDEF *)DT_INST_REG_ADDR(0),
+#endif
 	}
 };
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>
+#include <stm32cube_hal.h>
 
 #include "crypto_stm32_priv.h"
 
@@ -80,14 +81,15 @@ static int crypto_stm32_ct_memcmp(const void *a, const void *b, size_t n)
 
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
 
-typedef HAL_StatusTypeDef status_t;
+#define HAL_CRYP_INIT_FN(handle)	HAL_CRYP_Init(handle)
+#define HAL_CRYP_DEINIT_FN(handle)	HAL_CRYP_DeInit(handle)
 
 /**
  * @brief Function pointer type for AES encryption/decryption operations.
  *
  * This type defines a function pointer for generic AES operations.
  *
- * @param hcryp       Pointer to a CRYP_HandleTypeDef structure that contains
+ * @param hcryp       Pointer to a @c hal_crypt_handle_t structure that contains
  *                    the configuration information for the CRYP module.
  * @param in_data     Pointer to input data (plaintext for encryption or ciphertext for decryption).
  * @param size        Length of the input data in bytes.
@@ -95,10 +97,11 @@ typedef HAL_StatusTypeDef status_t;
  * decryption).
  * @param timeout     Timeout duration in milliseconds.
  *
- * @retval status_t  HAL status of the operation.
+ * @retval HAL status of the operation.
  */
-typedef status_t (*hal_cryp_aes_op_func_t)(CRYP_HandleTypeDef *hcryp, uint8_t *in_data,
-					   uint16_t size, uint8_t *out_data, uint32_t timeout);
+typedef stm32_status_t (*hal_cryp_aes_op_func_t)(hal_crypt_handle_t *hcryp, uint8_t *in_data,
+						 uint16_t size, uint8_t *out_data,
+						 uint32_t timeout);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 #define hal_ecb_encrypt_op HAL_CRYP_AESECB_Encrypt
@@ -124,6 +127,11 @@ typedef status_t (*hal_cryp_aes_op_func_t)(CRYP_HandleTypeDef *hcryp, uint8_t *i
 #else
 #define CAST_VEC(x) (uint32_t *)(x)
 #endif
+
+static void set_iv_ctr(crypt_config_t *config, uint32_t *iv)
+{
+	config->pInitVect = CAST_VEC(iv);
+}
 
 static int copy_words_adjust_endianness(uint8_t *dst_buf, int dst_len, const uint8_t *src_buf,
 					int src_len)
@@ -171,15 +179,15 @@ static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in
 }
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
-static status_t hal_encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size,
-			    uint8_t *pCypherData, uint32_t Timeout)
+static stm32_status_t hal_encrypt(hal_crypt_handle_t *hcryp, uint8_t *pPlainData, uint16_t Size,
+				  uint8_t *pCypherData, uint32_t Timeout)
 {
 	return HAL_CRYP_Encrypt(hcryp, (uint32_t *)pPlainData, Size, (uint32_t *)pCypherData,
 				Timeout);
 }
 
-static status_t hal_decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size,
-			    uint8_t *pPlainData, uint32_t Timeout)
+static stm32_status_t hal_decrypt(hal_crypt_handle_t *hcryp, uint8_t *pCypherData, uint16_t Size,
+				  uint8_t *pPlainData, uint32_t Timeout)
 {
 	return HAL_CRYP_Decrypt(hcryp, (uint32_t *)pCypherData, Size, (uint32_t *)pPlainData,
 				Timeout);
@@ -251,7 +259,7 @@ static int crypto_stm32_cbc_encrypt(struct cipher_ctx *ctx,
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
-	session->config.pInitVect = CAST_VEC(vec);
+	set_iv_ctr(&session->config, vec);
 
 	if ((ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
 		/* Prefix IV to ciphertext unless CAP_NO_IV_PREFIX is set. */
@@ -283,7 +291,7 @@ static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
-	session->config.pInitVect = CAST_VEC(vec);
+	set_iv_ctr(&session->config, vec);
 
 	if ((ctx->flags & CAP_NO_IV_PREFIX) == 0U) {
 		in_offset = 16;
@@ -315,7 +323,7 @@ static int crypto_stm32_ctr_encrypt(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	session->config.pInitVect = CAST_VEC(ctr);
+	set_iv_ctr(&session->config, ctr);
 
 	k_sem_take(&data->device_sem, K_FOREVER);
 
@@ -343,7 +351,7 @@ static int crypto_stm32_ctr_decrypt(struct cipher_ctx *ctx,
 		return -EIO;
 	}
 
-	session->config.pInitVect = CAST_VEC(ctr);
+	set_iv_ctr(&session->config, ctr);
 
 	k_sem_take(&data->device_sem, K_FOREVER);
 
@@ -416,7 +424,7 @@ static int do_aes_staged(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint
 		data->hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ONCE;
 		data->hcryp.KeyIVConfig = 1;
 
-		const status_t fn_rc =
+		const stm32_status_t fn_rc =
 			fn(&data->hcryp, staging_in, rem_len, staging_out, HAL_MAX_DELAY);
 
 		/* restore key and iv init */
@@ -463,7 +471,7 @@ static int crypto_stm32_gcm(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn,
 
 	iv[3] = 2U;
 
-	session->config.pInitVect = CAST_VEC(iv);
+	set_iv_ctr(&session->config, iv);
 
 	if ((apkt->ad == NULL) || (apkt->ad_len == 0U)) {
 		session->config.Header = NULL;
@@ -757,6 +765,13 @@ static int crypto_stm32_get_unused_session_index(const struct device *dev)
 	return -1;
 }
 
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+static bool hal_cryp_state_is_reset(hal_crypt_handle_t *hcryp)
+{
+	return hcryp->State == HAL_CRYP_STATE_RESET;
+}
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) */
+
 static int crypto_stm32_session_setup(const struct device *dev,
 				      struct cipher_ctx *ctx,
 				      enum cipher_algo algo,
@@ -809,28 +824,14 @@ static int crypto_stm32_session_setup(const struct device *dev,
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(dev);
 
-	if (data->hcryp.State == HAL_CRYP_STATE_RESET) {
-		if (HAL_CRYP_Init(&data->hcryp) != HAL_OK) {
+	if (hal_cryp_state_is_reset(&data->hcryp)) {
+		if (HAL_CRYP_INIT_FN(&data->hcryp) != HAL_OK) {
 			LOG_ERR("Initialization error");
 			session->in_use = false;
 			return -EIO;
 		}
 	}
 #endif
-
-	switch (ctx->keylen) {
-	case 16U:
-		session->config.KeySize = CRYP_KEYSIZE_128B;
-		break;
-#if defined(STM32_CRYPTO_KEYSIZE_192B_SUPPORT)
-	case 24U:
-		session->config.KeySize = CRYP_KEYSIZE_192B;
-		break;
-#endif
-	case 32U:
-		session->config.KeySize = CRYP_KEYSIZE_256B;
-		break;
-	}
 
 	if (op_type == CRYPTO_CIPHER_OP_ENCRYPT) {
 		switch (mode) {
@@ -906,6 +907,20 @@ static int crypto_stm32_session_setup(const struct device *dev,
 		return -EIO;
 	}
 
+	switch (ctx->keylen) {
+	case 16U:
+		session->config.KeySize = CRYP_KEYSIZE_128B;
+		break;
+#if defined(STM32_CRYPTO_KEYSIZE_192B_SUPPORT)
+	case 24U:
+		session->config.KeySize = CRYP_KEYSIZE_192B;
+		break;
+#endif
+	case 32U:
+		session->config.KeySize = CRYP_KEYSIZE_256B;
+		break;
+	}
+
 	session->config.pKey = CAST_VEC(session->key);
 	session->config.DataType = CRYP_DATATYPE_8B;
 
@@ -942,7 +957,7 @@ static int crypto_stm32_session_free(const struct device *dev,
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 	/* Deinitialize and reset peripheral. */
-	if (HAL_CRYP_DeInit(&data->hcryp) != HAL_OK) {
+	if (HAL_CRYP_DEINIT_FN(&data->hcryp) != HAL_OK) {
 		LOG_ERR("Deinitialization error");
 		k_sem_give(&data->session_sem);
 		return -EIO;
@@ -975,7 +990,7 @@ static int crypto_stm32_init(const struct device *dev)
 	k_sem_init(&data->device_sem, 1, 1);
 	k_sem_init(&data->session_sem, 1, 1);
 
-	if (HAL_CRYP_DeInit(&data->hcryp) != HAL_OK) {
+	if (HAL_CRYP_DEINIT_FN(&data->hcryp) != HAL_OK) {
 		LOG_ERR("Peripheral reset error");
 		return -EIO;
 	}

--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -8,13 +8,19 @@
 #ifndef ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_PRIV_H_
 #define ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_PRIV_H_
 
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
+#ifdef CONFIG_STM32_HAL2
+typedef struct hal2_aes_config_data crypt_config_t;
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 #define crypt_config_t CRYP_InitTypeDef
 #else
 #define crypt_config_t CRYP_ConfigTypeDef
-#endif
+#endif /* CONFIG_STM32_HAL2 */
 
+#ifdef CONFIG_STM32_HAL2
+typedef hal_aes_handle_t	hal_crypt_handle_t;
+#else
 typedef CRYP_HandleTypeDef	hal_crypt_handle_t;
+#endif /* CONFIG_STM32_HAL2 */
 
 /* Maximum supported key length is 256 bits */
 #define CRYPTO_STM32_AES_MAX_KEY_LEN (256 / 8)
@@ -29,6 +35,15 @@ struct crypto_stm32_data {
 	struct k_sem device_sem;
 	struct k_sem session_sem;
 };
+
+#ifdef CONFIG_STM32_HAL2
+/* HAL2 does not define a structure for the AES operatiopn configure, hence this local one */
+struct hal2_aes_config_data {
+	enum cipher_mode mode;
+	uint32_t *iv;
+	size_t iv_length;
+};
+#endif /* CONFIG_STM32_HAL2 */
 
 struct crypto_stm32_session {
 	crypt_config_t config;

--- a/drivers/crypto/crypto_stm32_priv.h
+++ b/drivers/crypto/crypto_stm32_priv.h
@@ -14,6 +14,8 @@
 #define crypt_config_t CRYP_ConfigTypeDef
 #endif
 
+typedef CRYP_HandleTypeDef	hal_crypt_handle_t;
+
 /* Maximum supported key length is 256 bits */
 #define CRYPTO_STM32_AES_MAX_KEY_LEN (256 / 8)
 
@@ -23,7 +25,7 @@ struct crypto_stm32_config {
 };
 
 struct crypto_stm32_data {
-	CRYP_HandleTypeDef hcryp;
+	hal_crypt_handle_t hcryp;
 	struct k_sem device_sem;
 	struct k_sem session_sem;
 };

--- a/dts/arm/st/c5/stm32c542.dtsi
+++ b/dts/arm/st/c5/stm32c542.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/c5/stm32c532.dtsi>
+#include <st/c5/stm32c5_crypt.dtsi>
 
 / {
 	soc {

--- a/dts/arm/st/c5/stm32c562.dtsi
+++ b/dts/arm/st/c5/stm32c562.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/c5/stm32c552.dtsi>
+#include <st/c5/stm32c5_crypt.dtsi>
 
 / {
 	soc {

--- a/dts/arm/st/c5/stm32c5_crypt.dtsi
+++ b/dts/arm/st/c5/stm32c5_crypt.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		aes: crypto@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <68 0>;
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/c5/stm32c5a3.dtsi
+++ b/dts/arm/st/c5/stm32c5a3.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <st/c5/stm32c593.dtsi>
+#include <st/c5/stm32c5_crypt.dtsi>
 
 / {
 	soc {

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 9e579a021d6ed794a7c2a4777a4c5be552769035
+      revision: pull/408/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update **drivers/crypto/crypto_stm32.c** to support STM32 HAL2 based SoC.
Add `aes` nodes in applicable stm32c5xx SoCs DTSI files.
Enable `aes` and ` hash` nodes in stm32c5 based ST boards and enable crypto tests for them.