### PR TITLE
boards: arduino: nano_r4: migrate to using mapped-partition

### DIFF
--- a/boards/arduino/nano_r4/arduino_nano_r4.dts
+++ b/boards/arduino/nano_r4/arduino_nano_r4.dts
@@ -32,7 +32,7 @@
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
+		zephyr,flash = &code_flash;
 		zephyr,entropy = &trng;
 		zephyr,code-partition = &code_partition;
 	};
@@ -180,7 +180,7 @@
 	status = "okay";
 };
 
-&flash0 {
+&code_flash {
 	partitions {
 		ranges;
 		#address-cells = <1>;


### PR DESCRIPTION
Migrate to using mapped-partition for the Arduino nano_r4.

This fixes the build failure in https://github.com/zephyrproject-rtos/zephyr/actions/runs/34507473891/job/102973534062