### PR TITLE
usb: device_next: initialize usbd_context mutex

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -524,6 +524,7 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 	))								\
 	static STRUCT_SECTION_ITERABLE(usbd_context, device_name) = {	\
 		.name = STRINGIFY(device_name),				\
+		.mutex = Z_MUTEX_INITIALIZER(device_name.mutex),	\
 		.dev = udc_dev,						\
 		.fs_desc = &fs_desc_##device_name,			\
 		IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (			\


### PR DESCRIPTION
USBD_DEVICE_DEFINE() leaves usbd_context.mutex value-initialized instead of calling k_mutex_init(). wait_q's dlist head ends up all-zero instead of self-pointing, so the first contended lock corrupts memory via sys_dlist_append() writing through a NULL list->tail. Uncontended locking survives by luck since lock_count == 0 short-circuits before the wait queue is touched.

Fixes it by initializing the mutex with Z_MUTEX_INITIALIZER, same as K_MUTEX_DEFINE().

Split out of #118165 as an independent, backportable fix.