### PR TITLE
soc: stm32: common: Fix wakeup compilation of F1-like power controller

### DIFF
--- a/soc/st/stm32/common/pwr_wkupctrl.c
+++ b/soc/st/stm32/common/pwr_wkupctrl.c
@@ -106,6 +106,7 @@ struct wkup_pin_desc {
 	uint8_t src_select;
 };
 
+#if !DT_NODE_HAS_COMPAT(WKUP_CTLR, st_stm32f1_pwr_wkupctrl)
 static void ll_pwr_set_wake_up_line_polarity_low(uint32_t ll_wkup_line)
 {
 #if defined(CONFIG_SOC_SERIES_STM32U3X)
@@ -123,6 +124,7 @@ static void ll_pwr_set_wake_up_line_polarity_high(uint32_t ll_wkup_line)
 	LL_PWR_SetWakeUpPinPolarityHigh(ll_wkup_line);
 #endif
 }
+#endif /* !DT_NODE_HAS_COMPAT(WKUP_CTLR, st_stm32f1_pwr_wkupctrl) */
 
 static void ll_pwr_enable_wake_up_line(uint32_t ll_wkup_line)
 {


### PR DESCRIPTION
Add #ifdef for `ll_pwr_set_wake_up_line_polarity_*` functions that don't exist on F1-like power controller.

This fixes a compilation and CI issue.