### PR TITLE
scripts/kconfig: reject board redefinition of build system symbols

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -50,6 +50,8 @@ def main():
     kconf = Kconfig(args.kconfig_file, warn_to_stderr=False,
                     suppress_traceback=True)
 
+    check_board_sym_redefinition(kconf)
+
     if args.handwritten_input_configs:
         # Warn for assignments to undefined symbols, but only for handwritten
         # fragments, to avoid warnings-turned-errors when using an old
@@ -145,6 +147,39 @@ def main():
 
     # Write the list of parsed Kconfig files to a file
     write_kconfig_filenames(kconf, args.kconfig_list_out)
+
+
+def check_board_sym_redefinition(kconf):
+    # boards/Kconfig.v2 and the generated $KCONFIG_BOARD_DIR/Kconfig define
+    # BOARD_<board>, BOARD_<board target> and BOARD_REVISION_<revision> for
+    # the board being built. Board Kconfig files may only 'select' and 'imply'
+    # from these symbols. A type, prompt or default there keeps the symbol
+    # alive, silently, once the build system stops defining it.
+    board_dir = os.environ.get("KCONFIG_BOARD_DIR", "")
+    kconfig_v2 = os.path.join(os.environ.get("srctree", ""), "boards", "Kconfig.v2")
+
+    def generated(node):
+        path = os.path.abspath(os.path.join(os.environ.get("srctree", ""), node.filename))
+        return path == kconfig_v2 or (board_dir and path.startswith(board_dir + os.sep))
+
+    errors = []
+    for sym in kconf.unique_defined_syms:
+        gen_nodes = [node for node in sym.nodes if generated(node)]
+        if not gen_nodes:
+            continue
+
+        for node in sym.nodes:
+            if node in gen_nodes:
+                continue
+            if node.has_type or node.prompt or node.defaults or node.ranges:
+                errors.append(
+                    f"{sym.name} is defined by the build system at "
+                    f"{gen_nodes[0].filename}:{gen_nodes[0].linenr} and redefined at "
+                    f"{node.filename}:{node.linenr}. Board Kconfig files may only "
+                    f"'select' and 'imply' from it, not set a type, prompt or default.")
+
+    if errors:
+        err("\n\n".join(errors))
 
 
 def check_no_promptless_assign(kconf):

--- a/scripts/kconfig/kconfiglib.py
+++ b/scripts/kconfig/kconfiglib.py
@@ -3169,6 +3169,7 @@ class Kconfig(object):
             if t0 in _TYPE_TOKENS:
                 # Relies on '_T_BOOL is BOOL', etc., to save a conversion
                 self._set_type(node.item, t0)
+                node.has_type = True
                 if self._tokens[1] is not None:
                     self._parse_prompt(node)
 
@@ -3199,6 +3200,7 @@ class Kconfig(object):
 
             elif t0 in _DEF_TOKEN_TO_TYPE:
                 self._set_type(node.item, _DEF_TOKEN_TO_TYPE[t0])
+                node.has_type = True
                 node.defaults.append((self._parse_expr(False),
                                       self._parse_cond(), self.loc))
 
@@ -5682,6 +5684,11 @@ class MenuNode(object):
       Also includes dependencies inherited from surrounding menus and ifs.
       Choices appear in the dependencies of choice symbols.
 
+    has_type:
+      True if this definition of the item sets its type ('bool', 'def_bool',
+      'int', ...). An item defined in several places has the type set in at
+      least one of them; the other definitions can only add properties.
+
     is_menuconfig:
       Set to True if the children of the menu node should be displayed in a
       separate menu. This is the case for the following items:
@@ -5717,6 +5724,7 @@ class MenuNode(object):
     """
     __slots__ = (
         "dep",
+        "has_type",
         "help",
         "include_path",
         "is_menuconfig",
@@ -5745,6 +5753,7 @@ class MenuNode(object):
         self.selects = []
         self.implies = []
         self.ranges = []
+        self.has_type = False
 
     @property
     def filename(self):


### PR DESCRIPTION
boards/Kconfig.v2 and the generated board Kconfig define BOARD_\<board\>,
BOARD_\<board target\> and BOARD_REVISION_\<revision\> for the board being
built. Several board Kconfig files define the same symbol again with a
type, prompt or default. Kconfig merges the definitions silently, and
the extra definition keeps the symbol alive once the build system stops
generating it, so a renamed or removed board target goes unnoticed.

Fail the Kconfig step when a symbol defined by the build system is
redefined with a type, prompt, default or range outside of it. Adding
'select' and 'imply' properties stays allowed. The error names both
definitions.
