### PR TITLE
libc/picolibc: Remove non-working picolibc optimization settings

### DIFF
--- a/lib/libc/picolibc/Kconfig
+++ b/lib/libc/picolibc/Kconfig
@@ -67,43 +67,6 @@ endchoice
 
 if PICOLIBC_USE_MODULE
 
-choice PICOLIBC_OPTIMIZATIONS
-	prompt "Optimization level"
-	default PICOLIBC_SIZE_OPTIMIZATIONS if SIZE_OPTIMIZATIONS
-	default PICOLIBC_SPEED_OPTIMIZATIONS if SPEED_OPTIMIZATIONS
-	default PICOLIBC_DEBUG_OPTIMIZATIONS if DEBUG_OPTIMIZATIONS
-	default PICOLIBC_NO_OPTIMIZATIONS if NO_OPTIMIZATIONS
-	help
-	  Note that these flags shall only control the compiler
-	  optimization level for picolibc, not the level for the
-	  rest of Zephyr
-
-config PICOLIBC_SIZE_OPTIMIZATIONS
-	bool "Optimize for size"
-	help
-	  Compiler optimizations will be set to -Os independently of other
-	  options.
-
-config PICOLIBC_SPEED_OPTIMIZATIONS
-	bool "Optimize for speed"
-	help
-	  Compiler optimizations will be set to -O2 independently of other
-	  options.
-
-config PICOLIBC_DEBUG_OPTIMIZATIONS
-	bool "Optimize debugging experience"
-	help
-	  Compiler optimizations will be set to -Og independently of other
-	  options.
-
-config PICOLIBC_NO_OPTIMIZATIONS
-	bool "Optimize nothing"
-	help
-	  Compiler optimizations will be set to -O0 independently of other
-	  options.
-
-endchoice
-
 config PICOLIBC_FAST_STRCMP
 	bool "always use fast strcmp paths"
 	default y

--- a/tests/benchmarks/ipi_metric/prj.conf
+++ b/tests/benchmarks/ipi_metric/prj.conf
@@ -14,10 +14,6 @@ CONFIG_TIMESLICING=n
 # improve system performance.
 CONFIG_HW_STACK_PROTECTION=n
 
-# Picolibc is faster than Zephyr's minimal libc memcpy
-CONFIG_PICOLIBC_SPEED_OPTIMIZATIONS=y
-CONFIG_PICOLIBC_USE_MODULE=y
-
 # Disable Thread Local Storage for better context switching times
 CONFIG_THREAD_LOCAL_STORAGE=n
 

--- a/tests/benchmarks/thread_metric/prj.conf
+++ b/tests/benchmarks/thread_metric/prj.conf
@@ -20,10 +20,6 @@ CONFIG_MP_MAX_NUM_CPUS=1
 # improve system performance.
 CONFIG_HW_STACK_PROTECTION=n
 
-# Picolibc is faster than Zephyr's minimal libc memcpy
-CONFIG_PICOLIBC_SPEED_OPTIMIZATIONS=y
-CONFIG_PICOLIBC_USE_MODULE=y
-
 # Disable Thread Local Storage for better context switching times
 CONFIG_THREAD_LOCAL_STORAGE=n
 


### PR DESCRIPTION
I can't find any trace of support for these outside of the Kconfig file; they "can't" have ever worked.