### PR TITLE
dts: xlnx: add SDHC nodes for Zynq SoC

### DIFF
--- a/boards/qemu/cortex_a9/board.cmake
+++ b/boards/qemu/cortex_a9/board.cmake
@@ -13,6 +13,35 @@ set(QEMU_BOARD_FLAGS
   -dtb ${CMAKE_CURRENT_LIST_DIR}/fdt-zynq7000s.dtb
   )
 
+if(CONFIG_XLNX_SDHC)
+  find_program(QEMU_IMG_EXECUTABLE qemu-img)
+  if(NOT QEMU_IMG_EXECUTABLE)
+    message(FATAL_ERROR
+      "qemu-img not found on PATH. It is required to generate the SD card "
+      "image for CONFIG_XLNX_SDHC.\n"
+      "  Linux:   sudo apt install qemu-utils  (or your distro's equivalent)\n"
+      "  macOS:   brew install qemu\n"
+      "  Windows: install from https://qemu.weilnetz.de/w64/, or use WSL/MSYS2"
+    )
+  endif()
+
+  set(SD_IMAGE ${ZEPHYR_BINARY_DIR}/sdcard.img)
+
+  if(NOT EXISTS ${SD_IMAGE})
+    execute_process(
+      COMMAND ${QEMU_IMG_EXECUTABLE} create -f raw ${SD_IMAGE} 64M
+      RESULT_VARIABLE SD_IMAGE_CREATE_RESULT
+    )
+    if(NOT SD_IMAGE_CREATE_RESULT EQUAL 0)
+      message(FATAL_ERROR "Failed to create SD card image at ${SD_IMAGE}")
+    endif()
+  endif()
+
+  list(APPEND QEMU_BOARD_FLAGS
+    -drive file=${SD_IMAGE},format=raw,if=sd,index=0
+  )
+endif()
+
 set(QEMU_KERNEL_OPTION
   "-device;loader,file=\$<TARGET_FILE:\${logical_target_for_zephyr_elf}>,cpu-num=0"
   )

--- a/boards/qemu/cortex_a9/qemu_cortex_a9.dts
+++ b/boards/qemu/cortex_a9/qemu_cortex_a9.dts
@@ -42,6 +42,11 @@
 		zephyr,shell-uart = &uart0;
 		zephyr,ocm = &ocm_low;
 		zephyr,uart-pipe = &uart1;
+		zephyr,sdhc = &sdhc0;
+	};
+
+	aliases {
+		sdhc0 = &sdhc0;
 	};
 };
 
@@ -70,6 +75,16 @@
 	gem0_phy: phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
+		status = "okay";
+	};
+};
+
+&sdhc0 {
+	status = "okay";
+
+	sdmmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
 		status = "okay";
 	};
 };

--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -3,12 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <freq.h>
 #include <mem.h>
 #include <arm/armv7-a.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/ethernet/xlnx_gem.h>
 
 / {
+	sdhci_ref_clk: sdhci-ref-clk {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(200)>;
+		#clock-cells = <0>;
+	};
+
 	soc {
 		interrupt-parent = <&gic>;
 
@@ -220,6 +227,24 @@
 				ngpios = <32>;
 				status = "okay";
 			};
+		};
+
+		sdhc0: mmc@e0100000 {
+			compatible = "xlnx,versal-8.9a";
+			reg = <0xe0100000 0x1000>;
+			status = "disabled";
+			clocks = <&sdhci_ref_clk>;
+			interrupts = <GIC_SPI 24 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+		};
+
+		sdhc1: mmc@e0101000 {
+			compatible = "xlnx,versal-8.9a";
+			reg = <0xe0101000 0x1000>;
+			status = "disabled";
+			clocks = <&sdhci_ref_clk>;
+			interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
 		};
 	};
 


### PR DESCRIPTION
Add SDHC controller nodes to the Zynq-7000 SoC devicetree, including the reference clock and interrupt configuration.

Enable the SDHC controller and SDMMC disk node on the QEMU Cortex-A9 board, and attach an SD image when CONFIG_XLNX_SDHC is enabled.

# Testing
Tested with `qemu_cortex_a9` tests/subsys/sd/sdmmc/

```
*** Booting Zephyr OS build v4.4.0-14797-g878f752655ab ***
Running TESTSUITE sd_stack
===================================================================
START - test_0_init
 PASS - test_0_init in 1.004 seconds
===================================================================
START - test_card_config
Card voltage: 3.3V
Card timing: Legacy
Bus Frequency: 50000000 Hz
Card type: SDMMC
Card spec: 2.0
 PASS - test_card_config in 0.001 seconds
===================================================================
START - test_ioctl
SD card reports sector count of 131072
SD card reports sector size of 512
 PASS - test_ioctl in 0.001 seconds
===================================================================
START - test_read
 PASS - test_read in 0.176 seconds
===================================================================
START - test_rw
 PASS - test_rw in 2.507 seconds
===================================================================
START - test_write
 PASS - test_write in 0.177 seconds
===================================================================
TESTSUITE sd_stack succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [sd_stack]: pass = 6, fail = 0, skip = 0, total = 6 duration = 3.866 seconds
 - PASS - [sd_stack.test_0_init] duration = 1.004 seconds
 - PASS - [sd_stack.test_card_config] duration = 0.001 seconds
 - PASS - [sd_stack.test_ioctl] duration = 0.001 seconds
 - PASS - [sd_stack.test_read] duration = 0.176 seconds
 - PASS - [sd_stack.test_rw] duration = 2.507 seconds
 - PASS - [sd_stack.test_write] duration = 0.177 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```