### PR TITLE
modules: hostap: Update sources for hostap 2.12 upmerge

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -212,6 +212,7 @@ if(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP OR CONFIG_WIFI_NM_HOSTAPD_AP)
     ${HOSTAP_SRC_BASE}/ap/hw_features.c
     ${HOSTAP_SRC_BASE}/ap/ieee802_11_auth.c
     ${HOSTAP_SRC_BASE}/ap/ieee802_11.c
+    ${HOSTAP_SRC_BASE}/ap/interference.c
     ${HOSTAP_SRC_BASE}/ap/comeback_token.c
     ${HOSTAP_SRC_BASE}/ap/ieee802_11_ht.c
     ${HOSTAP_SRC_BASE}/ap/ieee802_11_shared.c
@@ -619,18 +620,35 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP
   ${HOSTAP_SRC_BASE}/common/gas.c
   ${HOSTAP_SRC_BASE}/common/dpp_backup.c
 
-  ${HOSTAP_SRC_BASE}/crypto/aes-siv.c
-
   ${HOSTAP_SRC_BASE}/utils/json.c
   ${HOSTAP_SRC_BASE}/utils/ip_addr.c
 
   ${HOSTAP_SRC_BASE}/tls/asn1.c
 )
 
+# aes-siv.c is needed by DPP as well as by SAE (e.g. SAE Password
+# Identifier encryption/decryption), so it cannot be tied to a single
+# Kconfig symbol.
+if(CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP OR CONFIG_WIFI_NM_WPA_SUPPLICANT_WPA3)
+  zephyr_library_sources(
+    ${HOSTAP_SRC_BASE}/crypto/aes-siv.c
+  )
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
-  ${WIFI_NM_WPA_SUPPLICANT_BASE}/nan_usd.c
+  ${WIFI_NM_WPA_SUPPLICANT_BASE}/nan_supplicant.c
   ${HOSTAP_SRC_BASE}/ap/nan_usd_ap.c
   ${HOSTAP_SRC_BASE}/common/nan_de.c
+  ${HOSTAP_SRC_BASE}/nan/nan.c
+  ${HOSTAP_SRC_BASE}/nan/nan_util.c
+  ${HOSTAP_SRC_BASE}/nan/nan_ndp.c
+  ${HOSTAP_SRC_BASE}/nan/nan_ndl.c
+  ${HOSTAP_SRC_BASE}/nan/nan_crypto.c
+  ${HOSTAP_SRC_BASE}/nan/nan_sec.c
+  ${HOSTAP_SRC_BASE}/nan/nan_bootstrap.c
+
+  ${HOSTAP_SRC_BASE}/crypto/sha256-pbkdf2.c
+  ${HOSTAP_SRC_BASE}/crypto/sha384-pbkdf2.c
 )
 
 zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 4f141f443d66cfa06269edc1bcf213e86136d0e6
+      revision: pull/157/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
## Summary
- `modules/hostap/CMakeLists.txt`: update the hostap module's source
  list for the hostap 2.12 upmerge (see the companion hostap PR
  below): add `src/ap/interference.c`, fix `src/crypto/aes-siv.c`
  gating (now also needed by `CONFIG_SAE`, not just DPP), rewrite the
  NAN source list (the old standalone `wpa_supplicant/nan_usd.c` was
  replaced upstream by a full engine under `src/nan/`), and add the
  new `src/crypto/sha256-pbkdf2.c`/`sha384-pbkdf2.c` files needed by
  NAN pairing PMK derivation.
- `west.yml`: point the `hostap` module at
  zephyrproject-rtos/hostap#157 (`pull/157/head`) until that PR
  merges, then this needs a follow-up bumping it to the merged
  commit.

Companion hostap module PR: zephyrproject-rtos/hostap#157

## Test plan
- [x] `zephyr/tests/net/wifi/configs`: all 17 configs build clean
      (native_sim)
- [x] `zephyr/samples/net/wifi/shell`: `sample.net.wifi.hwsim`
      (native_sim) and `sample.net.wifi.nrf70dk` (real nRF7002/nRF7001
      driver path) build clean
- [ ] Real board testing (nRF70 hardware) - to be done separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)