### PR TITLE
usb: host: choose first used device configuration 

### DIFF
--- a/subsys/usb/host/usbh_class.c
+++ b/subsys/usb/host/usbh_class.c
@@ -14,6 +14,20 @@
 
 LOG_MODULE_REGISTER(usbh_class, CONFIG_USBH_LOG_LEVEL);
 
+bool usbh_class_is_any_iface_bound(struct usb_device *const udev)
+{
+	STRUCT_SECTION_FOREACH(usbh_class_node, c_node) {
+		struct usbh_class_data *const c_data = c_node->c_data;
+
+		if (c_node->state == USBH_CLASS_STATE_BOUND &&
+		    c_data->udev == udev) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void usbh_class_init_all(void)
 {
 	int ret;

--- a/subsys/usb/host/usbh_class.h
+++ b/subsys/usb/host/usbh_class.h
@@ -35,6 +35,16 @@ bool usbh_class_is_matching(const struct usbh_class_filter *const filter_rules,
 			    const struct usbh_class_filter *const filtered_data);
 
 /**
+ * @brief Check if any drivers are bound to a device interface.
+ *
+ * @param[in] udev USB device to probe.
+ *
+ * @retval true if a driver is bound to an interface
+ * @retval false if no drivers are bound to an interface
+ */
+bool usbh_class_is_any_iface_bound(struct usb_device *const udev);
+
+/**
  * @brief Initialize all available host class instances.
  */
 void usbh_class_init_all(void);

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -362,6 +362,9 @@ static void reset_configuration(struct usb_device *const udev)
  * configuration. If something fails, the device state will be set to addressed
  * and all resources will be released. We could increase resilience by reading
  * all configuration descriptors at once, but that would increase memory usage.
+ *
+ * TODO: Although almost everything is in place, there should be tests covering
+ * it before it is made a public interface for users and applications.
  */
 int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t num)
 {
@@ -381,6 +384,7 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 	}
 
 	/* Free any allocated resources unconditionally */
+	usbh_class_remove_all(udev);
 	k_heap_free(&usb_device_heap, udev->cfg_desc);
 	udev->cfg_desc = NULL;
 	reset_configuration(udev);
@@ -464,6 +468,8 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 
 	udev->actual_cfg = num;
 	udev->state = USB_STATE_CONFIGURED;
+
+	usbh_class_probe_device(udev);
 
 error:
 	k_mutex_unlock(&udev->mutex);
@@ -564,11 +570,6 @@ int usbh_device_init(struct usb_device *const udev)
 		goto error;
 	}
 
-	err = usbh_device_set_configuration(udev, 1);
-	if (err) {
-		LOG_ERR("Failed to configure new device with address %u", udev->addr);
-	}
-
 error:
 	k_mutex_unlock(&udev->mutex);
 
@@ -599,7 +600,10 @@ void usbh_device_connect(struct usbh_context *const ctx,
 		return;
 	}
 
-	usbh_class_probe_device(udev);
+	err = usbh_device_set_configuration(udev, 1);
+	if (err) {
+		LOG_ERR("Failed to configure new device with address %u", udev->addr);
+	}
 }
 
 void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -491,46 +491,6 @@ struct usb_device *usbh_device_get_root(struct usbh_context *const ctx)
 	return ctx->root;
 }
 
-void usbh_device_connect(struct usbh_context *const ctx,
-			 struct usb_device *const udev)
-{
-	int err;
-
-	LOG_DBG("Device connected event");
-
-	udev->state = USB_STATE_DEFAULT;
-
-	if (ctx->root == NULL) {
-		ctx->root = udev;
-	}
-
-	err = usbh_device_init(udev);
-	if (err != 0) {
-		LOG_ERR("Failed to init new USB device");
-		if (usbh_device_is_root(ctx, udev)) {
-			ctx->root = NULL;
-		}
-
-		usbh_device_free(udev);
-		return;
-	}
-
-	usbh_class_probe_device(udev);
-}
-
-void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
-{
-	usbh_class_remove_all(udev);
-
-	if (usbh_device_is_root(ctx, udev)) {
-		ctx->root = NULL;
-	}
-
-	usbh_device_free(udev);
-
-	LOG_DBG("Device removed");
-}
-
 int usbh_device_init(struct usb_device *const udev)
 {
 	struct usbh_context *const uhs_ctx = udev->ctx;
@@ -607,4 +567,44 @@ error:
 	k_mutex_unlock(&udev->mutex);
 
 	return err;
+}
+
+void usbh_device_connect(struct usbh_context *const ctx,
+			 struct usb_device *const udev)
+{
+	int err;
+
+	LOG_DBG("Device connected event");
+
+	udev->state = USB_STATE_DEFAULT;
+
+	if (ctx->root == NULL) {
+		ctx->root = udev;
+	}
+
+	err = usbh_device_init(udev);
+	if (err != 0) {
+		LOG_ERR("Failed to init new USB device");
+		if (usbh_device_is_root(ctx, udev)) {
+			ctx->root = NULL;
+		}
+
+		usbh_device_free(udev);
+		return;
+	}
+
+	usbh_class_probe_device(udev);
+}
+
+void usbh_device_disconnect(struct usbh_context *ctx, struct usb_device *udev)
+{
+	usbh_class_remove_all(udev);
+
+	if (usbh_device_is_root(ctx, udev)) {
+		ctx->root = NULL;
+	}
+
+	usbh_device_free(udev);
+
+	LOG_DBG("Device removed");
 }

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -357,6 +357,12 @@ static void reset_configuration(struct usb_device *const udev)
 	udev->state = USB_STATE_ADDRESSED;
 }
 
+/*
+ * usbh_device_set_configuration() does not attempt to restore the previous
+ * configuration. If something fails, the device state will be set to addressed
+ * and all resources will be released. We could increase resilience by reading
+ * all configuration descriptors at once, but that would increase memory usage.
+ */
 int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t num)
 {
 	struct usb_cfg_descriptor cfg_desc;
@@ -374,8 +380,12 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 		goto error;
 	}
 
+	/* Free any allocated resources unconditionally */
+	k_heap_free(&usb_device_heap, udev->cfg_desc);
+	udev->cfg_desc = NULL;
+	reset_configuration(udev);
+
 	if (num == 0) {
-		reset_configuration(udev);
 		err = usbh_req_set_cfg(udev, num);
 		if (err) {
 			LOG_ERR("Set Configuration %u request failed", num);
@@ -426,10 +436,6 @@ int usbh_device_set_configuration(struct usb_device *const udev, const uint8_t n
 	}
 
 	memset(udev->cfg_desc, 0, cfg_desc.wTotalLength + sizeof(struct usb_desc_header));
-	if (udev->state == USB_STATE_CONFIGURED) {
-		reset_configuration(udev);
-	}
-
 	err = usbh_req_desc_cfg(udev, idx, cfg_desc.wTotalLength, udev->cfg_desc);
 	if (err) {
 		LOG_ERR("Failed to read configuration descriptor of %u bytes: %d",

--- a/subsys/usb/host/usbh_device.c
+++ b/subsys/usb/host/usbh_device.c
@@ -600,9 +600,24 @@ void usbh_device_connect(struct usbh_context *const ctx,
 		return;
 	}
 
-	err = usbh_device_set_configuration(udev, 1);
-	if (err) {
-		LOG_ERR("Failed to configure new device with address %u", udev->addr);
+	/*
+	 * For now, choosing the configuration is quite simple. If a current
+	 * configuration is not used by any driver, try the next one. There is
+	 * no reason to revert to first configuration if no driver uses
+	 * anything.
+	 */
+	for (int n = 1; n < udev->dev_desc.bNumConfigurations + 1; n++) {
+		err = usbh_device_set_configuration(udev, n);
+		if (err) {
+			LOG_ERR("Failed to set device %u configuration to %u",
+				udev->addr, n);
+			break;
+		}
+
+		LOG_DBG("Set device %u configuration to %u", udev->addr, n);
+		if (usbh_class_is_any_iface_bound(udev)) {
+			break;
+		}
 	}
 }
 


### PR DESCRIPTION
Prepare usbh_device_set_configuration() to become a user or application
interface in the future. After device initialization, choose first used
device configuration.

