### PR TITLE
stm32: add hash/aes/cryp nodes in SoC DTSI files and enable them in ST boards

### DIFF
--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -245,6 +245,14 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &octospi1 {
 	pinctrl-0 = <&octospim_p1_clk_pe10 &octospim_p1_ncs_pe11
 		     &octospim_p1_io0_pe12 &octospim_p1_io1_pe13

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
@@ -10,6 +10,7 @@ flash: 2048
 supported:
   - arduino_gpio
   - arduino_i2c
+  - crypto
   - i2c
   - hts221
   - lps22hb

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.yaml
@@ -10,14 +10,14 @@ flash: 2048
 supported:
   - arduino_gpio
   - arduino_i2c
+  - bluetooth
   - crypto
-  - i2c
+  - gpio
   - hts221
+  - i2c
   - lps22hb
   - lsm6dsl
   - pwm
-  - gpio
-  - bluetooth
   - spi
   - vl53l0x
   - watchdog

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.dts
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.dts
@@ -179,6 +179,14 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&cryp {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &dma2 {
 	status = "okay";
 };

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
@@ -11,19 +11,19 @@ supported:
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
-  - netif:eth
-  - i2c
-  - ptp_clock
-  - spi
-  - gpio
-  - pwm
-  - counter
-  - usb_device
-  - watchdog
   - adc
+  - counter
   - crypto
   - dac
   - dma
+  - gpio
+  - i2c
+  - netif:eth
+  - ptp_clock
+  - pwm
   - rtc
+  - spi
   - usbd
+  - usb_device
+  - watchdog
 vendor: st

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.yaml
@@ -21,6 +21,7 @@ supported:
   - usb_device
   - watchdog
   - adc
+  - crypto
   - dac
   - dma
   - rtc

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -178,6 +178,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&rng {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -170,6 +170,14 @@ zephyr_udc0: &usbotg_fs {
 	};
 };
 
+&rng {
+	status = "okay";
+};
+
+&cryp {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
@@ -19,6 +19,7 @@ supported:
   - usb_device
   - i2c
   - pwm
+  - rng
   - spi
   - usbd
 vendor: st

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
@@ -8,18 +8,18 @@ toolchain:
 ram: 256
 flash: 1024
 supported:
-  - arduino_i2c
   - arduino_gpio
+  - arduino_i2c
   - arduino_spi
   - crypto
-  - ptp_clock
-  - uart
   - gpio
-  - netif:eth
-  - usb_device
   - i2c
+  - netif:eth
+  - ptp_clock
   - pwm
   - rng
   - spi
+  - uart
   - usbd
+  - usb_device
 vendor: st

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_i2c
   - arduino_gpio
   - arduino_spi
+  - crypto
   - ptp_clock
   - uart
   - gpio

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -260,3 +260,11 @@ zephyr_udc0: &usbotg_hs {
 	 */
 	status = "okay";
 };
+
+&cryp {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};

--- a/boards/st/nucleo_h7s3l8/twister.yaml
+++ b/boards/st/nucleo_h7s3l8/twister.yaml
@@ -14,6 +14,7 @@ supported:
   - octospi
   - can
   - canfd
+  - crypto
   - netif:eth
   - rtc
   - usbd

--- a/boards/st/nucleo_h7s3l8/twister.yaml
+++ b/boards/st/nucleo_h7s3l8/twister.yaml
@@ -4,20 +4,20 @@ arch: arm
 toolchain:
   - zephyr
 supported:
-  - gpio
-  - ptp_clock
-  - uart
-  - watchdog
-  - dma
-  - entropy
   - adc
-  - octospi
   - can
   - canfd
   - crypto
+  - dma
+  - entropy
+  - gpio
   - netif:eth
+  - octospi
+  - ptp_clock
   - rtc
+  - uart
   - usbd
+  - watchdog
 vendor: st
 variants:
   nucleo_h7s3l8/stm32h7s3xx:

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -362,6 +362,14 @@ csi_capture_port: &pipe_main {};
 	status = "okay";
 };
 
+&cryp {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -10,6 +10,7 @@ supported:
   - adc
   - backup_sram
   - can
+  - crypto
   - dma
   - i2c
   - gpio

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -190,6 +190,14 @@
 	status = "okay";
 };
 
+&aes {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &spi1 {
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6
 		     &spi1_mosi_pa7>;

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_spi
   - can
   - crc
+  - crypto
   - dac
   - dma
   - gpio

--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.dts
@@ -55,3 +55,11 @@
 &rng {
 	status = "okay";
 };
+
+&aes {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};

--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.yaml
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q.yaml
@@ -11,6 +11,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - can
+  - crypto
   - gpio
   - i2c
   - spi

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.yaml
@@ -6,16 +6,16 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
-  - gpio
-  - i2c
-  - spi
-  - adc
-  - rng
-  - crypto
-  - usbd
   - arduino_gpio
   - arduino_i2c
   - arduino_spi
+  - adc
+  - crypto
+  - gpio
+  - i2c
+  - rng
+  - spi
+  - usbd
 ram: 448
 flash: 2048
 vendor: st

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -510,3 +510,11 @@ zephyr_jpegenc: &jpeg {
 &gpu2d {
 	status = "okay";
 };
+
+&cryp {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};

--- a/boards/st/stm32h7s78_dk/twister.yaml
+++ b/boards/st/stm32h7s78_dk/twister.yaml
@@ -7,6 +7,7 @@ supported:
   - adc
   - arduino_gpio
   - crc
+  - crypto
   - dma
   - entropy
   - gpio

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -41,6 +41,10 @@
 	status = "okay";
 };
 
+&hash {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.yaml
@@ -12,6 +12,7 @@ supported:
   - bluetooth
   - counter
   - crc
+  - crypto
   - dac
   - dma
   - gpio

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -639,6 +639,14 @@ zephyr_jpegenc: &jpeg {
 	status = "okay";
 };
 
+&cryp {
+	status = "okay";
+};
+
+&hash {
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -13,6 +13,7 @@ supported:
   - can
   - counter
   - crc
+  - crypto
   - dma
   - dmic
   - i2c

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -256,3 +256,7 @@ zephyr_udc0: &usb {
 		 <&rcc STM32_SRC_HSI48 CLK48_SEL(1)>;
 	status = "okay";
 };
+
+&aes {
+	status = "okay";
+};

--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -19,5 +19,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f4/stm32f439.dtsi
+++ b/dts/arm/st/f4/stm32f439.dtsi
@@ -18,5 +18,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f4/stm32f479.dtsi
+++ b/dts/arm/st/f4/stm32f479.dtsi
@@ -17,5 +17,14 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			interrupts = <80 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f7/stm32f750.dtsi
+++ b/dts/arm/st/f7/stm32f750.dtsi
@@ -9,5 +9,25 @@
 / {
 	soc {
 		compatible = "st,stm32f750", "st,stm32f7", "simple-bus";
+
+		cryp: crypto@50060000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			/* HASH interrupt is shared with RNG, but not yet supported.
+			 * interrupts = <80 0>;
+			 */
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/f7/stm32f756.dtsi
+++ b/dts/arm/st/f7/stm32f756.dtsi
@@ -9,5 +9,25 @@
 / {
 	soc {
 		compatible = "st,stm32f756", "st,stm32f7", "simple-bus";
+
+		cryp: crypto@50060000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			resets = <&rctl STM32_RESET(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			/* HASH interrupt is shared with RNG, but not yet supported.
+			 * interrupts = <80 0>;
+			 */
+			status = "okay";
+		};
 	};
 };

--- a/dts/arm/st/f7/stm32f777.dtsi
+++ b/dts/arm/st/f7/stm32f777.dtsi
@@ -18,5 +18,16 @@
 			interrupts = <79 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			resets = <&rctl STM32_RESET(AHB2, 5)>;
+			/* HASH interrupt is shared with RNG, but not yet supported.
+			 * interrupts = <80 0>;
+			 */
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g441.dtsi
+++ b/dts/arm/st/g4/stm32g441.dtsi
@@ -9,5 +9,14 @@
 / {
 	soc {
 		compatible = "st,stm32g441", "st,stm32g4", "simple-bus";
+
+		aes: crypto@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>;
+			resets = <&rctl STM32_RESET(AHB2, 24)>;
+			interrupts = <85 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g483.dtsi
+++ b/dts/arm/st/g4/stm32g483.dtsi
@@ -9,5 +9,14 @@
 / {
 	soc {
 		compatible = "st,stm32g483", "st,stm32g4", "simple-bus";
+
+		aes: crypto@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>;
+			resets = <&rctl STM32_RESET(AHB2, 24)>;
+			interrupts = <85 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g484.dtsi
+++ b/dts/arm/st/g4/stm32g484.dtsi
@@ -9,5 +9,14 @@
 / {
 	soc {
 		compatible = "st,stm32g484", "st,stm32g4", "simple-bus";
+
+		aes: crypto@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>;
+			resets = <&rctl STM32_RESET(AHB2, 24)>;
+			interrupts = <85 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/g4/stm32g4a1.dtsi
+++ b/dts/arm/st/g4/stm32g4a1.dtsi
@@ -9,5 +9,14 @@
 / {
 	soc {
 		compatible = "st,stm32g4a1", "st,stm32g4", "simple-bus";
+
+		aes: crypto@50060000 {
+			compatible = "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 24)>;
+			resets = <&rctl STM32_RESET(AHB2, 24)>;
+			interrupts = <85 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1120,6 +1120,15 @@
 			status = "disabled";
 		};
 
+		hash: crypto@48020400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48020400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 1)>;
+			resets = <&rctl STM32_RESET(AHB3, 1)>;
+			interrupts = <36 0>;
+			status = "disabled";
+		};
+
 		mac: ethernet@40028000 {
 			compatible = "st,stm32h7-ethernet", "st,stm32-ethernet", "snps,dwmac";
 			reg = <0x40028000 0x8000>;

--- a/dts/arm/st/h7rs/stm32h7s3.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s3.dtsi
@@ -12,6 +12,15 @@
 / {
 	soc {
 		compatible = "st,stm32h7s3", "st,stm32h7rs", "simple-bus";
+
+		cryp: crypto@48020800 {
+			compatible = "st,stm32-cryp";
+			reg = <0x48020800 0x800>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 2)>;
+			resets = <&rctl STM32_RESET(AHB3, 2)>;
+			interrupts = <34 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/st/h7rs/stm32h7s7.dtsi
+++ b/dts/arm/st/h7rs/stm32h7s7.dtsi
@@ -12,6 +12,15 @@
 / {
 	soc {
 		compatible = "st,stm32h7s7", "st,stm32h7rs", "simple-bus";
+
+		cryp: crypto@48020800 {
+			compatible = "st,stm32-cryp";
+			reg = <0x48020800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 2)>;
+			resets = <&rctl STM32_RESET(AHB3, 2)>;
+			interrupts = <34 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/st/l0/stm32l083.dtsi
+++ b/dts/arm/st/l0/stm32l083.dtsi
@@ -13,9 +13,13 @@
 		aes: crypto@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
-			resets = <&rctl STM32_RESET(AHB1, 16)>;
-			interrupts = <31 0>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 24)>;
+			resets = <&rctl STM32_RESET(AHB1, 24)>;
+			/* Interrupt is shared with RNG and LPUART1.
+			 * Driver does not yet support it hence we don't define it
+			 * interrupts = <29 0>;
+			 */
+			gcm-ccm-supported;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -10,5 +10,13 @@
 / {
 	soc {
 		compatible = "st,stm32l462", "st,stm32l4", "simple-bus";
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -10,5 +10,13 @@
 / {
 	soc {
 		compatible = "st,stm32l486", "st,stm32l4", "simple-bus";
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -10,5 +10,13 @@
 / {
 	soc {
 		compatible = "st,stm32l4a6", "st,stm32l4", "simple-bus";
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -458,6 +458,14 @@
 			status = "disabled";
 		};
 
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			status = "disabled";
+		};
+
 		rng: rng@50060800 {
 			nist-config = <0xf00d00>;
 			health-test-magic = <0x17590abc>;

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -10,5 +10,13 @@
 / {
 	soc {
 		compatible = "st,stm32l4q5", "st,stm32l4", "simple-bus";
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -10,5 +10,13 @@
 / {
 	soc {
 		compatible = "st,stm32l4s5", "st,stm32l4", "simple-bus";
+
+		hash: crypto@50060400 {
+			compatible = "st,stm32-hash";
+			reg = <0x50060400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -5,17 +5,27 @@
  */
 
 #include <st/l4/stm32l4r5.dtsi>
-#include <st/l4/stm32l4_crypt.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32l4s5", "st,stm32l4", "simple-bus";
+
+		aes: crypto@50060000 {
+			compatible = "st,stm32l4-aes", "st,stm32-aes";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2, 16)>;
+			interrupts = <79 0>;
+			interrupt-names = "aes";
+			status = "disabled";
+		};
 
 		hash: crypto@50060400 {
 			compatible = "st,stm32-hash";
 			reg = <0x50060400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
 			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			interrupts = <82 0>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -513,6 +513,15 @@
 			status = "disabled";
 		};
 
+		hash: crypto@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			interrupts = <96 0>;
+			status = "disabled";
+		};
+
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;

--- a/dts/arm/st/n6/stm32n657.dtsi
+++ b/dts/arm/st/n6/stm32n657.dtsi
@@ -9,5 +9,23 @@
 / {
 	soc {
 		compatible = "st,stm32n657", "st,stm32n6", "simple-bus";
+
+		cryp: crypto@54020800 {
+			compatible = "st,stm32-cryp";
+			reg = <0x54020800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 2)>;
+			resets = <&rctl STM32_RESET(AHB3, 2)>;
+			interrupts = <37 0>;
+			status = "disabled";
+		};
+
+		hash: crypto@54020400 {
+			compatible = "st,stm32-hash";
+			reg = <0x54020400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 1)>;
+			resets = <&rctl STM32_RESET(AHB3, 1)>;
+			interrupts = <39 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/u0/stm32u083.dtsi
+++ b/dts/arm/st/u0/stm32u083.dtsi
@@ -18,5 +18,16 @@
 			interrupts = <30 0>;
 			status = "disabled";
 		};
+
+		aes: crypto@40026000 {
+			compatible = "st,stm32-aes";
+			reg = <0x40026000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
+			resets = <&rctl STM32_RESET(AHB1, 16)>;
+			/* Interrupt is shared with RNG but driver does not yet support it
+			 * interrupts = <31 0>;
+			 */
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/u3/stm32u385.dtsi
+++ b/dts/arm/st/u3/stm32u385.dtsi
@@ -9,5 +9,23 @@
 / {
 	soc {
 		compatible = "st,stm32u385", "st,stm32u3", "simple-bus";
+
+		aes: crypto@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2L, 16)>;
+			interrupts = <93 0>;
+			status = "disabled";
+		};
+
+		hash: crypto@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2L, 17)>;
+			interrupts = <61 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/u3/stm32u3c5.dtsi
+++ b/dts/arm/st/u3/stm32u3c5.dtsi
@@ -30,5 +30,23 @@
 				};
 			};
 		};
+
+		aes: crypto@420c0000 {
+			compatible = "st,stm32-aes";
+			reg = <0x420c0000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
+			resets = <&rctl STM32_RESET(AHB2L, 16)>;
+			interrupts = <93 0>;
+			status = "disabled";
+		};
+
+		hash: crypto@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2L, 17)>;
+			interrupts = <96 0>;
+			status = "disabled";
+		};
 	};
 };

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -562,6 +562,15 @@
 			status = "disabled";
 		};
 
+		hash: crypto@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			interrupts = <61 0>;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/dts/arm/st/wba/stm32wba23.dtsi
+++ b/dts/arm/st/wba/stm32wba23.dtsi
@@ -58,6 +58,10 @@
 			interrupts = <52 0>;
 		};
 
+		hash: crypto@420c0400 {
+			interrupts = <55 0>;
+		};
+
 		rng: rng@420c0800 {
 			interrupts = <53 0>;
 		};

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -529,7 +529,7 @@
 			compatible = "st,stm32-aes";
 			reg = <0x58001800 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB3, 17)>;
-			resets = <&rctl STM32_RESET(AHB3, 16)>;
+			resets = <&rctl STM32_RESET(AHB3, 17)>;
 			interrupts = <51 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/wl3/stm32wl3x.dtsi
+++ b/dts/arm/st/wl3/stm32wl3x.dtsi
@@ -15,6 +15,7 @@
 / {
 	chosen {
 		zephyr,flash-controller = &flash;
+		zephyr,entropy = &rng;
 	};
 
 	cpus {
@@ -177,6 +178,22 @@
 				 <&rcc STM32_SRC_CLK_ROOT_DIV NO_SEL>;
 			resets = <&rctl STM32_RESET(APB1, 10)>;
 			interrupts = <8 0>;
+			status = "disabled";
+		};
+
+		rng: rng@48600000 {
+			compatible = "st,stm32-rng-noirq";
+			reg = <0x48600000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB0, 18)>;
+			status = "disabled";
+		};
+
+		aes: crypto@48900000 {
+			compatible = "st,stm32-aes";
+			reg = <0x48900000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB0, 20)>;
+			resets = <&rctl STM32_RESET(AHB0, 20)>;
+			interrupts = <13 0>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Add `aes`, `cryp` and `hash` nodes in STM32 SoC DTSI files where these crypto HW assistance is applicable
Fix stm32l0xx and stm32wlxx inetrrupt description for the `aes` node.
Enable these nodes in some ST boards to ease non-regression testing.
Alphabetize `supported` tag list in some ST board YAML files.

These changes, together with https://github.com/zephyrproject-rtos/zephyr/pull/118739, aims at better defining which STM32 SoC have some HW crypto assistance, and will help their integration as PSA Crypto Drivers in a latter change.