### PR TITLE
drivers: uhc: max3421e: Handle multi-packet IN transfers

### DIFF
--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -495,7 +495,7 @@ static int max3421e_hrslt_success(const struct device *dev)
 
 		LOG_INF("bc %u tr %u", bc, net_buf_tailroom(buf));
 
-		if (bc < MAX3421E_MAX_EP_SIZE || !net_buf_tailroom(buf)) {
+		if (bc < xfer->mps || !net_buf_tailroom(buf)) {
 			LOG_INF("hrslt bulk in %u, %u", bc, len);
 			if (xfer->ep == USB_CONTROL_EP_IN) {
 				xfer->stage = UHC_CONTROL_STAGE_STATUS;


### PR DESCRIPTION
Use the endpoint maximum packet size when deciding whether an IN transfer ended with a short packet. Comparing the received byte count against the controller maximum incorrectly completes transfers on endpoints with smaller packets.

This allows descriptor transfers from low-speed devices, whose endpoint zero maximum packet size is eight bytes, to span multiple packets.

Note: this is related to #110420.