### PR TITLE
usb: host: hid_boot: Implement USB host HID Boot class

### DIFF
--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -19,6 +19,13 @@ USB_BUF_POOL_VAR_DEFINE(uhc_ep_pool,
 			CONFIG_UHC_BUF_COUNT, CONFIG_UHC_BUF_POOL_SIZE,
 			0, NULL);
 
+int uhc_common_init(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	return k_mutex_init(&data->mutex);
+}
+
 int uhc_submit_event(const struct device *dev,
 		     const enum uhc_event_type type,
 		     const int status)
@@ -182,6 +189,58 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
+
+	return 0;
+}
+
+static void uhc_xfer_dlist_cleanup_cancelled(const struct device *dev, sys_dlist_t *dlist)
+{
+	struct uhc_transfer *tmp;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (tmp->err == -ECONNRESET) {
+			uhc_xfer_return(dev, tmp, -ECONNRESET);
+		}
+	}
+}
+
+void uhc_xfer_cleanup_cancelled(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+}
+
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *tmp;
+	sys_dlist_t *dlist;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		dlist = &data->ctrl_xfers;
+		break;
+	case USB_EP_TYPE_BULK:
+		dlist = &data->bulk_xfers;
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		dlist = &data->periodic_xfers;
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
+		if (xfer == tmp) {
+			tmp->err = -ECONNRESET;
+			break;
+		}
 	}
 
 	return 0;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -171,8 +171,26 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 	return xfer;
 }
 
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer)
+static int uhc_xfer_add_new_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				     uint32_t frame_number)
+{
+	if (xfer->interval == 0) {
+		LOG_ERR("Tried to schedule a periodic xfer that has interval equal to 0");
+		return -EINVAL;
+	}
+
+	xfer->start_frame = frame_number + xfer->interval;
+
+	LOG_DBG("New periodic transfer s.f. %u f.n. %u interval %u", xfer->start_frame,
+		frame_number, xfer->interval);
+
+	uhc_xfer_add_periodic(dev, xfer);
+
+	return 0;
+}
+
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 
@@ -185,8 +203,7 @@ int uhc_xfer_append(const struct device *dev,
 		break;
 	case USB_EP_TYPE_ISO:
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_periodic(dev, xfer);
-		break;
+		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
 	}

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -92,21 +93,72 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
+static enum uhc_xfer_mask uhc_xfer_type_to_mask(const struct uhc_transfer *xfer)
+{
+	return BIT(xfer->type);
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
+						       uint32_t frame_number,
+						       enum uhc_xfer_mask mask,
+						       uhc_xfer_filter_func_t filter, void *priv)
 {
 	struct uhc_data *data = dev->data;
-	struct uhc_transfer *xfer;
+	struct uhc_transfer *xfer = NULL;
+	sys_dnode_t *node;
 
-	/* Draft, WIP */
+	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
-	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
-	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
-		return xfer;
+		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
+			break;
+		}
+
+		if (uhc_xfer_type_to_mask(xfer) & ~mask) {
+			continue;
+		}
+
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
 	}
 
-	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
-	if (xfer == NULL) {
-		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	return NULL;
+}
+
+static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *dev,
+						       sys_dlist_t *dlist,
+						       uhc_xfer_filter_func_t filter, void *priv)
+{
+	struct uhc_transfer *xfer = NULL;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(dlist, xfer, node) {
+		if (filter == NULL || filter(xfer, priv)) {
+			return xfer;
+		}
+	}
+
+	return NULL;
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
+				       void *priv)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *xfer = NULL;
+
+	if (mask & UHC_XFER_MASK_PERIODIC) {
+		xfer = uhc_xfer_get_next_periodic(dev, frame_number, mask, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_CONTROL) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->ctrl_xfers, filter, priv);
+	}
+
+	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
+		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
 	}
 
 	return xfer;

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -54,19 +54,62 @@ void uhc_xfer_return(const struct device *dev,
 	data->event_cb(dev, &drv_evt);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev)
+void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+	sys_dlist_t *int_list = &data->int_xfers;
+	struct uhc_transfer *curr;
+
+	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
+			continue;
+		}
+		sys_dlist_insert(&curr->node, &xfer->node);
+		return;
+	}
+
+	sys_dlist_append(int_list, &xfer->node);
+}
+
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number)
+{
+	uint16_t old_start_frame = xfer->start_frame;
+
+	if (unlikely(xfer->interval == 0)) {
+		/* Prevent a infinite loop if somehow interval equals 0 */
+		xfer->interval = 1;
+	}
+
+	do {
+		xfer->start_frame += xfer->interval;
+	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
+
+	sys_dlist_remove(&xfer->node);
+	uhc_xfer_add_to_int(dev, xfer);
+
+	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
+}
+
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
-	sys_dnode_t *node;
 
 	/* Draft, WIP */
-	node = sys_dlist_peek_head(&data->ctrl_xfers);
-	if (node == NULL) {
-		node = sys_dlist_peek_head(&data->bulk_xfers);
+
+	xfer = SYS_DLIST_CONTAINER(sys_dlist_peek_tail(&data->int_xfers), xfer, node);
+	if (xfer && xfer_seq_cmp(xfer->start_frame, frame_number) <= 0) {
+		return xfer;
 	}
 
-	return (node == NULL) ? NULL : SYS_DLIST_CONTAINER(node, xfer, node);
+	xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->ctrl_xfers, xfer, node);
+	if (xfer == NULL) {
+		xfer = SYS_DLIST_PEEK_HEAD_CONTAINER(&data->bulk_xfers, xfer, node);
+	}
+
+	return xfer;
 }
 
 int uhc_xfer_append(const struct device *dev,
@@ -74,7 +117,21 @@ int uhc_xfer_append(const struct device *dev,
 {
 	struct uhc_data *data = dev->data;
 
-	sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_append(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_append(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_to_int(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+	}
 
 	return 0;
 }
@@ -339,6 +396,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
+	sys_dlist_init(&data->int_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -94,6 +94,8 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
+	/* Reset active flag, in case the interrupt was in the active list */
+	xfer->active = 0;
 	uhc_xfer_add_periodic(dev, xfer);
 
 	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
@@ -149,6 +151,57 @@ static struct uhc_transfer *uhc_xfer_get_next_non_periodic(const struct device *
 	return NULL;
 }
 
+static void uhc_xfer_set_in_progress(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	struct uhc_data *data = dev->data;
+
+	sys_dlist_remove(&xfer->node);
+	sys_dlist_append(&data->active_xfers, &xfer->node);
+	xfer->active = 1;
+}
+
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer)
+{
+	sys_dlist_remove(&xfer->node);
+	xfer->active = 0;
+
+	struct uhc_data *data = dev->data;
+
+	switch (xfer->type) {
+	case USB_EP_TYPE_CONTROL:
+		sys_dlist_prepend(&data->ctrl_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_BULK:
+		sys_dlist_prepend(&data->bulk_xfers, &xfer->node);
+		break;
+	case USB_EP_TYPE_ISO:
+	case USB_EP_TYPE_INTERRUPT:
+		uhc_xfer_add_periodic(dev, xfer);
+		break;
+	default:
+		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int uhc_xfer_defer_all_active(const struct device *dev)
+{
+	struct uhc_data *data = dev->data;
+	struct uhc_transfer *current, *next;
+	int ret;
+
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&data->active_xfers, current, next, node) {
+		ret = uhc_xfer_defer_active(dev, current);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
 struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
 				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
 				       void *priv)
@@ -166,6 +219,10 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 
 	if (xfer == NULL && mask & UHC_XFER_MASK_BULK) {
 		xfer = uhc_xfer_get_next_non_periodic(dev, &data->bulk_xfers, filter, priv);
+	}
+
+	if (xfer) {
+		uhc_xfer_set_in_progress(dev, xfer);
 	}
 
 	return xfer;
@@ -206,6 +263,7 @@ int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
 		return uhc_xfer_add_new_periodic(dev, xfer, frame_number);
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
+		return -EINVAL;
 	}
 
 	return 0;
@@ -229,6 +287,7 @@ void uhc_xfer_cleanup_cancelled(const struct device *dev)
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->ctrl_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->bulk_xfers);
 	uhc_xfer_dlist_cleanup_cancelled(dev, &data->periodic_xfers);
+	uhc_xfer_dlist_cleanup_cancelled(dev, &data->active_xfers);
 }
 
 int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
@@ -253,14 +312,18 @@ int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer)
 		return -EINVAL;
 	}
 
+	if (xfer->active) {
+		dlist = &data->active_xfers;
+	}
+
 	SYS_DLIST_FOR_EACH_CONTAINER(dlist, tmp, node) {
 		if (xfer == tmp) {
 			tmp->err = -ECONNRESET;
-			break;
+			return 0;
 		}
 	}
 
-	return 0;
+	return -ENOENT;
 }
 
 struct net_buf *uhc_xfer_buf_alloc(const struct device *dev,
@@ -559,6 +622,7 @@ int uhc_init(const struct device *dev,
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
 	sys_dlist_init(&data->periodic_xfers);
+	sys_dlist_init(&data->active_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -55,13 +55,13 @@ void uhc_xfer_return(const struct device *dev,
 	data->event_cb(dev, &drv_evt);
 }
 
-void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xfer)
+void uhc_xfer_add_periodic(const struct device *dev, struct uhc_transfer *const xfer)
 {
 	struct uhc_data *data = dev->data;
-	sys_dlist_t *int_list = &data->int_xfers;
+	sys_dlist_t *periodic_list = &data->periodic_xfers;
 	struct uhc_transfer *curr;
 
-	SYS_DLIST_FOR_EACH_CONTAINER(int_list, curr, node) {
+	SYS_DLIST_FOR_EACH_CONTAINER(periodic_list, curr, node) {
 		if (xfer_seq_cmp(xfer->start_frame, curr->start_frame) < 0) {
 			continue;
 		}
@@ -69,7 +69,7 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 		return;
 	}
 
-	sys_dlist_append(int_list, &xfer->node);
+	sys_dlist_append(periodic_list, &xfer->node);
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
@@ -87,9 +87,9 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 	} while (xfer_seq_cmp(xfer->start_frame, frame_number) <= 0);
 
 	sys_dlist_remove(&xfer->node);
-	uhc_xfer_add_to_int(dev, xfer);
+	uhc_xfer_add_periodic(dev, xfer);
 
-	LOG_DBG("Interrupt transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
+	LOG_DBG("Periodic transfer advance frame old s.f. %u new s.f %u f.n. %u interval %u",
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
@@ -107,8 +107,8 @@ static struct uhc_transfer *uhc_xfer_get_next_periodic(const struct device *dev,
 	struct uhc_transfer *xfer = NULL;
 	sys_dnode_t *node;
 
-	for (node = sys_dlist_peek_tail(&data->int_xfers); node != NULL;
-	     node = sys_dlist_peek_prev(&data->int_xfers, node)) {
+	for (node = sys_dlist_peek_tail(&data->periodic_xfers); node != NULL;
+	     node = sys_dlist_peek_prev(&data->periodic_xfers, node)) {
 		xfer = SYS_DLIST_CONTAINER(node, xfer, node);
 
 		if (xfer_seq_cmp(xfer->start_frame, frame_number) > 0) {
@@ -177,9 +177,8 @@ int uhc_xfer_append(const struct device *dev,
 		sys_dlist_append(&data->bulk_xfers, &xfer->node);
 		break;
 	case USB_EP_TYPE_ISO:
-		LOG_WRN("Iso xfers not implemeted yet, treating as interrupt xfer");
 	case USB_EP_TYPE_INTERRUPT:
-		uhc_xfer_add_to_int(dev, xfer);
+		uhc_xfer_add_periodic(dev, xfer);
 		break;
 	default:
 		LOG_ERR("Invalid xfer type: %d", xfer->type);
@@ -483,7 +482,7 @@ int uhc_init(const struct device *dev,
 	data->event_ctx = event_ctx;
 	sys_dlist_init(&data->ctrl_xfers);
 	sys_dlist_init(&data->bulk_xfers);
-	sys_dlist_init(&data->int_xfers);
+	sys_dlist_init(&data->periodic_xfers);
 
 	ret = api->init(dev);
 	if (ret == 0) {

--- a/drivers/usb/uhc/uhc_common.c
+++ b/drivers/usb/uhc/uhc_common.c
@@ -72,9 +72,9 @@ void uhc_xfer_add_to_int(const struct device *dev, struct uhc_transfer *const xf
 }
 
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number)
+				  uint32_t frame_number)
 {
-	uint16_t old_start_frame = xfer->start_frame;
+	uint32_t old_start_frame = xfer->start_frame;
 
 	if (unlikely(xfer->interval == 0)) {
 		/* Prevent a infinite loop if somehow interval equals 0 */
@@ -92,7 +92,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 		old_start_frame, xfer->start_frame, frame_number, xfer->interval);
 }
 
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number)
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number)
 {
 	struct uhc_data *data = dev->data;
 	struct uhc_transfer *xfer;
@@ -147,6 +147,40 @@ void uhc_xfer_buf_free(const struct device *dev, struct net_buf *const buf)
 	net_buf_unref(buf);
 }
 
+static uint32_t uhc_xfer_bInterval_to_microframe(const struct usb_device *const udev,
+					       uint16_t bInterval, uint8_t ep_type)
+{
+	if (bInterval == 0) {
+		return 0;
+	}
+
+	switch (udev->speed) {
+	case USB_SPEED_SPEED_SS:
+	case USB_SPEED_SPEED_HS:
+		bInterval = CLAMP(bInterval, 1, 16);
+		return 1U << (bInterval - 1);
+	case USB_SPEED_SPEED_FS:
+		/*
+		 * ISO FS uses 2^(bInterval - 1) * 1ms
+		 * unlike ISO HS which uses 2^(bInterval - 1) * 125microseconds
+		 * INT FS does it the same as INT LS
+		 * See USB 2.0 Specification 5.6.4 and 5.7.4
+		 */
+		if (ep_type == USB_EP_TYPE_ISO) {
+			bInterval = CLAMP(bInterval, 1, 16);
+			return (1U << (bInterval - 1)) * 8;
+		}
+		bInterval = CLAMP(bInterval, 1, 255);
+		return bInterval * 8;
+	case USB_SPEED_SPEED_LS:
+	case USB_SPEED_UNKNOWN:
+		bInterval = CLAMP(bInterval, 10, 255);
+		return bInterval * 8;
+	}
+
+	return 0;
+}
+
 struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 				    const uint8_t ep,
 				    struct usb_device *const udev,
@@ -157,7 +191,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	const struct uhc_driver_api *api = DEVICE_API_GET(uhc, dev);
 	struct uhc_transfer *xfer = NULL;
 	uint16_t mps;
-	uint16_t interval;
+	uint16_t bInterval;
 	uint8_t type;
 
 	api->lock(dev);
@@ -167,7 +201,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	}
 
 	if (ep_idx == 0) {
-		interval = 0;
+		bInterval = 0;
 		type = USB_EP_TYPE_CONTROL;
 		mps = udev->dev_desc.bMaxPacketSize0;
 	} else {
@@ -185,7 +219,7 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 		}
 
 		mps = ep_desc->wMaxPacketSize;
-		interval = ep_desc->bInterval;
+		bInterval = ep_desc->bInterval;
 		type = ep_desc->bmAttributes & USB_EP_TRANSFER_TYPE_MASK;
 	}
 
@@ -199,7 +233,8 @@ struct uhc_transfer *uhc_xfer_alloc(const struct device *dev,
 	memset(xfer, 0, sizeof(struct uhc_transfer));
 	xfer->ep = ep;
 	xfer->mps = mps;
-	xfer->interval = interval;
+	xfer->interval = uhc_xfer_bInterval_to_microframe(udev, bInterval, type);
+	xfer->bInterval = bInterval;
 	xfer->type = type;
 	xfer->udev = udev;
 	xfer->cb = cb;

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -51,6 +51,18 @@ static inline void *uhc_get_private(const struct device *dev)
 }
 
 /**
+ * @brief Initialize UHC common data
+ *
+ * UHC drivers using the common helpers must call this function during
+ * driver initialization.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_common_init(const struct device *dev);
+
+/**
  * @brief Locking function for the drivers.
  *
  * @param[in] dev     Pointer to device struct of the driver instance
@@ -161,6 +173,29 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
  */
 int uhc_xfer_append(const struct device *dev,
 		    struct uhc_transfer *const xfer);
+
+/**
+ * @brief Cleans up canceled transfer in the internal queues.
+ *
+ * A canceled transfer is marked by having the err field set to `-ECONNRESET`
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ */
+void uhc_xfer_cleanup_cancelled(const struct device *dev);
+
+/**
+ * @brief Marks a queued transfer as canceled
+ *
+ * This function does not fully remove the transfer.
+ * To fully delete the transfer, call `uhc_xfer_cleanup_cancelled()`
+ * after marking a transfer as canceled.
+ *
+ * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] xfer   Pointer to UHC transfer that should be canceled
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_dequeue(const struct device *dev, struct uhc_transfer *const xfer);
 
 /**
  * @brief Helper function to send UHC event to a higher level.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -131,6 +131,33 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 				  uint32_t frame_number);
 
 /**
+ * @brief Defer a UHC transfer for the next frame.
+ *
+ * Puts back the UHC transfer at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer that should be deferred.
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_active(const struct device *dev, struct uhc_transfer *const xfer);
+
+/**
+ * @brief Defer all UHC transfers for a later time.
+ *
+ * Puts back all UHC transfers at the top of list.
+ * Periodic transfers get put at their exact place in the queue,
+ * so it is allowed to defer periodic transfer in any order.
+ *
+ * @param[in] dev      Pointer to device struct of the driver instance
+ *
+ * @return 0 on success, all other values should be treated as error.
+ */
+int uhc_xfer_defer_all_active(const struct device *dev);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * Return the next transfer that matches the provided mask and is accepted by

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -59,6 +59,22 @@ static inline int uhc_unlock_internal(const struct device *dev)
 }
 
 /**
+ * @brief Compare frame numbers of xfers to determine which one should be sent first.
+ *
+ * @return Negative value if a < b, positive if a > b, 0 if a == b
+ */
+static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+{
+	/*
+	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * wrapped subtraction is interpreted as a signed delta, so values just
+	 * after rollover compare newer than values just before it. Comparisons
+	 * are meaningful only within half the counter range.
+	 */
+	return (int16_t)(a - b);
+}
+
+/**
  * @brief Helper function to return UHC transfer to a higher level.
  *
  * Function to dequeue transfer and send UHC event to a higher level.
@@ -72,15 +88,26 @@ void uhc_xfer_return(const struct device *dev,
 		     const int err);
 
 /**
+ * @brief Reschedules the periodic UHC transfer to it's next valid frame.
+ *
+ * @param[inout] xfer   Pointer to UHC transfer
+ * @param frame_number The current USB frame number
+ */
+void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
+				  uint16_t frame_number);
+
+/**
  * @brief Helper to get next transfer to process.
  *
  * This is currently a draft, and simple picks a transfer
  * from the lists.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
+ * @param[in] dev    Pointer to device struct of the driver instance.
+ * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -63,15 +63,15 @@ static inline int uhc_unlock_internal(const struct device *dev)
  *
  * @return Negative value if a < b, positive if a > b, 0 if a == b
  */
-static inline int16_t xfer_seq_cmp(uint16_t a, uint16_t b)
+static inline int32_t xfer_seq_cmp(uint32_t a, uint32_t b)
 {
 	/*
-	 * Use serial-number arithmetic for the unsigned 16-bit frame counter. The
+	 * Use serial-number arithmetic for the unsigned 32-bit frame counter. The
 	 * wrapped subtraction is interpreted as a signed delta, so values just
 	 * after rollover compare newer than values just before it. Comparisons
 	 * are meaningful only within half the counter range.
 	 */
-	return (int16_t)(a - b);
+	return (int32_t)(a - b);
 }
 
 /**
@@ -94,7 +94,7 @@ void uhc_xfer_return(const struct device *dev,
  * @param frame_number The current USB frame number
  */
 void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer *const xfer,
-				  uint16_t frame_number);
+				  uint32_t frame_number);
 
 /**
  * @brief Helper to get next transfer to process.
@@ -107,7 +107,7 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
  *
  * @return pointer to the next transfer or NULL on error.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint16_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,27 @@
 #define ZEPHYR_INCLUDE_UHC_COMMON_H
 
 #include <zephyr/drivers/usb/uhc.h>
+
+/**
+ * @brief Transfer types selectable by uhc_xfer_get_next().
+ *
+ * Combine values with bitwise OR to select multiple transfer types.
+ */
+enum uhc_xfer_mask {
+	UHC_XFER_MASK_CONTROL = BIT(USB_EP_TYPE_CONTROL),     /**< Control transfers. */
+	UHC_XFER_MASK_ISO = BIT(USB_EP_TYPE_ISO),             /**< Isochronous transfers. */
+	UHC_XFER_MASK_BULK = BIT(USB_EP_TYPE_BULK),           /**< Bulk transfers. */
+	UHC_XFER_MASK_INTERRUPT = BIT(USB_EP_TYPE_INTERRUPT), /**< Interrupt transfers. */
+	/** Periodic transfers: interrupt or isochronous. */
+	UHC_XFER_MASK_PERIODIC = UHC_XFER_MASK_INTERRUPT | UHC_XFER_MASK_ISO,
+	/** Non-periodic transfers: control or bulk. */
+	UHC_XFER_MASK_NON_PERIODIC = UHC_XFER_MASK_CONTROL | UHC_XFER_MASK_BULK,
+	/** All transfer types. */
+	UHC_XFER_MASK_ALL = UHC_XFER_MASK_PERIODIC | UHC_XFER_MASK_NON_PERIODIC,
+};
+
+/** Transfer filtering function used in uhc_xfer_get_next(). */
+typedef bool (*uhc_xfer_filter_func_t)(const struct uhc_transfer *xfer, void *priv);
 
 /**
  * @brief Get driver's private data
@@ -99,15 +121,34 @@ void uhc_xfer_reschedule_periodic(const struct device *dev, struct uhc_transfer 
 /**
  * @brief Helper to get next transfer to process.
  *
- * This is currently a draft, and simple picks a transfer
- * from the lists.
+ * Return the next transfer that matches the provided mask and is accepted by
+ * the optional filter function. Move the selected transfer to the active list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance.
+ * If the mask matches more than one transfer type, prioritize transfers in this order:
+ *
+ * -# Most-overdue eligible periodic transfer, either interrupt or isochronous.
+ * -# Control transfer.
+ * -# Bulk transfer.
+ *
+ * To use a different priority order, call this function multiple times with masks that each
+ * match only one transfer type.
+ *
+ * @param[in] dev          Pointer to device struct of the driver instance.
  * @param[in] frame_number Current USB frame number used to determine periodic transfer eligibility.
+ * @param[in] mask         Bitmask of transfer types to consider. Combine UHC_XFER_MASK_* values
+ *                         with bitwise OR to select multiple transfer types.
+ * @param[in] filter       Optional function for further filtering transfers selected by @p mask.
+ *                         Return `true` to accept a transfer or `false` to skip it. Set to `NULL`
+ *                         to accept the first transfer selected by @p mask.
+ * @param[in] priv         Private data passed unchanged to @p filter. May be `NULL`.
  *
- * @return pointer to the next transfer or NULL on error.
+ * @return Next eligible transfer, or `NULL` if there are no pending matching non-periodic
+ *         transfers, no matching periodic transfer is due, or all otherwise eligible transfers
+ *         are rejected by @p filter.
  */
-struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number);
+struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_number,
+				       enum uhc_xfer_mask mask, uhc_xfer_filter_func_t filter,
+				       void *priv);
 
 /**
  * @brief Helper to append a transfer to internal list.

--- a/drivers/usb/uhc/uhc_common.h
+++ b/drivers/usb/uhc/uhc_common.h
@@ -165,14 +165,16 @@ struct uhc_transfer *uhc_xfer_get_next(const struct device *dev, uint32_t frame_
 /**
  * @brief Helper to append a transfer to internal list.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] xfer   Pointer to UHC transfer
+ * @param[in] dev      Pointer to device struct of the driver instance
+ * @param[in] xfer     Pointer to UHC transfer
+ * @param[in] frame_number The current USB frame number, used to schedule periodic transfers
  *
  * @return 0 on success, all other values should be treated as error.
+ * @retval -EINVAL if the provided xfers is periodic and has interval equal to 0
  * @retval -ENOMEM if there is no buffer in the queue
  */
-int uhc_xfer_append(const struct device *dev,
-		    struct uhc_transfer *const xfer);
+int uhc_xfer_append(const struct device *dev, struct uhc_transfer *const xfer,
+		    uint32_t frame_number);
 
 /**
  * @brief Cleans up canceled transfer in the internal queues.

--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -252,7 +252,7 @@ static usb_host_pipe_handle uhc_mcux_check_hal_ep(const struct device *dev,
 	if (mcux_ep->pipeType != xfer->type ||
 	    mcux_ep->maxPacketSize != USB_MPS_EP_SIZE(xfer->mps) ||
 	    mcux_ep->numberPerUframe != USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps) + 1 ||
-	    priv->mcux_eps_interval[i] != xfer->interval) {
+	    priv->mcux_eps_interval[i] != xfer->bInterval) {
 		status = priv->mcux_if->controllerClosePipe(priv->mcux_host.controllerHandle,
 							    mcux_ep);
 		if (status != kStatus_USB_Success) {
@@ -294,7 +294,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	 * 'number per uframe' and the endpoint type cannot be got yet.
 	 */
 	pipe_init.numberPerUframe = USB_MPS_ADDITIONAL_TRANSACTIONS(xfer->mps);
-	pipe_init.interval = xfer->interval;
+	pipe_init.interval = xfer->bInterval;
 	pipe_init.pipeType = xfer->type;
 
 	status = priv->mcux_if->controllerOpenPipe(priv->mcux_host.controllerHandle,
@@ -315,7 +315,7 @@ usb_host_pipe_t *uhc_mcux_init_hal_ep(const struct device *dev, struct uhc_trans
 	for (i = 0; i < USB_HOST_CONFIG_MAX_PIPES; i++) {
 		if (priv->mcux_eps[i] == NULL) {
 			priv->mcux_eps[i] = mcux_ep;
-			priv->mcux_eps_interval[i] = xfer->interval;
+			priv->mcux_eps_interval[i] = xfer->bInterval;
 			break;
 		}
 	}

--- a/drivers/usb/uhc/uhc_mcux_ehci.c
+++ b/drivers/usb/uhc/uhc_mcux_ehci.c
@@ -181,7 +181,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ip3516hs.c
+++ b/drivers/usb/uhc/uhc_mcux_ip3516hs.c
@@ -173,7 +173,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_khci.c
+++ b/drivers/usb/uhc/uhc_mcux_khci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_mcux_ohci.c
+++ b/drivers/usb/uhc/uhc_mcux_ohci.c
@@ -160,7 +160,7 @@ static int uhc_mcux_enqueue(const struct device *dev, struct uhc_transfer *const
 	usb_status_t status;
 	usb_host_transfer_t *mcux_xfer;
 
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, 0);
 
 	/* firstly check and init the mcux endpoint handle */
 	mcux_ep = uhc_mcux_init_hal_ep(dev, xfer);

--- a/drivers/usb/uhc/uhc_virtual.c
+++ b/drivers/usb/uhc/uhc_virtual.c
@@ -49,7 +49,8 @@ struct uhc_vrt_data {
 	struct uhc_transfer *last_xfer;
 	struct uhc_vrt_frame frame;
 	struct k_timer sof_timer;
-	uint16_t frame_number;
+	uint32_t frame_number;
+	uint8_t frame_increment;
 	uint8_t req;
 };
 
@@ -198,51 +199,53 @@ static inline uint8_t get_xfer_ep_idx(const uint8_t ep)
 	return USB_EP_GET_IDX(ep & BIT_MASK(4)) + 16U;
 }
 
+bool vrt_filter_xfers(const struct uhc_transfer *xfer, void *priv)
+{
+	uint32_t *bm = priv;
+
+	uint8_t idx = get_xfer_ep_idx(xfer->ep);
+
+	/* There could be multiple transfers queued for the same
+	 * endpoint, for now we only allow one to be scheduled per frame.
+	 */
+	if (*bm & BIT(idx)) {
+		return false;
+	}
+
+	*bm |= BIT(idx);
+
+	return true;
+}
+
 static void vrt_assemble_frame(const struct device *dev)
 {
 	struct uhc_vrt_data *const priv = uhc_get_private(dev);
 	struct uhc_vrt_frame *const frame = &priv->frame;
-	struct uhc_data *const data = dev->data;
 	struct uhc_transfer *tmp;
 	unsigned int n = 0;
 	unsigned int key;
 	uint32_t bm = 0;
 
+	key = irq_lock();
+
+	uhc_xfer_defer_all_active(dev);
+
 	sys_dlist_init(&frame->list);
 	frame->ptr = NULL;
 	frame->count = 0;
-	key = irq_lock();
 
 	/* TODO: add periodic transfers up to 90% */
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		uint8_t idx = get_xfer_ep_idx(tmp->ep);
-
-		/* There could be multiple transfers queued for the same
-		 * endpoint, for now we only allow one to be scheduled per frame.
-		 */
-		if (bm & BIT(idx)) {
-			continue;
+	while (n < FRAME_MAX_TRANSFERS) {
+		tmp = uhc_xfer_get_next(dev, priv->frame_number, UHC_XFER_MASK_ALL,
+					vrt_filter_xfers, &bm);
+		if (tmp == NULL) {
+			/* No pending transfers */
+			break;
 		}
 
-		if (tmp->interval) {
-			if (tmp->start_frame != priv->frame_number) {
-				continue;
-			}
-
-			tmp->start_frame = priv->frame_number + tmp->interval;
-			LOG_DBG("Interrupt transfer s.f. %u f.n. %u interval %u",
-				tmp->start_frame, priv->frame_number, tmp->interval);
-		}
-
-		bm |= BIT(idx);
 		frame->slots[n].xfer = tmp;
 		sys_dlist_append(&frame->list, &frame->slots[n].node);
 		n++;
-
-		if (n >= FRAME_MAX_TRANSFERS) {
-			/* No more free slots */
-			break;
-		}
 	}
 
 	irq_unlock(key);
@@ -398,18 +401,12 @@ handle_reply_err:
 static void vrt_xfer_cleanup_cancelled(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 
 	if (priv->last_xfer != NULL && priv->last_xfer->err == -ECONNRESET) {
 		vrt_xfer_drop_active(dev, -ECONNRESET);
 	}
 
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (tmp->err == -ECONNRESET) {
-			uhc_xfer_return(dev, tmp, -ECONNRESET);
-		}
-	}
+	uhc_xfer_cleanup_cancelled(dev);
 }
 
 static void xfer_work_handler(struct k_work *work)
@@ -424,7 +421,7 @@ static void xfer_work_handler(struct k_work *work)
 
 		switch (ev->type) {
 		case UHC_VRT_EVT_SOF:
-			priv->frame_number++;
+			priv->frame_number += priv->frame_increment;
 			vrt_xfer_cleanup_cancelled(dev);
 			vrt_assemble_frame(dev);
 			schedule = true;
@@ -472,10 +469,12 @@ static void vrt_device_act(const struct device *dev,
 		break;
 	case UVB_DEVICE_ACT_FS:
 		type = UHC_EVT_DEV_CONNECTED_FS;
+		priv->frame_increment = 8;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
 		break;
 	case UVB_DEVICE_ACT_HS:
 		type = UHC_EVT_DEV_CONNECTED_HS;
+		priv->frame_increment = 1;
 		k_timer_start(&priv->sof_timer, K_MSEC(1), K_USEC(125));
 		break;
 	case UVB_DEVICE_ACT_REMOVED:
@@ -506,8 +505,9 @@ static void uhc_vrt_uvb_cb(const void *const vrt_priv,
 static int uhc_vrt_sof_enable(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return 0;
 }
@@ -525,13 +525,14 @@ static int uhc_vrt_bus_suspend(const struct device *dev)
 static int uhc_vrt_bus_reset(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 	int ret;
 
 	k_timer_stop(&priv->sof_timer);
 	ret = uvb_advert(priv->host_node, UVB_EVT_RESET, NULL);
 	/* TDRSTR */
 	k_msleep(50);
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return ret;
 }
@@ -539,8 +540,9 @@ static int uhc_vrt_bus_reset(const struct device *dev)
 static int uhc_vrt_bus_resume(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
+	k_timeout_t period = priv->frame_increment == 8 ? K_MSEC(1) : K_USEC(125);
 
-	k_timer_start(&priv->sof_timer, K_MSEC(1), K_MSEC(1));
+	k_timer_start(&priv->sof_timer, K_MSEC(1), period);
 
 	return uvb_advert(priv->host_node, UVB_EVT_RESUME, NULL);
 }
@@ -550,13 +552,7 @@ static int uhc_vrt_enqueue(const struct device *dev,
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
 
-	if (xfer->interval) {
-		xfer->start_frame = priv->frame_number + xfer->interval;
-		LOG_DBG("New interrupt transfer s.f. %u f.n. %u interval %u",
-			xfer->start_frame, priv->frame_number, xfer->interval);
-	}
-
-	uhc_xfer_append(dev, xfer);
+	uhc_xfer_append(dev, xfer, priv->frame_number);
 
 	return 0;
 }
@@ -564,18 +560,10 @@ static int uhc_vrt_enqueue(const struct device *dev,
 static int uhc_vrt_dequeue(const struct device *dev,
 			    struct uhc_transfer *const xfer)
 {
-	struct uhc_data *data = dev->data;
-	struct uhc_transfer *tmp;
 	unsigned int key;
 
 	key = irq_lock();
-
-	SYS_DLIST_FOR_EACH_CONTAINER(&data->ctrl_xfers, tmp, node) {
-		if (xfer == tmp) {
-			tmp->err = -ECONNRESET;
-		}
-	}
-
+	uhc_xfer_dequeue(dev, xfer);
 	irq_unlock(key);
 
 	return 0;
@@ -619,12 +607,13 @@ static int uhc_vrt_unlock(const struct device *dev)
 static int uhc_vrt_driver_preinit(const struct device *dev)
 {
 	struct uhc_vrt_data *priv = uhc_get_private(dev);
-	struct uhc_data *data = dev->data;
 
 	priv->dev = dev;
-	k_mutex_init(&data->mutex);
+	uhc_common_init(dev);
 
 	priv->host_node->priv = dev;
+	/* Default to SOF every 1 millisecond */
+	priv->frame_increment = 8;
 	k_fifo_init(&priv->fifo);
 	k_work_init(&priv->work, xfer_work_handler);
 	k_timer_init(&priv->sof_timer, sof_timer_handler, NULL);

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -130,10 +130,18 @@ struct uhc_transfer {
 	uint8_t type;
 	/** Maximum packet size */
 	uint16_t mps;
-	/** Interval, used for periodic transfers only */
-	uint16_t interval;
+	/**
+	 * Tick interval converted from the bInterval, used for periodic transfers only.
+	 * For Low Speed and Full Speed interrupt endpoints its equal to bInterval * 8
+	 * For Full Speed isochronous endpoints its equal to 2^(bInterval - 1) * 8
+	 * For High Speed and Super Speed endpoints its equal to 2^(bInterval - 1)
+	 * 1 tick = 125 microseconds
+	 */
+	uint32_t interval;
+	/** Unconverted bInterval, used for periodic transfers only */
+	uint16_t bInterval;
 	/** Start frame, used for periodic transfers only */
-	uint16_t start_frame;
+	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
 	/** Control stage status, up to the driver to use it or not */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -260,8 +260,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
-	/** dlist for interrupt transfers, sorted in descending order by start_frame */
-	sys_dlist_t int_xfers;
+	/** dlist for periodic transfers, sorted in descending order by start_frame */
+	sys_dlist_t periodic_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -144,6 +144,11 @@ struct uhc_transfer {
 	uint32_t start_frame;
 	/** Flag marks request buffer is queued */
 	unsigned int queued : 1;
+	/**
+	 * Flag marks if the transfer is currently in the active xfer dlist,
+	 *  which means that it is processed by the UHC driver
+	 */
+	unsigned int active : 1;
 	/** Control stage status, up to the driver to use it or not */
 	unsigned int stage : 2;
 	/**
@@ -262,6 +267,8 @@ struct uhc_data {
 	sys_dlist_t bulk_xfers;
 	/** dlist for periodic transfers, sorted in descending order by start_frame */
 	sys_dlist_t periodic_xfers;
+	/** dlist for transfers being scheduled in hardware */
+	sys_dlist_t active_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -252,6 +252,8 @@ struct uhc_data {
 	sys_dlist_t ctrl_xfers;
 	/** dlist for bulk transfers */
 	sys_dlist_t bulk_xfers;
+	/** dlist for interrupt transfers, sorted in descending order by start_frame */
+	sys_dlist_t int_xfers;
 	/** Callback to submit an UHC event to upper layer */
 	uhc_event_cb_t event_cb;
 	/** Opaque pointer to store higher layer context */

--- a/subsys/usb/host/CMakeLists.txt
+++ b/subsys/usb/host/CMakeLists.txt
@@ -25,6 +25,11 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_sources_ifdef(
+  CONFIG_USBH_HID_BOOT_CLASS
+  class/usbh_hid_boot.c
+)
+
+zephyr_library_sources_ifdef(
   CONFIG_USBIP
   usbip.c
 )

--- a/subsys/usb/host/class/Kconfig
+++ b/subsys/usb/host/class/Kconfig
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 rsource "Kconfig.uvc"
+rsource "Kconfig.hid_boot"

--- a/subsys/usb/host/class/Kconfig.hid_boot
+++ b/subsys/usb/host/class/Kconfig.hid_boot
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config USBH_HID_BOOT_CLASS
+	bool "USB host HID Boot class [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	depends on INPUT
+	help
+	  USB Host HID Boot Class implementation.
+
+config USBH_HID_BOOT_INIT_PRIORITY
+	int "Host HID Boot initialization priority"
+	default 60
+	depends on USBH_HID_BOOT_CLASS
+	help
+	  priority used for initialization of HID Boot device class in the USB host subsystem.
+
+module = USBH_HID_BOOT
+module-str = usbh hid boot
+default-count = 1
+source "subsys/logging/Kconfig.template.log_config"
+source "subsys/usb/common/Kconfig.template.instances_count"

--- a/subsys/usb/host/class/usbh_hid_boot.c
+++ b/subsys/usb/host/class/usbh_hid_boot.c
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/usb/usbh.h>
+#include <zephyr/usb/usb_ch9.h>
+#include <zephyr/drivers/usb/udc.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/input/input.h>
+
+#include <zephyr/sys/util.h>
+#include <sys/errno.h>
+
+#include "usbh_ch9.h"
+#include "usbh_class.h"
+#include "usbh_desc.h"
+#include "usbh_device.h"
+#include "zephyr/drivers/usb/uhc.h"
+#include <zephyr/usb/class/hid.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "usbh_hid_boot.h"
+
+#define USBH_HID_BOOT_SUBCLASS 1
+
+#define USBH_HID_BOOT_REPORT_LEN_BYTES 8
+
+LOG_MODULE_REGISTER(usbh_hid_boot, CONFIG_USBH_HID_BOOT_LOG_LEVEL);
+
+#define USBH_HID_BOOT_DECLARE_DEVICES(n, _) DEVICE_DECLARE(usbh_hid_boot_##n);
+LISTIFY(CONFIG_USBH_HID_BOOT_INSTANCES_COUNT, USBH_HID_BOOT_DECLARE_DEVICES, (;), _)
+
+int hid_boot_report_key(struct hid_boot_data *const priv, uint16_t code, int32_t value)
+{
+	return input_report_key(priv->dev, code, value, true, K_FOREVER);
+}
+
+int hid_boot_report_rel(struct hid_boot_data *const priv, uint16_t code, int32_t value)
+{
+	return input_report_rel(priv->dev, code, value, true, K_FOREVER);
+}
+
+static uint16_t hid_to_input(uint8_t hid_key)
+{
+	if (hid_key >= ARRAY_SIZE(hid_to_input_map)) {
+		return 0;
+	}
+	return hid_to_input_map[hid_key];
+}
+
+static int usbh_hid_boot_init(struct usbh_class_data *const c_data)
+{
+	LOG_INF("HID Boot Device Class initialized");
+	return 0;
+}
+
+static int verify_desc(struct usb_device *const udev, const uint8_t iface,
+		       const struct usb_if_descriptor *if_desc)
+{
+	if (iface == USBH_CLASS_IFNUM_DEVICE) {
+		LOG_INF("HID Boot Class driver called on the device and not function");
+		return -ENOTSUP;
+	}
+
+	if (if_desc == NULL) {
+		LOG_ERR("No descriptor found for iface : %d", iface);
+		return -ENOTSUP;
+	}
+
+	if (!usbh_desc_is_valid_interface(if_desc)) {
+		LOG_ERR("Not a valid interface descriptor for iface : %d", iface);
+		return -ENOTSUP;
+	}
+
+	if (if_desc->bInterfaceClass != 3 || if_desc->bInterfaceSubClass != 1) {
+		LOG_INF("Not a HID Boot function");
+		return -ENOTSUP;
+	}
+
+	if (if_desc->bInterfaceProtocol != 1 && if_desc->bInterfaceProtocol != 2) {
+		LOG_WRN("Invalid protocol in a HID Boot Device: %d", if_desc->bInterfaceProtocol);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static const struct usb_ep_descriptor *find_int_in_ep(const void *desc)
+{
+	const struct usb_ep_descriptor *ep_desc = desc;
+
+	while ((ep_desc = usbh_desc_get_next(ep_desc))) {
+		if (ep_desc->bDescriptorType != USB_DESC_ENDPOINT) {
+			continue;
+		}
+
+		if (!USB_EP_DIR_IS_IN(ep_desc->bEndpointAddress) ||
+		    ep_desc->Attributes.transfer != USB_EP_TYPE_INTERRUPT) {
+			continue;
+		}
+
+		LOG_DBG("Found Endpoint for a HID Boot function: %02x", ep_desc->bEndpointAddress);
+		break;
+	}
+
+	if (ep_desc == NULL) {
+		LOG_WRN("Endpoint not found for a HID Boot function");
+	}
+
+	return ep_desc;
+}
+
+static bool is_kbd_phantom_cond(struct hid_kbd_report *report)
+{
+	ARRAY_FOR_EACH_PTR(report->pressed_keys, key) {
+		if (*key != 1) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static void handle_kbd_modifiers(struct hid_boot_data *priv, union hid_kbd_modifiers *modifiers)
+{
+	uint16_t keycodes[] = {
+		INPUT_KEY_LEFTCTRL,  INPUT_KEY_LEFTSHIFT,  INPUT_KEY_LEFTALT,  INPUT_KEY_LEFTMETA,
+
+		INPUT_KEY_RIGHTCTRL, INPUT_KEY_RIGHTSHIFT, INPUT_KEY_RIGHTALT, INPUT_KEY_RIGHTMETA,
+	};
+
+	uint8_t changed = modifiers->raw ^ priv->last_report.kbd.modifiers.raw;
+
+	ARRAY_FOR_EACH(keycodes, i) {
+		if (changed & BIT(i)) {
+			hid_boot_report_key(priv, keycodes[i], modifiers->raw >> i & 1);
+		}
+	}
+
+	priv->last_report.kbd.modifiers = *modifiers;
+}
+
+static bool is_kbd_key_pressed(struct hid_kbd_report *report, int8_t hid_key)
+{
+	ARRAY_FOR_EACH_PTR(report->pressed_keys, key) {
+		if (*key == hid_key) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void handle_kbd_released(struct hid_boot_data *priv, struct hid_kbd_report *report)
+{
+	ARRAY_FOR_EACH_PTR(priv->last_report.kbd.pressed_keys, key) {
+		if (*key == 0) {
+			break;
+		}
+		if (!is_kbd_key_pressed(report, *key)) {
+			uint16_t key_code = hid_to_input(*key);
+
+			if (key_code == 0) {
+				LOG_WRN("Invalid hid key code");
+				continue;
+			}
+			hid_boot_report_key(priv, key_code, 0);
+		}
+	}
+}
+
+static void handle_kbd_pressed(struct hid_boot_data *priv, struct hid_kbd_report *report)
+{
+	ARRAY_FOR_EACH_PTR(report->pressed_keys, key) {
+		if (*key == 0) {
+			break;
+		}
+		if (!is_kbd_key_pressed(&priv->last_report.kbd, *key)) {
+			uint16_t key_code = hid_to_input(*key);
+
+			if (key_code == 0) {
+				LOG_WRN("Invalid hid key code");
+				continue;
+			}
+			hid_boot_report_key(priv, key_code, 1);
+		}
+	}
+}
+
+static void handle_kbd_keys(struct hid_boot_data *priv, struct hid_kbd_report *report)
+{
+	handle_kbd_released(priv, report);
+	handle_kbd_pressed(priv, report);
+
+	memcpy(priv->last_report.kbd.pressed_keys, report->pressed_keys,
+	       sizeof(report->pressed_keys));
+}
+
+static void handle_kbd_report(struct hid_boot_data *priv, struct hid_kbd_report *report)
+{
+	__ASSERT_NO_MSG(priv->type == KEYBOARD);
+
+	handle_kbd_modifiers(priv, &report->modifiers);
+
+	if (is_kbd_phantom_cond(report)) {
+		LOG_INF("Keyboard phantom condition occurred (too much keys pressed at once)");
+	} else {
+		handle_kbd_keys(priv, report);
+	}
+}
+
+static void handle_mouse_report(struct hid_boot_data *priv, struct hid_mouse_report *report)
+{
+	__ASSERT_NO_MSG(priv->type == MOUSE);
+
+	union hid_mouse_btns changed = {
+		.raw = (report->btns.raw ^ priv->last_report.mouse_btns.raw)};
+
+	if (changed.lmb) {
+		hid_boot_report_key(priv, INPUT_BTN_LEFT, report->btns.lmb);
+	}
+	if (changed.rmb) {
+		hid_boot_report_key(priv, INPUT_BTN_RIGHT, report->btns.rmb);
+	}
+	if (changed.mmb) {
+		hid_boot_report_key(priv, INPUT_BTN_MIDDLE, report->btns.mmb);
+	}
+
+	if (report->dx != 0) {
+		hid_boot_report_rel(priv, INPUT_REL_X, report->dx);
+	}
+	if (report->dy != 0) {
+		hid_boot_report_rel(priv, INPUT_REL_Y, report->dy);
+	}
+
+	priv->last_report.mouse_btns = report->btns;
+}
+
+static void handle_hid_boot_report(struct hid_boot_data *priv, uint8_t *report, uint8_t len)
+{
+	switch (priv->type) {
+	case KEYBOARD:
+		if (len < sizeof(struct hid_kbd_report)) {
+			LOG_ERR("HID Boot Keyboard report too short (should be %d bytes), "
+				"currently %d bytes",
+				sizeof(struct hid_kbd_report), len);
+			return;
+		}
+		handle_kbd_report(priv, (struct hid_kbd_report *)report);
+		break;
+	case MOUSE:
+		if (len < sizeof(struct hid_mouse_report)) {
+			LOG_ERR("HID Boot Mouse report too short (should be %d bytes), currently "
+				"%d bytes",
+				sizeof(struct hid_mouse_report), len);
+			return;
+		}
+		handle_mouse_report(priv, (struct hid_mouse_report *)report);
+		break;
+	}
+}
+
+/* Passing a NULL ptr or a xfer with no buffer is valid */
+static void free_xfer_buff(struct uhc_transfer *const xfer)
+{
+	if (!xfer || !xfer->buf) {
+		return;
+	}
+	usbh_xfer_buf_free(xfer->udev, xfer->buf);
+	xfer->buf = NULL;
+}
+
+/* Passing a NULL ptr or a xfer with no buffer is valid */
+static void free_xfer(struct uhc_transfer *const xfer)
+{
+	struct hid_boot_data *priv;
+
+	if (!xfer) {
+		return;
+	}
+
+	priv = xfer->priv;
+
+	free_xfer_buff(xfer);
+	if (priv) {
+		priv->int_xfer = NULL;
+	}
+	usbh_xfer_free(xfer->udev, xfer);
+}
+
+static int continue_transfer(struct uhc_transfer *const xfer)
+{
+	struct net_buf *buf;
+	size_t net_buf_len;
+	int ret;
+
+	net_buf_len = xfer->buf->len;
+	free_xfer_buff(xfer);
+
+	buf = usbh_xfer_buf_alloc(xfer->udev, net_buf_len);
+	if (!buf) {
+		LOG_ERR("Failed to allocate buffer");
+		free_xfer(xfer);
+		return -ENOMEM;
+	}
+	xfer->buf = buf;
+	xfer->recived_data_len = 0;
+
+	ret = usbh_xfer_enqueue(xfer->udev, xfer);
+	if (ret != 0) {
+		LOG_ERR("Enqueue failed: %d", ret);
+		free_xfer(xfer);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+static int hid_boot_req_cb(struct usb_device *const dev, struct uhc_transfer *const xfer)
+{
+	bool send_next_xfer_and_parse_report = true;
+
+	if (xfer->err == -ECONNRESET) {
+		LOG_INF("Interrupt transfer was canceled");
+		send_next_xfer_and_parse_report = false;
+	} else if (xfer->err) {
+		LOG_ERR("Interrupt request failed, err %d", xfer->err);
+		send_next_xfer_and_parse_report = false;
+	}
+
+	if (!xfer->priv) {
+		/* Device was disconnected */
+		send_next_xfer_and_parse_report = false;
+	}
+
+	if (send_next_xfer_and_parse_report) {
+		handle_hid_boot_report(xfer->priv, xfer->buf->data, xfer->buf->len);
+		continue_transfer(xfer);
+	} else {
+		LOG_INF("Stopping the polling of the device");
+		free_xfer(xfer);
+	}
+
+	return 0;
+}
+
+static int initiate_transfers(struct hid_boot_data *priv, struct usb_device *const udev,
+			      uint16_t len, uint8_t ep)
+{
+	struct net_buf *buf;
+	int ret;
+
+	priv->int_xfer =
+		usbh_xfer_alloc(udev, ep, USBH_HID_BOOT_REPORT_LEN_BYTES, hid_boot_req_cb, priv);
+	if (!priv->int_xfer) {
+		LOG_ERR("Failed to allocate transfer");
+		return -ENOMEM;
+	}
+
+	buf = usbh_xfer_buf_alloc(udev, len);
+	if (!buf) {
+		LOG_ERR("Failed to allocate buffer");
+		free_xfer(priv->int_xfer);
+		return -ENOMEM;
+	}
+	priv->int_xfer->buf = buf;
+
+	ret = usbh_xfer_enqueue(udev, priv->int_xfer);
+	if (ret != 0) {
+		LOG_ERR("Enqueue failed: %d", ret);
+		free_xfer(priv->int_xfer);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int hid_boot_class_init(struct hid_boot_data *priv, struct usb_device *const udev,
+			       uint8_t if_idx, uint8_t bInterfaceProtocol)
+{
+	if (priv == NULL) {
+		LOG_ERR("Class private data should be statically allocated");
+		return -EINVAL;
+	}
+
+	*priv = (struct hid_boot_data){.dev = priv->dev};
+
+	priv->type = bInterfaceProtocol == HID_BOOT_IFACE_CODE_KEYBOARD ? KEYBOARD : MOUSE;
+	priv->if_idx = if_idx;
+	priv->udev = udev;
+
+	return 0;
+}
+
+/* 7.2.6 of HID1.11 Specification */
+static int hid_set_boot_protocol(struct usb_device *const udev, uint16_t if_idx)
+{
+	const struct usb_req_type_field bmRequestType = {.direction = USB_REQTYPE_DIR_TO_DEVICE,
+							 .type = USB_REQTYPE_TYPE_CLASS,
+							 .recipient =
+								 USB_REQTYPE_RECIPIENT_INTERFACE};
+	LOG_DBG("Sending set boot protocol request to the device.");
+	return usbh_req_setup(udev, *(uint8_t *)&bmRequestType, USB_HID_SET_PROTOCOL,
+			      HID_PROTOCOL_BOOT, if_idx, 0, NULL);
+}
+
+/* 7.2.4 of HID1.11 Specification */
+static int hid_set_idle(struct usb_device *const udev, uint16_t if_idx)
+{
+	const struct usb_req_type_field bmRequestType = {.direction = USB_REQTYPE_DIR_TO_DEVICE,
+							 .type = USB_REQTYPE_TYPE_CLASS,
+							 .recipient =
+								 USB_REQTYPE_RECIPIENT_INTERFACE};
+	LOG_DBG("Sending set idle request to the device.");
+	return usbh_req_setup(udev, *(uint8_t *)&bmRequestType, USB_HID_SET_IDLE, 0, if_idx, 0,
+			      NULL);
+}
+
+static int usbh_hid_boot_probe(struct usbh_class_data *const c_data, struct usb_device *const udev,
+			       const uint8_t iface)
+{
+	const struct usb_if_descriptor *if_desc = NULL;
+	const struct usb_ep_descriptor *ep_desc = NULL;
+	struct hid_boot_data *priv = c_data->priv;
+	int ret = 0;
+	uint16_t max_packet_size;
+	uint8_t ep_addr;
+
+	LOG_DBG("Connected a HID Boot device");
+
+	if_desc = usbh_desc_get_iface(udev, iface);
+	ret = verify_desc(udev, iface, if_desc);
+	if (ret) {
+		return ret;
+	}
+
+	ep_desc = find_int_in_ep(if_desc);
+	if (ep_desc == NULL) {
+		return -ENOTSUP;
+	}
+	ep_addr = ep_desc->bEndpointAddress;
+	max_packet_size = ep_desc->wMaxPacketSize;
+
+	ret = hid_boot_class_init(priv, udev, iface, if_desc->bInterfaceProtocol);
+	if (ret) {
+		return ret;
+	}
+
+	if (if_desc->bInterfaceProtocol == HID_BOOT_IFACE_CODE_KEYBOARD) {
+		LOG_INF("HID Boot Keyboard detected");
+	} else if (if_desc->bInterfaceProtocol == HID_BOOT_IFACE_CODE_MOUSE) {
+		LOG_INF("HID Boot Mouse detected");
+	}
+
+	ret = hid_set_boot_protocol(udev, iface);
+	if (ret) {
+		LOG_ERR("Failed to set boot protocol");
+		return ret;
+	}
+
+	if (hid_set_idle(udev, iface)) {
+		LOG_WRN("Set Idle request failed. Continuing without idle configuration");
+	}
+
+	if (initiate_transfers(priv, udev, max_packet_size, ep_addr)) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int usbh_hid_boot_resumed(struct usbh_class_data *const c_data)
+{
+	struct hid_boot_data *priv = c_data->priv;
+
+	hid_set_idle(priv->udev, priv->if_idx);
+
+	return 0;
+};
+
+static int usbh_hid_boot_removed(struct usbh_class_data *c_data)
+{
+	struct hid_boot_data *priv = c_data->priv;
+
+	LOG_INF("HID Boot device disconnected");
+
+	if (priv->int_xfer) {
+		usbh_xfer_dequeue(priv->udev, priv->int_xfer);
+	}
+
+	return 0;
+}
+
+static struct usbh_class_api usbh_hid_boot_class_api = {
+	.init = usbh_hid_boot_init,
+	.probe = usbh_hid_boot_probe,
+	.removed = usbh_hid_boot_removed,
+	.completion_cb = NULL,
+	.suspended = NULL,
+	.resumed = NULL,
+};
+
+static struct usbh_class_filter usbh_hid_boot_filters[] = {
+	{
+		.flags = USBH_CLASS_MATCH_CODE_TRIPLE,
+		.class = USB_BCC_HID,
+		.sub = USBH_HID_BOOT_SUBCLASS,
+		.proto = HID_BOOT_IFACE_CODE_KEYBOARD,
+	},
+	{
+		.flags = USBH_CLASS_MATCH_CODE_TRIPLE,
+		.class = USB_BCC_HID,
+		.sub = USBH_HID_BOOT_SUBCLASS,
+		.proto = HID_BOOT_IFACE_CODE_MOUSE,
+	},
+	{0},
+};
+
+#define USBH_HID_BOOT_CLASS_DEFINE(n, _)                                                           \
+	static struct hid_boot_data hid_boot_data_##n = {.dev = DEVICE_GET(usbh_hid_boot_##n)};    \
+                                                                                                   \
+	DEVICE_DEFINE(usbh_hid_boot_##n, "usbh_hid_boot_" #n, NULL, NULL, NULL, NULL,              \
+		      PRE_KERNEL_1, CONFIG_USBH_HID_BOOT_INIT_PRIORITY, NULL);                     \
+	USBH_DEFINE_CLASS(usbh_hid_boot_##n, &usbh_hid_boot_class_api, &hid_boot_data_##n,         \
+			  usbh_hid_boot_filters);
+
+LISTIFY(CONFIG_USBH_HID_BOOT_INSTANCES_COUNT, USBH_HID_BOOT_CLASS_DEFINE, (;), _)

--- a/subsys/usb/host/class/usbh_hid_boot.h
+++ b/subsys/usb/host/class/usbh_hid_boot.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Antmicro <www.antmicro.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/usb/class/hid.h>
+#include <zephyr/input/input.h>
+#include <zephyr/usb/usbh.h>
+
+/*
+ * lmb - left mouse button
+ * rmb - right mouse button
+ * mmb - middle mouse button
+ */
+union hid_mouse_btns {
+	uint8_t raw;
+	struct {
+		uint8_t lmb: 1;
+		uint8_t rmb: 1;
+		uint8_t mmb: 1;
+		uint8_t: 5;
+	};
+} __packed;
+
+struct hid_mouse_report {
+	union hid_mouse_btns btns;
+	int8_t dx;
+	int8_t dy;
+} __packed;
+
+union hid_kbd_modifiers {
+	uint8_t raw;
+	struct {
+		uint8_t l_ctrl: 1;
+		uint8_t l_shift: 1;
+		uint8_t l_alt: 1;
+		uint8_t l_gui: 1;
+
+		uint8_t r_ctrl: 1;
+		uint8_t r_shift: 1;
+		uint8_t r_alt: 1;
+		uint8_t r_gui: 1;
+	};
+} __packed;
+
+struct hid_kbd_report {
+	union hid_kbd_modifiers modifiers;
+	uint8_t: 8;
+	uint8_t pressed_keys[6];
+} __packed;
+
+enum hid_boot_type {
+	KEYBOARD = HID_BOOT_IFACE_CODE_KEYBOARD,
+	MOUSE = HID_BOOT_IFACE_CODE_MOUSE,
+};
+
+struct hid_boot_data {
+	const struct device *dev;
+	struct uhc_transfer *int_xfer;
+	struct usb_device *udev;
+	enum hid_boot_type type;
+	union {
+		union hid_mouse_btns mouse_btns;
+		struct hid_kbd_report kbd;
+	} last_report;
+	uint8_t if_idx;
+};
+
+static const uint16_t hid_to_input_map[] = {
+	[HID_KEY_A] = INPUT_KEY_A,
+	[HID_KEY_B] = INPUT_KEY_B,
+	[HID_KEY_C] = INPUT_KEY_C,
+	[HID_KEY_D] = INPUT_KEY_D,
+	[HID_KEY_E] = INPUT_KEY_E,
+	[HID_KEY_F] = INPUT_KEY_F,
+	[HID_KEY_G] = INPUT_KEY_G,
+	[HID_KEY_H] = INPUT_KEY_H,
+	[HID_KEY_I] = INPUT_KEY_I,
+	[HID_KEY_J] = INPUT_KEY_J,
+	[HID_KEY_K] = INPUT_KEY_K,
+	[HID_KEY_L] = INPUT_KEY_L,
+	[HID_KEY_M] = INPUT_KEY_M,
+	[HID_KEY_N] = INPUT_KEY_N,
+	[HID_KEY_O] = INPUT_KEY_O,
+	[HID_KEY_P] = INPUT_KEY_P,
+	[HID_KEY_Q] = INPUT_KEY_Q,
+	[HID_KEY_R] = INPUT_KEY_R,
+	[HID_KEY_S] = INPUT_KEY_S,
+	[HID_KEY_T] = INPUT_KEY_T,
+	[HID_KEY_U] = INPUT_KEY_U,
+	[HID_KEY_V] = INPUT_KEY_V,
+	[HID_KEY_W] = INPUT_KEY_W,
+	[HID_KEY_X] = INPUT_KEY_X,
+	[HID_KEY_Y] = INPUT_KEY_Y,
+	[HID_KEY_Z] = INPUT_KEY_Z,
+	[HID_KEY_1] = INPUT_KEY_1,
+	[HID_KEY_2] = INPUT_KEY_2,
+	[HID_KEY_3] = INPUT_KEY_3,
+	[HID_KEY_4] = INPUT_KEY_4,
+	[HID_KEY_5] = INPUT_KEY_5,
+	[HID_KEY_6] = INPUT_KEY_6,
+	[HID_KEY_7] = INPUT_KEY_7,
+	[HID_KEY_8] = INPUT_KEY_8,
+	[HID_KEY_9] = INPUT_KEY_9,
+	[HID_KEY_0] = INPUT_KEY_0,
+	[HID_KEY_ENTER] = INPUT_KEY_ENTER,
+	[HID_KEY_ESC] = INPUT_KEY_ESC,
+	[HID_KEY_BACKSPACE] = INPUT_KEY_BACKSPACE,
+	[HID_KEY_TAB] = INPUT_KEY_TAB,
+	[HID_KEY_SPACE] = INPUT_KEY_SPACE,
+	[HID_KEY_MINUS] = INPUT_KEY_MINUS,
+	[HID_KEY_EQUAL] = INPUT_KEY_EQUAL,
+	[HID_KEY_LEFTBRACE] = INPUT_KEY_LEFTBRACE,
+	[HID_KEY_RIGHTBRACE] = INPUT_KEY_RIGHTBRACE,
+	[HID_KEY_BACKSLASH] = INPUT_KEY_BACKSLASH,
+	[HID_KEY_SEMICOLON] = INPUT_KEY_SEMICOLON,
+	[HID_KEY_APOSTROPHE] = INPUT_KEY_APOSTROPHE,
+	[HID_KEY_GRAVE] = INPUT_KEY_GRAVE,
+	[HID_KEY_COMMA] = INPUT_KEY_COMMA,
+	[HID_KEY_DOT] = INPUT_KEY_DOT,
+	[HID_KEY_SLASH] = INPUT_KEY_SLASH,
+	[HID_KEY_CAPSLOCK] = INPUT_KEY_CAPSLOCK,
+	[HID_KEY_F1] = INPUT_KEY_F1,
+	[HID_KEY_F2] = INPUT_KEY_F2,
+	[HID_KEY_F3] = INPUT_KEY_F3,
+	[HID_KEY_F4] = INPUT_KEY_F4,
+	[HID_KEY_F5] = INPUT_KEY_F5,
+	[HID_KEY_F6] = INPUT_KEY_F6,
+	[HID_KEY_F7] = INPUT_KEY_F7,
+	[HID_KEY_F8] = INPUT_KEY_F8,
+	[HID_KEY_F9] = INPUT_KEY_F9,
+	[HID_KEY_F10] = INPUT_KEY_F10,
+	[HID_KEY_F11] = INPUT_KEY_F11,
+	[HID_KEY_F12] = INPUT_KEY_F12,
+	[HID_KEY_SYSRQ] = INPUT_KEY_SYSRQ,
+	[HID_KEY_SCROLLLOCK] = INPUT_KEY_SCROLLLOCK,
+	[HID_KEY_PAUSE] = INPUT_KEY_PAUSE,
+	[HID_KEY_INSERT] = INPUT_KEY_INSERT,
+	[HID_KEY_HOME] = INPUT_KEY_HOME,
+	[HID_KEY_PAGEUP] = INPUT_KEY_PAGEUP,
+	[HID_KEY_DELETE] = INPUT_KEY_DELETE,
+	[HID_KEY_END] = INPUT_KEY_END,
+	[HID_KEY_PAGEDOWN] = INPUT_KEY_PAGEDOWN,
+	[HID_KEY_RIGHT] = INPUT_KEY_RIGHT,
+	[HID_KEY_LEFT] = INPUT_KEY_LEFT,
+	[HID_KEY_DOWN] = INPUT_KEY_DOWN,
+	[HID_KEY_UP] = INPUT_KEY_UP,
+	[HID_KEY_NUMLOCK] = INPUT_KEY_NUMLOCK,
+	[HID_KEY_KPSLASH] = INPUT_KEY_KPSLASH,
+	[HID_KEY_KPASTERISK] = INPUT_KEY_KPASTERISK,
+	[HID_KEY_KPMINUS] = INPUT_KEY_KPMINUS,
+	[HID_KEY_KPPLUS] = INPUT_KEY_KPPLUS,
+	[HID_KEY_KPENTER] = INPUT_KEY_KPENTER,
+	[HID_KEY_KP_1] = INPUT_KEY_KP1,
+	[HID_KEY_KP_2] = INPUT_KEY_KP2,
+	[HID_KEY_KP_3] = INPUT_KEY_KP3,
+	[HID_KEY_KP_4] = INPUT_KEY_KP4,
+	[HID_KEY_KP_5] = INPUT_KEY_KP5,
+	[HID_KEY_KP_6] = INPUT_KEY_KP6,
+	[HID_KEY_KP_7] = INPUT_KEY_KP7,
+	[HID_KEY_KP_8] = INPUT_KEY_KP8,
+	[HID_KEY_KP_9] = INPUT_KEY_KP9,
+	[HID_KEY_KP_0] = INPUT_KEY_KP0,
+	[HID_KEY_KPDOT] = INPUT_KEY_KPDOT,
+	[HID_KEY_MENU] = INPUT_KEY_MENU,
+};


### PR DESCRIPTION
Add support for Boot subclass of HID that enables Zephyr-based systems to act as USB hosts for most keyboards and mice. This allows applications to easily get human inputs from USB keyboards and mice by simply adding a callback to the input subsystem.

Note: this effort was largely tested on the max3421e controller and therefore depends on:
* https://github.com/zephyrproject-rtos/zephyr/pull/110420 (in the original feature scope)
* https://github.com/zephyrproject-rtos/zephyr/pull/118748
* https://github.com/zephyrproject-rtos/zephyr/pull/118749
* https://github.com/zephyrproject-rtos/zephyr/pull/118750