### PR TITLE
manifest: trusted-firmware-m: update to cherry-pick

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: ef35073337e66e3117a6ef33fc60f69596d2afbc
+      revision: a33c88e2f71e1fee08b07775e49fd8f53ede635c
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee

--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: a33c88e2f71e1fee08b07775e49fd8f53ede635c
+      revision: pull/232/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update Zephyr's trusted-firmware-m manifest revision to track:
`pull/232/head`

Referenced TF-M PR:
https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/232

That TF-M PR cherry-picks this merged Gerrit change:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/54179