### PR TITLE
scripts: ci: report analyzer: don't look past the start of the build log

### DIFF
--- a/scripts/ci/twister_report_analyzer.py
+++ b/scripts/ci/twister_report_analyzer.py
@@ -228,7 +228,12 @@ class TwisterReports:
         last_overflow = ''
         lines = log.splitlines()
         for i, line in enumerate(lines):
-            if "error: ld returned" in line and "overflowed by" in lines[i - 1]:
+            # The overflow is reported on the line before the linker error, so
+            # when the linker error is the first line there is nothing to read.
+            # lines[i - 1] at i == 0 is the last line of the log, which twister
+            # takes from the handler's stderr rather than from the build.
+            previous = lines[i - 1] if i else ""
+            if "error: ld returned" in line and "overflowed by" in previous:
                 # get build step where overflow occurs
                 build_step = ""
                 if len(build_step_stack) > 0:

--- a/scripts/tests/ci/test_twister_report_analyzer.py
+++ b/scripts/tests/ci/test_twister_report_analyzer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for scripts/ci/twister_report_analyzer.py.
+
+Run from the zephyr root::
+
+    pytest scripts/tests/ci/test_twister_report_analyzer.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ZEPHYR_BASE = os.environ.get("ZEPHYR_BASE", str(Path(__file__).parents[3]))
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "ci"))
+
+import twister_report_analyzer as tra  # noqa: E402, I001
+
+LD_RETURNED = "/usr/bin/ld.bfd: error: ld returned 1 exit status"
+OVERFLOWED = "/usr/bin/ld.bfd: region `FLASH' overflowed by 4096 bytes"
+BUILD_STEP = "-- Performing build step for 'mcuboot'"
+STDERR_TAIL = "west error: region `RAM' overflowed by 8 bytes"
+
+TESTDATA_BUILD_INFO = [
+    (
+        [OVERFLOWED, LD_RETURNED],
+        " at region FLASH",
+    ),
+    (
+        [BUILD_STEP, OVERFLOWED, LD_RETURNED],
+        " at region FLASH at build step for mcuboot",
+    ),
+    (
+        [BUILD_STEP, "-- Completed 'mcuboot'", OVERFLOWED, LD_RETURNED],
+        " at region FLASH",
+    ),
+    (
+        ["main.c:1:1: error: nope is not a thing"],
+        "",
+    ),
+    # The overflow is reported on the line before the linker error, so a
+    # linker error on the first line has no line to read. Reading lines[i - 1]
+    # there wraps around to the end of the log -- which twister fills with the
+    # handler's stderr -- and returns before the real overflow further down.
+    (
+        [LD_RETURNED, BUILD_STEP, OVERFLOWED, LD_RETURNED, STDERR_TAIL],
+        " at region FLASH at build step for mcuboot",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "log_lines, expected",
+    TESTDATA_BUILD_INFO,
+    ids=[
+        "overflow before linker error",
+        "overflow inside a build step",
+        "build step already completed",
+        "not a linker failure",
+        "linker error first, stderr overflow last",
+    ],
+)
+def test_get_info_from_build_failure(log_lines, expected):
+    reports = tra.TwisterReports()
+    assert reports._get_info_from_build_failure("\n".join(log_lines)) == expected


### PR DESCRIPTION
`_get_info_from_build_failure()` in `scripts/ci/twister_report_analyzer.py` works out which region overflowed by reading the line before the one carrying `error: ld returned`:

```python
if "error: ld returned" in line and "overflowed by" in lines[i - 1]:
```

At `i == 0` that is `lines[-1]`, the last line of the log. That line does not even come from the build: `JsonReport.create()` appends the handler's stderr to the build log before writing it to `twister.json`, which is what this tool reads. So when a log opens on a linker error and happens to end on a line that mentions an overflow, the function returns straight away with no region and no build step, and the real overflow further down the log never makes it into the CI job summary.

It is the same expression that commit 30beaec88f2f ("twister: reports: don't look past the start of the build log") fixed in `JsonReport._parse_build_failure()`. That commit said it was leaving this tool for a change of its own; this is that change. The fix reads the previous line only when there is one.

I also added the first unit tests for the tool, under `scripts/tests/ci/` next to the existing `test_test_plan_v2.py`. Four cases pass before and after the fix (overflow before the linker error, overflow inside a build step, build step already completed, and a log that is not a linker failure); one case only passes with it.

Two things worth flagging. No workflow currently runs `scripts/tests/ci/`, so these tests are not executed by CI — run them with `pytest scripts/tests/ci/test_twister_report_analyzer.py`. I can wire that directory into a workflow in a separate PR if you want it. And I have not run the tool against a real `twister.json`.
