### PR TITLE
subsys: ctf: add circular buffer support

### DIFF
--- a/doc/services/tracing/ctf_circular_ram.rst
+++ b/doc/services/tracing/ctf_circular_ram.rst
@@ -1,0 +1,549 @@
+.. SPDX-FileCopyrightText: Copyright Qualcomm Technologies, Inc. and/or its subsidiaries.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _ctf_circular_ram_capture:
+
+CTF Circular RAM Capture
+########################
+
+Overview
+********
+
+The CTF circular RAM capture provides a bounded, overwrite-oldest trace store for
+devices where continuously streaming trace data over UART, USB, or another transport is
+not practical. It operates as a flight recorder: once the allocated RAM is full, the
+oldest complete CTF packet is replaced while newer packets remain available for
+post-mortem analysis.
+
+The capture path is local to the :ref:`Common Trace Format (CTF) <ctf>` implementation.
+It is intentionally not registered as a generic tracing backend. CTF events are already
+available as complete, self-contained event records at ``CTF_GATHER_FIELDS()``. Writing
+them directly at that point preserves event boundaries and avoids exposing a
+CTF-specific packet store to other tracing frontends.
+
+After the RAM buffer is dumped from the target, the
+:zephyr_file:`scripts/tracing/sort_ctf_circular.py` host utility validates and orders the
+packets. The resulting trace directory can be passed directly to Babeltrace 2 or another
+CTF 1.8 consumer.
+
+Use cases
+=========
+
+The circular capture is useful when:
+
+* the failure of interest occurs before a host can start a trace capture;
+* the target cannot dedicate an I/O peripheral to tracing;
+* trace collection must continue for an indefinite period using bounded memory;
+* only the events immediately preceding a crash, watchdog reset, or debugger halt are
+  required; or
+* preserving complete CTF event and packet boundaries is more important than retaining
+  the oldest events.
+
+It is not intended to replace a streaming backend when the complete trace history must
+be retained.
+
+Design
+******
+
+Event routing
+=============
+
+With a normal tracing output selected, the CTF path remains unchanged::
+
+   CTF_EVENT()
+       -> CTF_GATHER_FIELDS()
+       -> tracing_format_raw_data()
+       -> tracing core
+       -> selected tracing backend
+
+With :kconfig:option:`CONFIG_TRACING_CTF_CIRCULAR_RAM` selected, the final routing step
+changes::
+
+   CTF_EVENT()
+       -> CTF_GATHER_FIELDS()
+       -> ctf_circular_ram_write()
+       -> ram_tracing_circular[]
+
+The two paths are selected at build time. Circular capture uses the RAM tracing backend
+selection while CTF events are routed directly to the CTF-local writer.
+
+The local writer still uses the tracing core's enable state. Calling the existing tracing
+control integration to disable tracing therefore also stops writes to the circular
+buffer. The circular output itself does not provide a transport for receiving host
+commands.
+
+Why this is not a tracing backend
+=================================
+
+A generic tracing backend receives bytes after the frontend and formatting decisions
+have already been made. The circular implementation has additional CTF-specific
+requirements:
+
+* each write must contain exactly one complete CTF event;
+* the event timestamp must be the first serialized event field;
+* CTF packet headers and packet context fields must be generated and updated;
+* rollover must replace complete CTF packets rather than arbitrary byte ranges; and
+* the host must use metadata matching the generated packet context.
+
+Registering this code as a generic backend would imply that other tracing formats and
+frontend APIs could use it. Those callers do not necessarily provide CTF events or
+preserve event boundaries. In particular, asynchronous tracing can deliver arbitrary
+byte runs that may contain a partial event or multiple events. Keeping the writer inside
+``subsys/tracing/ctf`` makes these constraints explicit.
+
+Alternatives considered
+=======================
+
+Generic tracing backend
+-----------------------
+
+A registered backend reuses the existing tracing-core dispatch mechanism and requires
+fewer changes in the CTF frontend. However, it incorrectly presents a CTF-only format as
+a general-purpose backend and relies on every caller providing exactly one complete CTF
+event. It is also incompatible with the asynchronous formatter's arbitrary byte runs.
+
+Linear RAM backend
+------------------
+
+The existing RAM backend is simple and produces a byte stream that can be dumped with a
+debugger. Once its buffer is full, subsequent events are discarded. This retains the
+beginning of the trace instead of the events closest to a late failure.
+
+Byte-oriented circular buffer
+-----------------------------
+
+A conventional byte ring buffer can use nearly all available memory, but rollover may
+split a CTF event or packet header. The host would then need to search for a valid event
+boundary without enough information to distinguish payload bytes from framing bytes.
+Whole-packet rotation makes recovery deterministic.
+
+Whole CTF packet rotation
+-------------------------
+
+The selected design divides RAM into fixed-size, independently decodable CTF packets.
+Rollover may leave unused bytes at the end of a packet, but it never intentionally splits
+an event. Packet sequence numbers provide an unambiguous host-side ordering after the
+physical buffer wraps.
+
+Configuration
+*************
+
+Enable the capture with a configuration similar to:
+
+.. code-block:: cfg
+
+   CONFIG_TRACING=y
+   CONFIG_TRACING_CTF=y
+   CONFIG_TRACING_SYNC=y
+   CONFIG_TRACING_CTF_CIRCULAR_RAM=y
+   CONFIG_TRACING_BACKEND_RAM=y
+   CONFIG_TRACING_CTF_TIMESTAMP=y
+
+   CONFIG_RAM_TRACING_BUFFER_SIZE=4096
+   CONFIG_TRACING_BACKEND_RAM_PACKET_COUNT=32
+   CONFIG_TRACING_PACKET_MAX_SIZE=64
+
+The relevant options are:
+
+* :kconfig:option:`CONFIG_TRACING_CTF_CIRCULAR_RAM` enables the CTF-local circular
+  capture path.
+* :kconfig:option:`CONFIG_TRACING_SYNC` is required because the writer consumes one
+  complete event per call.
+* :kconfig:option:`CONFIG_TRACING_BACKEND_RAM` is the required tracing backend
+  selection. CTF events are routed directly to the circular capture writer.
+* :kconfig:option:`CONFIG_TRACING_CTF_TIMESTAMP_64` is selected automatically. The
+  circular metadata and packet writer use 64-bit timestamps.
+* :kconfig:option:`CONFIG_RAM_TRACING_BUFFER_SIZE` sets the total size of
+  ``ram_tracing_circular``.
+* :kconfig:option:`CONFIG_TRACING_BACKEND_RAM_PACKET_COUNT` sets the number of rotating
+  packet slots.
+* :kconfig:option:`CONFIG_TRACING_PACKET_MAX_SIZE` contributes to the build-time check
+  that one slot can contain a packet header and the configured maximum trace packet.
+
+Use the RAM tracing backend with circular CTF capture.
+
+Buffer sizing
+=============
+
+For a buffer of size :math:`B` and :math:`N` packet slots, each slot has size:
+
+.. math::
+
+   S = B / N
+
+The current packet header and context occupy 36 bytes. Therefore, the nominal event-data
+capacity, before end-of-packet fragmentation, is:
+
+.. math::
+
+   B - (36 * N)
+
+The build fails unless:
+
+* At least two packet slots are configured.
+* ``CONFIG_RAM_TRACING_BUFFER_SIZE`` is divisible by
+  ``CONFIG_TRACING_BACKEND_RAM_PACKET_COUNT``.
+* A slot can contain the 36-byte header plus ``CONFIG_TRACING_PACKET_MAX_SIZE`` bytes.
+* The slot size in bits can be represented by the 32-bit ``packet_size`` field.
+
+With the defaults of 4096 bytes and 32 slots, each slot is 128 bytes. Packet headers use
+1152 bytes in total, leaving a nominal 2944 bytes for events. A smaller slot count reduces
+header overhead and provides more room for large events, while a larger slot count creates
+more independently ordered packets at the cost of additional headers.
+
+.. _ctf_circular_ram_maximum_event_size:
+
+Maximum event size
+==================
+
+The nominal capacity above is the total event-data capacity across all slots. It is not
+the maximum size of one event. A single event must fit in the event-data area of one slot:
+
+.. math::
+
+   E_{max} = S - 36
+
+where :math:`S` is the slot size and 36 bytes is the packet header and context size. With
+the default 128-byte slot, the largest event that can be recorded is 92 bytes.
+
+When an event fits in an empty slot but not in the active slot, the writer closes the
+active packet and writes the complete event to the next packet. The unused bytes at the
+end of the closed packet are padding and are excluded by its ``content_size`` field.
+
+An event larger than :math:`E_{max}` cannot fit in the current packet or in any subsequent
+packet. The writer drops it without modifying the circular buffer. It does not split an
+event across two packets because every packet must remain independently decodable after
+rollover or a debugger halt. Splitting would require continuation framing and would leave
+an incomplete event if either packet were overwritten or captured during an update.
+
+Set :kconfig:option:`CONFIG_TRACING_PACKET_MAX_SIZE` no larger than :math:`E_{max}`. The
+build-time assertion verifies this configuration. If a larger event must be retained,
+increase :kconfig:option:`CONFIG_RAM_TRACING_BUFFER_SIZE`, reduce
+:kconfig:option:`CONFIG_TRACING_BACKEND_RAM_PACKET_COUNT`, or both. For a requested
+maximum event size :math:`P`, the configuration must satisfy:
+
+.. math::
+
+   \frac{B}{N} \mathrel{\geq} 36 + P
+
+Memory format
+*************
+
+The exported target symbol remains::
+
+   uint8_t ram_tracing_circular[CONFIG_RAM_TRACING_BUFFER_SIZE];
+
+The buffer consists of equally sized slots. Each populated slot begins with the following
+packed, little-endian header and packet context:
+
+.. list-table:: Circular CTF packet layout
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Field
+     - Offset
+     - Size
+     - Description
+   * - ``magic``
+     - 0
+     - 4 bytes
+     - CTF packet magic, ``0xC1FC1FC1``.
+   * - ``timestamp_begin``
+     - 4
+     - 8 bytes
+     - Timestamp of the first event written to the packet.
+   * - ``timestamp_end``
+     - 12
+     - 8 bytes
+     - Timestamp of the most recently completed event in the packet.
+   * - ``content_size``
+     - 20
+     - 4 bytes
+     - Valid packet content size in bits, including this header.
+   * - ``packet_size``
+     - 24
+     - 4 bytes
+     - Full slot size in bits.
+   * - ``packet_seq_num``
+     - 28
+     - 8 bytes
+     - Monotonically increasing logical packet sequence number.
+   * - Event data
+     - 36
+     - Variable
+     - Complete serialized CTF events up to ``content_size``.
+
+The layout is described by
+:zephyr_file:`subsys/tracing/ctf/tsdl/metadata_circular`. Use this metadata instead of the
+standard CTF metadata when processing a circular dump.
+
+Packet lifecycle
+****************
+
+Initialization
+==============
+
+At initialization, the implementation:
+
+#. clears the complete RAM buffer;
+#. formats each slot as an empty packet;
+#. assigns sequence number zero to the unused slots; and
+#. opens slot zero with the first live sequence number.
+
+Empty packets contain only the 36-byte packet header. The host utility ignores them
+because they contain no event records.
+
+Writing an event
+================
+
+For each event, the writer:
+
+#. verifies that tracing is enabled;
+#. rejects an event that cannot fit in an otherwise empty slot;
+#. reads the 64-bit timestamp from the beginning of the event;
+#. checks whether the event fits in the active slot;
+#. advances to and reinitializes the next slot when rollover is required;
+#. copies the complete event into the active slot; and
+#. updates ``content_size`` and ``timestamp_end``.
+
+The packet context is updated after every completed event. Consequently, a debugger dump
+taken after halting the target ends at the last complete event instead of exposing unused
+slot bytes as valid trace content.
+
+Rollover
+========
+
+When an event does not fit, the active packet is closed and the next physical slot is
+opened. If the next slot contains the oldest packet, it is overwritten as a unit. The new
+packet receives a sequence number greater than the previous packet, regardless of its
+physical slot index.
+
+After rollover, physical slot order and chronological order are different. This is why a
+raw memory dump must be normalized before it is given to Babeltrace.
+
+Dumping and decoding a trace
+****************************
+
+Halt before dumping
+===================
+
+Halt the target before reading the buffer. Although packet context is updated after each
+event, a live debugger read can race with an event copy or context update and produce an
+inconsistent snapshot.
+
+For example, with GDB:
+
+.. code-block:: console
+
+   (gdb) p sizeof(ram_tracing_circular)
+   (gdb) dump binary memory ram_tracing_circular.bin \
+         &ram_tracing_circular[0] \
+         &ram_tracing_circular[0] + sizeof(ram_tracing_circular)
+
+An equivalent debugger or Trace32 memory-save operation can be used as long as it dumps
+the complete symbol without adding a textual or debugger-specific header.
+
+Sort the packets
+================
+
+Run the host utility with either the configured packet count or the calculated slot size:
+
+.. code-block:: console
+
+   python3 $ZEPHYR_BASE/scripts/tracing/sort_ctf_circular.py \
+       ram_tracing_circular.bin ctf-trace --packet-count 32
+
+Alternatively:
+
+.. code-block:: console
+
+   python3 $ZEPHYR_BASE/scripts/tracing/sort_ctf_circular.py \
+       ram_tracing_circular.bin ctf-trace --slot-size 128
+
+The default metadata path is resolved relative to the script file, not the current working
+directory. The command can therefore be run from any directory as long as the script
+remains in its normal Zephyr repository location. Use ``--metadata`` when processing the
+dump with a copied script or custom metadata:
+
+.. code-block:: console
+
+   python3 sort_ctf_circular.py ram_tracing_circular.bin ctf-trace \
+       --packet-count 32 --metadata /path/to/metadata_circular
+
+The utility creates:
+
+* ``ctf-trace/metadata``, copied from ``metadata_circular``; and
+* ``ctf-trace/channel0``, containing valid packets in chronological sequence-number
+  order.
+
+Existing output files are not replaced unless ``--force`` is supplied.
+
+The utility rejects or ignores slots with:
+
+* an invalid CTF magic value;
+* a packet size that does not match the configured slot size;
+* an invalid content size;
+* no completed event data;
+* a begin timestamp later than the end timestamp; or
+* a duplicate packet sequence number.
+
+Decode the trace
+================
+
+Pass the generated directory to Babeltrace 2:
+
+.. code-block:: console
+
+   babeltrace2 ctf-trace
+
+Because the host utility has already restored chronological packet order, Babeltrace sees
+a conventional CTF stream and does not need to understand the target's physical circular
+buffer layout.
+
+Advantages
+**********
+
+Bounded memory use
+   The target allocation is fixed at build time and does not grow with capture duration.
+
+Recent-event retention
+   The capture preserves events nearest to a late crash or debugger halt instead of
+   stopping when the buffer first becomes full.
+
+Complete-event rollover
+   Events are never intentionally split across the end of a slot. Host recovery does not
+   need to scan arbitrary payload bytes for a possible event boundary.
+
+Self-describing packet state
+   Every populated slot contains CTF magic, valid-content size, timestamps, and a sequence
+   number. A halted target can be decoded through standard CTF tooling after normalization.
+
+Frontend isolation
+   CTF-specific packet construction is kept out of the generic tracing backend API. Other
+   tracing formats retain their normal backend behavior.
+
+No continuous transport requirement
+   Trace collection does not depend on host availability, UART bandwidth, USB setup, or a
+   filesystem on the target.
+
+Stable debugger symbol
+   The ``ram_tracing_circular`` symbol provides a simple and deterministic debugger dump
+   target.
+
+Trade-offs and limitations
+**************************
+
+Old events are lost
+   Overwriting is the intended policy. Once all slots have been used, the oldest complete
+   packet is no longer recoverable.
+
+Packet headers consume RAM
+   Every slot uses 36 bytes for framing. More slots increase metadata overhead. Unused
+   bytes at the end of a closed packet add internal fragmentation.
+
+Synchronous execution cost
+   Event data and packet context are copied and updated in the tracing call path. CTF
+   events are commonly emitted while interrupts are locked, so large events or a high
+   event rate can increase interrupt latency.
+
+CTF-only format
+   The stored data is not a generic byte log. It depends on CTF event layout,
+   ``metadata_circular``, and a timestamp at the start of every event.
+
+No asynchronous mode
+   Asynchronous tracing does not preserve one-event-per-write boundaries and is therefore
+   unsupported.
+
+Little-endian target assumption
+   Packet header fields are written in the target's native representation and the metadata
+   declares little-endian byte order. A big-endian target requires explicit byte-order
+   conversion or different metadata.
+
+Offline normalization step
+   The raw dump is not chronological after wraparound. It must be processed by
+   ``sort_ctf_circular.py`` before use with standard CTF tools.
+
+Target must be halted for a reliable snapshot
+   Updating an event and its packet context is not an atomic memory transaction. Reading
+   the buffer while the target runs may capture partially updated state.
+
+Limited SMP synchronization
+   The existing CTF event path uses interrupt locking to prevent local interrupt reentry.
+   It does not provide a global lock between CPUs. Concurrent writers on an SMP system
+   require additional serialization or per-CPU packet buffers.
+
+Oversized events are dropped
+   See :ref:`ctf_circular_ram_maximum_event_size` for the maximum event size, why event
+   records are not split between packets, and configuration options for larger events.
+
+Timestamp interpretation
+   Circular events use the 64-bit cycle counter to avoid the short rollover interval of a
+   32-bit nanosecond timestamp. Consumers that need seconds or wall-clock time must know
+   the target counter frequency or extend the metadata with an appropriate CTF clock
+   description.
+
+Trace confidentiality
+   Kernel and application events can contain identifiers, addresses, names, and other
+   sensitive state. Protect RAM dumps and generated trace directories according to the
+   product's security requirements.
+
+Comparison with the linear RAM backend
+**************************************
+
+.. list-table:: RAM tracing output comparison
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Property
+     - Linear RAM backend
+     - CTF circular RAM capture
+   * - Full-buffer policy
+     - Discard new trace data.
+     - Overwrite the oldest complete packet.
+   * - Retained history
+     - Beginning of the capture.
+     - Most recent capture window.
+   * - Format support
+     - Generic tracing byte output.
+     - CTF events only.
+   * - Packet framing overhead
+     - None beyond the emitted trace data.
+     - 36 bytes per packet slot plus end-of-packet fragmentation.
+   * - Host preparation
+     - Place the dump beside matching metadata.
+     - Validate and sort packets, then use the generated trace directory.
+   * - Best suited for
+     - Short, deliberately started captures.
+     - Long-running flight recording and post-mortem debugging.
+
+Implementation files
+********************
+
+The implementation is divided as follows:
+
+* :zephyr_file:`subsys/tracing/ctf/ctf_top.h` selects the local writer or normal tracing
+  formatter from ``CTF_GATHER_FIELDS()``.
+* :zephyr_file:`subsys/tracing/ctf/ctf_circular_ram.c` implements packet rotation and
+  exports the RAM symbol.
+* :zephyr_file:`subsys/tracing/ctf/ctf_circular_ram.h` declares the CTF-local writer.
+* :zephyr_file:`subsys/tracing/ctf/tsdl/metadata_circular` describes the generated CTF
+  packet and event layout.
+* :zephyr_file:`scripts/tracing/sort_ctf_circular.py` validates and orders the dumped
+  packets.
+
+Verification recommendations
+****************************
+
+When changing the implementation or metadata:
+
+#. Build a CTF synchronous configuration with circular capture enabled.
+#. Confirm that ``ram_tracing_circular`` has the configured size in the ELF file.
+#. Generate enough events to wrap through every packet slot at least once.
+#. Halt the target and dump the complete symbol.
+#. Run ``sort_ctf_circular.py`` and verify that reported sequence numbers are increasing.
+#. Decode the generated directory with Babeltrace 2.
+#. Confirm that event timestamps and event types are ordered as expected across the
+   physical slot-zero boundary.
+#. Repeat with a debugger halt while the current packet is partially filled.
+#. Verify that a normal CTF backend still uses ``tracing_format_raw_data()`` when circular
+   capture is disabled.

--- a/scripts/tracing/sort_ctf_circular.py
+++ b/scripts/tracing/sort_ctf_circular.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert a circular CTF RAM dump into a chronological CTF trace.
+
+The target stores fixed-size CTF packets in a circular RAM buffer.  A raw
+memory dump is consequently in physical slot order, not time order.  This
+tool validates each packet, orders valid packets by packet sequence number,
+and emits a conventional CTF trace directory suitable for babeltrace2.
+"""
+
+import argparse
+import shutil
+import struct
+import sys
+from pathlib import Path
+
+
+PACKET_MAGIC = 0xC1FC1FC1
+# magic, timestamp_begin, timestamp_end, content_size, packet_size, sequence
+PACKET_HEADER = struct.Struct("<IQQIIQ")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump", type=Path, help="raw ram_tracing_circular memory dump")
+    parser.add_argument("output", type=Path, help="output CTF trace directory")
+    size_group = parser.add_mutually_exclusive_group(required=True)
+    size_group.add_argument("--slot-size", type=int,
+                            help="size in bytes of one CTF packet slot")
+    size_group.add_argument("--packet-count", type=int,
+                            help="number of equal-size packet slots in the dump")
+    parser.add_argument("--metadata", type=Path,
+                        default=Path(__file__).resolve().parents[2] /
+                        "subsys/tracing/ctf/tsdl/metadata_circular",
+                        help="CTF metadata to copy (default: metadata_circular)")
+    parser.add_argument("--stream-name", default="channel0",
+                        help="name for the generated CTF stream file")
+    parser.add_argument("--force", action="store_true",
+                        help="replace metadata and stream files if they exist")
+    return parser.parse_args()
+
+
+def packet_from_slot(slot, index, slot_size):
+    magic, begin, end, content_bits, packet_bits, sequence = PACKET_HEADER.unpack_from(slot)
+    if magic != PACKET_MAGIC:
+        return None
+    if packet_bits != slot_size * 8:
+        return None
+    if not PACKET_HEADER.size * 8 < content_bits <= packet_bits:
+        return None
+    if begin > end:
+        return None
+    return sequence, begin, end, index, slot
+
+
+def main():
+    args = parse_args()
+    dump = args.dump.read_bytes()
+    if len(dump) < PACKET_HEADER.size:
+        sys.exit("dump is smaller than a CTF packet header")
+
+    if args.packet_count is not None:
+        if args.packet_count <= 0 or len(dump) % args.packet_count:
+            sys.exit("dump size must be divisible by --packet-count")
+        slot_size = len(dump) // args.packet_count
+    else:
+        slot_size = args.slot_size
+        if slot_size < PACKET_HEADER.size or len(dump) % slot_size:
+            sys.exit("--slot-size must fit a header and divide the dump size")
+
+    packets = []
+    for index, offset in enumerate(range(0, len(dump), slot_size)):
+        packet = packet_from_slot(dump[offset:offset + slot_size], index, slot_size)
+        if packet is not None:
+            packets.append(packet)
+
+    if not packets:
+        sys.exit("no completed CTF packets found")
+    if len({packet[0] for packet in packets}) != len(packets):
+        sys.exit("duplicate packet sequence numbers found; dump is inconsistent")
+
+    packets.sort(key=lambda packet: (packet[0], packet[1]))
+    args.output.mkdir(parents=True, exist_ok=True)
+    metadata_output = args.output / "metadata"
+    stream_output = args.output / args.stream_name
+    if not args.force and (metadata_output.exists() or stream_output.exists()):
+        sys.exit("output metadata or stream already exists (use --force to replace it)")
+
+    shutil.copyfile(args.metadata, metadata_output)
+    with stream_output.open("wb") as stream:
+        for _, _, _, _, packet in packets:
+            stream.write(packet)
+
+    first, last = packets[0], packets[-1]
+    print(f"wrote {len(packets)} packets from slots {first[3]}..{last[3]} "
+          f"(sequence {first[0]}..{last[0]}) to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -144,6 +144,15 @@ config TRACING_CTF_TIMESTAMP
 	  Timestamp prefix will be added to the beginning of CTF
 	  event internally.
 
+config TRACING_CTF_TIMESTAMP_64
+	bool "64-bit cycle counter timestamp for CTF events"
+	default n
+	depends on TRACING_CTF && TRACING_CTF_TIMESTAMP
+	help
+	  Use sys_clock_cycle_get_64() as the CTF event timestamp instead of
+	  the default 32-bit nanosecond value. Avoids the ~4.29 s counter
+	  rollover. Required by the circular RAM backend.
+
 choice TRACING_METHOD_CHOICE
 	prompt "Tracing Method"
 	default TRACING_ASYNC
@@ -253,6 +262,21 @@ config TRACING_BACKEND_NAME
 	default "tracing_backend_ram" if TRACING_BACKEND_RAM
 	default "tracing_backend_semihost" if TRACING_BACKEND_SEMIHOST
 	default "tracing_backend_adsp_memory_window" if TRACING_BACKEND_ADSP_MEMORY_WINDOW
+	
+config TRACING_CTF_CIRCULAR_RAM
+	bool "Circular (overwrite-oldest) CTF RAM capture"
+	default y
+	depends on TRACING_CTF && TRACING_SYNC && TRACING_BACKEND_RAM
+	select TRACING_CTF_TIMESTAMP_64
+	help
+	  Flight-recorder style circular RAM capture. This is not a tracing
+	  backend: CTF_GATHER_FIELDS() writes complete CTF events directly to the
+	  circular buffer. The buffer is divided
+	  into TRACING_BACKEND_RAM_PACKET_COUNT equal-size CTF packets; when
+	  the active packet is full the next slot overwrites the oldest, so
+	  the most recent events are always retained. Requires TRACING_SYNC
+	  (one complete CTF event per write() call); the async path delivers
+	  arbitrary byte runs and cannot preserve CTF packet boundaries.
 
 config RAM_TRACING_BUFFER_SIZE
 	int "Ram Tracing buffer size"
@@ -261,6 +285,17 @@ config RAM_TRACING_BUFFER_SIZE
 	help
 	  Size of the RAM trace buffer. Trace will be discarded if the
 	  length is exceeded.
+
+config TRACING_BACKEND_RAM_PACKET_COUNT
+	int "Number of rotating CTF packets in circular RAM capture"
+	default 32
+	range 2 256
+	depends on TRACING_CTF_CIRCULAR_RAM
+	help
+	  Number of equal-size packet slots. Each slot is
+	  RAM_TRACING_BUFFER_SIZE / TRACING_BACKEND_RAM_PACKET_COUNT bytes.
+	  RAM_TRACING_BUFFER_SIZE must be a multiple of this value and a slot
+	  must hold the CTF packet header plus TRACING_PACKET_MAX_SIZE bytes.
 
 config TRACING_HANDLE_HOST_CMD
 	bool "Host command handle"

--- a/subsys/tracing/ctf/CMakeLists.txt
+++ b/subsys/tracing/ctf/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 zephyr_sources(ctf_top.c)
 
+zephyr_sources_ifdef(
+  CONFIG_TRACING_CTF_CIRCULAR_RAM
+  ctf_circular_ram.c
+  )
+
 zephyr_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ARCH_DIR}/${ARCH}/include

--- a/subsys/tracing/ctf/ctf_circular_ram.c
+++ b/subsys/tracing/ctf/ctf_circular_ram.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 IoT.bzh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
+#include <tracing_core.h>
+#include "ctf_circular_ram.h"
+
+/*
+ * Circular RAM capture path for the upstream CTF format
+ * (CONFIG_TRACING_CTF_CIRCULAR_RAM).
+ *
+ * Unlike the linear backend which drops every event once the buffer fills,
+ * this backend models the buffer as N rotating, self-contained CTF packets
+ * (LTTng flight-recorder style). When the active packet has no room for the
+ * next event, the backend advances to the next slot - overwriting the oldest
+ * whole packet - so the most recent traffic is always retained.
+ *
+ * Each slot carries a CTF packet header (magic 0xC1FC1FC1) and packet context
+ * (timestamp_begin/end, content_size, packet_size, packet_seq_num), matching
+ * ctf/tsdl/metadata_circular. The host-side sort_ctf_circular.py utility
+ * orders the valid slots by sequence number before babeltrace2 decodes them.
+ *
+ * This capture path requires CONFIG_TRACING_SYNC (one complete CTF event per
+ * write() call). The async path delivers arbitrary byte runs and is not
+ * supported.
+ *
+ * The dumped symbol is still ram_tracing_circular[CONFIG_RAM_TRACING_BUFFER_SIZE], so
+ * the existing T32 / gdb dump flow is unchanged.
+ */
+
+#define SLOT_COUNT       CONFIG_TRACING_BACKEND_RAM_PACKET_COUNT
+#define SLOT_SIZE        (CONFIG_RAM_TRACING_BUFFER_SIZE / SLOT_COUNT)
+#define CTF_PACKET_MAGIC 0xC1FC1FC1U
+
+BUILD_ASSERT((CONFIG_RAM_TRACING_BUFFER_SIZE % SLOT_COUNT) == 0,
+	     "RAM_TRACING_BUFFER_SIZE must be a multiple of TRACING_BACKEND_RAM_PACKET_COUNT");
+
+/*
+ * On-wire CTF packet header + context. Field order and sizes MUST match the
+ * trace.packet.header and stream.packet.context in ctf/tsdl/metadata_circular.
+ * The stream is little-endian; this assumes a little-endian target.
+ */
+struct ctf_packet_hdr {
+	uint32_t magic;           /* trace.packet.header.magic */
+	uint64_t timestamp_begin; /* stream.packet.context ... */
+	uint64_t timestamp_end;
+	uint32_t content_size;    /* bits, includes this header */
+	uint32_t packet_size;     /* bits, == SLOT_SIZE * 8 */
+	uint64_t packet_seq_num;
+} __packed;
+
+#define CTX_BYTES (sizeof(struct ctf_packet_hdr))
+
+BUILD_ASSERT(SLOT_SIZE >= (CTX_BYTES + CONFIG_TRACING_PACKET_MAX_SIZE),
+	     "Circular CTF packet slot must fit its header and one tracing packet");
+
+uint8_t ram_tracing_circular[CONFIG_RAM_TRACING_BUFFER_SIZE];
+
+static uint32_t cur_slot;    /* slot currently being filled, 0..SLOT_COUNT-1 */
+static uint32_t cur_off;     /* write cursor within the current slot (bytes)  */
+static uint64_t seq;         /* monotonic packet sequence number              */
+static uint64_t last_tstamp; /* timestamp of the most recent event            */
+
+static inline uint8_t *slot_base(uint32_t s)
+{
+	return ram_tracing_circular + (s * SLOT_SIZE);
+}
+
+/*
+ * Extract the event timestamp, which CTF_EVENT writes as the first field of
+ * every event. Width depends on CONFIG_TRACING_CTF_TIMESTAMP_64; fall back
+ * to the previous timestamp for any anomalously short packet.
+ */
+static inline uint64_t event_tstamp(const uint8_t *data, uint32_t length)
+{
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP_64
+	uint64_t t;
+
+	if (length >= sizeof(t)) {
+		memcpy(&t, data, sizeof(t));
+		return t;
+	}
+#else
+	uint32_t t;
+
+	if (length >= sizeof(t)) {
+		memcpy(&t, data, sizeof(t));
+		return (uint64_t)t;
+	}
+#endif /* CONFIG_TRACING_CTF_TIMESTAMP_64 */
+	return last_tstamp;
+}
+
+static void packet_open(uint32_t s, uint64_t tstamp)
+{
+	struct ctf_packet_hdr hdr = {
+		.magic = CTF_PACKET_MAGIC,
+		.timestamp_begin = tstamp,
+		.timestamp_end = tstamp,
+		.content_size = (uint32_t)(CTX_BYTES * 8U),
+		.packet_size = (uint32_t)(SLOT_SIZE * 8U),
+		.packet_seq_num = seq,
+	};
+
+	memcpy(slot_base(s), &hdr, sizeof(hdr));
+	cur_off = CTX_BYTES;
+}
+
+static void packet_update(uint32_t s, uint64_t tstamp)
+{
+	struct ctf_packet_hdr *hdr = (struct ctf_packet_hdr *)slot_base(s);
+
+	hdr->content_size = cur_off * 8U;
+	hdr->timestamp_end = tstamp;
+}
+
+/* SYNC mode: data/length is exactly one whole CTF event. */
+void ctf_circular_ram_write(const uint8_t *data, uint32_t length)
+{
+	uint64_t tstamp;
+
+	if (!is_tracing_enabled()) {
+		return;
+	}
+
+	if (length > (SLOT_SIZE - CTX_BYTES)) {
+		return;
+	}
+
+	tstamp = event_tstamp(data, length);
+
+	if ((cur_off + length) > SLOT_SIZE) {
+		/* Close the current packet, then overwrite the oldest one. */
+		packet_update(cur_slot, last_tstamp);
+		cur_slot = (cur_slot + 1U) % SLOT_COUNT;
+		seq++;
+		packet_open(cur_slot, tstamp);
+	}
+
+	memcpy(slot_base(cur_slot) + cur_off, data, length);
+	cur_off += length;
+	last_tstamp = tstamp;
+
+	/*
+	 * Keep the packet self-consistent after every event so a dump taken
+	 * mid-slot truncates cleanly at the last completed event rather than
+	 * leaving a half-written event for the parser.
+	 */
+	packet_update(cur_slot, tstamp);
+}
+
+static int ctf_circular_ram_init(void)
+{
+	uint32_t s;
+
+	memset(ram_tracing_circular, 0, CONFIG_RAM_TRACING_BUFFER_SIZE);
+
+	/* Pre-format every slot as a valid empty packet. */
+	seq = 0U;
+	last_tstamp = 0U;
+	for (s = 0U; s < SLOT_COUNT; s++) {
+		packet_open(s, 0U);
+		packet_update(s, 0U);
+	}
+
+	/* Open slot 0 for writing with the first live sequence number. */
+	cur_slot = 0U;
+	seq = 1U;
+	packet_open(cur_slot, 0U);
+
+	return 0;
+}
+
+SYS_INIT(ctf_circular_ram_init, APPLICATION, 0);

--- a/subsys/tracing/ctf/ctf_circular_ram.h
+++ b/subsys/tracing/ctf/ctf_circular_ram.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SUBSYS_TRACING_CTF_CIRCULAR_RAM_H
+#define SUBSYS_TRACING_CTF_CIRCULAR_RAM_H
+
+#include <stdint.h>
+
+/**
+ * @brief Store one complete CTF event in the circular RAM capture buffer.
+ *
+ * This is intentionally a CTF-local output path, rather than a tracing
+ * backend. @p data must contain exactly one event as assembled by
+ * CTF_GATHER_FIELDS().
+ */
+void ctf_circular_ram_write(const uint8_t *data, uint32_t length);
+
+#endif /* SUBSYS_TRACING_CTF_CIRCULAR_RAM_H */

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -14,6 +14,13 @@
 #include <zephyr/tracing/tracing_format.h>
 #include <zephyr/net/net_ip.h>
 
+#ifdef CONFIG_TRACING_CTF_CIRCULAR_RAM
+#include <ctf_circular_ram.h>
+#define CTF_OUTPUT_EVENT(_event) ctf_circular_ram_write((_event), sizeof(_event))
+#else
+#define CTF_OUTPUT_EVENT(_event) tracing_format_raw_data((_event), sizeof(_event))
+#endif
+
 /* Limit strings to 20 bytes to optimize bandwidth */
 #define CTF_MAX_STRING_LEN 20
 
@@ -47,7 +54,7 @@
 		uint8_t *epacket_cursor = &epacket[0];                                             \
                                                                                                    \
 		MAP(CTF_INTERNAL_FIELD_APPEND, ##__VA_ARGS__)                                      \
-		tracing_format_raw_data(epacket, sizeof(epacket));                                 \
+		CTF_OUTPUT_EVENT(epacket);                                                         \
 	}
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
@@ -58,6 +65,19 @@ static inline uint64_t ctf_top_timestamp_get(void)
 	return timing_ns_get();
 }
 
+#ifdef CONFIG_TRACING_CTF_TIMESTAMP_64
+#define CTF_EVENT(...)                                                                             \
+	{                                                                                          \
+		if (!is_tracing_enabled()) {                                                       \
+			return;                                                                    \
+		}                                                                                  \
+		int key = irq_lock();                                                              \
+		const uint64_t tstamp = sys_clock_cycle_get_64();                                  \
+	                                                                                                   \
+		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
+		irq_unlock(key);                                                                   \
+	}
+#else
 #define CTF_EVENT(...)                                                                             \
 	{                                                                                          \
 		if (!is_tracing_enabled()) {                                                       \
@@ -65,13 +85,14 @@ static inline uint64_t ctf_top_timestamp_get(void)
 		}                                                                                  \
 		int key = irq_lock();                                                              \
 		const uint64_t tstamp = ctf_top_timestamp_get();                                   \
-                                                                                                   \
+	                                                                                                   \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                                             \
 		irq_unlock(key);                                                                   \
 	}
+#endif /* CONFIG_TRACING_CTF_TIMESTAMP_64 */
 #else
 #define CTF_EVENT(...) {CTF_GATHER_FIELDS(__VA_ARGS__)}
-#endif
+#endif /* CONFIG_TRACING_CTF_TIMESTAMP */
 
 /* Anonymous compound literal with 1 member. Legal since C99.
  * This permits us to take the address of literals, like so:

--- a/subsys/tracing/ctf/tsdl/metadata_circular
+++ b/subsys/tracing/ctf/tsdl/metadata_circular
@@ -1,0 +1,3406 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* CTF 1.8 */
+typealias integer { size = 8; align = 8; signed = true; } := int8_t;
+typealias integer { size = 8; align = 8; signed = false; } := uint8_t;
+typealias integer { size = 16; align = 8; signed = false; } := uint16_t;
+typealias integer { size = 32; align = 8; signed = false; } := uint32_t;
+typealias integer { size = 32; align = 8; signed = true; } := int32_t;
+typealias integer { size = 64; align = 8; signed = false; } := uint64_t;
+typealias integer { size = 8; align = 8; signed = false; encoding = ASCII; } := ctf_bounded_string_t;
+
+struct event_header {
+	uint64_t timestamp;
+	uint16_t id;
+};
+
+/*
+ * Circular RAM variant of the standard Zephyr CTF metadata.
+ *
+ * Events use the same IDs and layouts as metadata. Each fixed-size packet
+ * includes the magic value and context needed to order packets after the RAM
+ * buffer wraps.
+ */
+struct packet_context {
+	uint64_t timestamp_begin;
+	uint64_t timestamp_end;
+	uint32_t content_size;
+	uint32_t packet_size;
+	uint64_t packet_seq_num;
+};
+
+trace {
+	major = 1;
+	minor = 8;
+	byte_order = le;
+	packet.header := struct {
+		uint32_t magic;
+	};
+};
+
+stream {
+	event.header := struct event_header;
+	packet.context := struct packet_context;
+};
+
+event {
+	name = thread_switched_out;
+	id = 0x10;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_switched_in;
+	id = 0x11;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = k_sleep_enter;
+	id = 0x7F;
+	fields := struct {
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = k_sleep_exit;
+	id = 0x80;
+	fields := struct {
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = thread_priority_set;
+	id = 0x12;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+		int8_t prio;
+	};
+
+};
+
+event {
+	name = thread_create;
+	id = 0x13;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_abort;
+	id = 0x14;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_suspend;
+	id = 0x15;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_resume;
+	id = 0x16;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+event {
+        name = thread_ready;
+        id = 0x17;
+        fields := struct {
+                uint32_t thread_id;
+				ctf_bounded_string_t name[20];
+        };
+};
+
+event {
+	name = thread_pending;
+	id = 0x18;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_info;
+	id = 0x19;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+		uint32_t stack_base;
+		uint32_t stack_size;
+	};
+};
+
+event {
+	name = thread_name_set;
+	id = 0x1a;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = isr_enter;
+	id = 0x1B;
+};
+
+event {
+	name = isr_exit;
+	id = 0x1C;
+};
+
+event {
+	name = isr_exit_to_scheduler;
+	id = 0x1D;
+};
+
+event {
+	name = idle;
+	id = 0x1E;
+};
+
+event {
+	name = semaphore_init;
+	id = 0x21;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = semaphore_give_enter;
+	id = 0x22;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = semaphore_give_exit;
+	id = 0x23;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = semaphore_take_enter;
+	id = 0x24;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = semaphore_take_exit;
+	id = 0x26;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+
+event {
+	name = semaphore_take_blocking;
+	id = 0x25;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+
+event {
+	name = semaphore_reset;
+	id = 0x27;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mutex_init;
+	id = 0x28;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mutex_lock_enter;
+	id = 0x29;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mutex_lock_blocking;
+	id = 0x2A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mutex_lock_exit;
+	id = 0x2B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mutex_unlock_enter;
+	id = 0x2C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mutex_unlock_exit;
+	id = 0x2D;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = timer_init;
+	id = 0x2E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_start;
+	id = 0x2F;
+	fields := struct {
+		uint32_t id;
+		uint32_t duration;
+		uint32_t period;
+	};
+};
+
+event {
+	name = timer_stop;
+	id = 0x30;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_status_sync_enter;
+	id = 0x31;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_status_sync_blocking;
+	id = 0x32;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = timer_status_sync_exit;
+	id = 0x33;
+	fields := struct {
+		uint32_t id;
+		uint32_t result;
+	};
+};
+
+event {
+	name = user_mode_enter;
+	id = 0x34;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_wakeup;
+	id = 0x35;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = socket_init;
+	id = 0x36;
+	fields := struct {
+		uint32_t id;
+		uint32_t family;
+		uint32_t type;
+		uint32_t proto;
+	};
+};
+
+event {
+	name = socket_close_enter;
+	id = 0x37;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = socket_close_exit;
+	id = 0x38;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_shutdown_enter;
+	id = 0x39;
+	fields := struct {
+		uint32_t id;
+		uint32_t how;
+	};
+};
+
+event {
+	name = socket_shutdown_exit;
+	id = 0x3A;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_bind_enter;
+	id = 0x3B;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		uint16_t port;
+	};
+};
+
+event {
+	name = socket_bind_exit;
+	id = 0x3C;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_connect_enter;
+	id = 0x3D;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+	};
+};
+
+event {
+	name = socket_connect_exit;
+	id = 0x3E;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_listen_enter;
+	id = 0x3F;
+	fields := struct {
+		uint32_t id;
+		uint32_t backlog;
+	};
+};
+
+event {
+	name = socket_listen_exit;
+	id = 0x40;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_accept_enter;
+	id = 0x41;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = socket_accept_exit;
+	id = 0x42;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		uint16_t port;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_sendto_enter;
+	id = 0x43;
+	fields := struct {
+		uint32_t id;
+		uint32_t data_length;
+		uint32_t flags;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+	};
+};
+
+event {
+	name = socket_sendto_exit;
+	id = 0x44;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_sendmsg_enter;
+	id = 0x45;
+	fields := struct {
+		uint32_t id;
+		uint32_t flags;
+		uint32_t msghdr;
+		ctf_bounded_string_t address[46];
+		uint32_t data_length;
+	};
+};
+
+event {
+	name = socket_sendmsg_exit;
+	id = 0x46;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_recvfrom_enter;
+	id = 0x47;
+	fields := struct {
+		uint32_t id;
+		uint32_t max_length;
+		uint32_t flags;
+		uint32_t address;
+		uint32_t address_length;
+	};
+};
+
+event {
+	name = socket_recvfrom_exit;
+	id = 0x48;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_recvmsg_enter;
+	id = 0x49;
+	fields := struct {
+		uint32_t id;
+		uint32_t msg;
+		uint32_t max_msg_length;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_recvmsg_exit;
+	id = 0x4A;
+	fields := struct {
+		uint32_t id;
+		uint32_t msg_length;
+		ctf_bounded_string_t address[46];
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_fcntl_enter;
+	id = 0x4B;
+	fields := struct {
+		uint32_t id;
+		uint32_t cmd;
+		uint32_t flags;
+	};
+};
+
+event {
+	name = socket_fcntl_exit;
+	id = 0x4C;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_ioctl_enter;
+	id = 0x4D;
+	fields := struct {
+		uint32_t id;
+		uint32_t request;
+	};
+};
+
+event {
+	name = socket_ioctl_exit;
+	id = 0x4E;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_poll_enter;
+	id = 0x4F;
+	fields := struct {
+		uint32_t fds;
+		uint32_t num_fds;
+		int32_t timeout;
+	};
+};
+
+event {
+	name = socket_poll_value;
+	id = 0x50;
+	fields := struct {
+		int32_t fd;
+		uint16_t events;
+	};
+};
+
+event {
+	name = socket_poll_exit;
+	id = 0x51;
+	fields := struct {
+		uint32_t fds;
+		uint32_t num_fds;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_getsockopt_enter;
+	id = 0x52;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+	};
+};
+
+event {
+	name = socket_getsockopt_exit;
+	id = 0x53;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+		uint32_t optval;
+		uint32_t optlen;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_setsockopt_enter;
+	id = 0x54;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+		uint32_t optval;
+		uint32_t optlen;
+	};
+};
+
+event {
+	name = socket_setsockopt_exit;
+	id = 0x55;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_getpeername_enter;
+	id = 0x56;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = socket_getpeername_exit;
+	id = 0x57;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_getsockname_enter;
+	id = 0x58;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = socket_getsockname_exit;
+	id = 0x59;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+	};
+};
+
+event {
+	name = socket_socketpair_enter;
+	id = 0x5A;
+	fields := struct {
+		uint32_t family;
+		uint32_t type;
+		uint32_t proto;
+		uint32_t sv;
+	};
+};
+
+event {
+	name = socket_socketpair_exit;
+	id = 0x5B;
+	fields := struct {
+		int32_t socket0;
+		int32_t socket1;
+		int32_t result;
+	};
+};
+
+event {
+	name = net_recv_data_enter;
+	id = 0x5C;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t pkt_len;
+	};
+};
+
+event {
+	name = net_recv_data_exit;
+	id = 0x5D;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		int32_t result;
+	};
+};
+
+event {
+	name = net_send_data_enter;
+	id = 0x5E;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t pkt_len;
+	};
+};
+
+event {
+	name = net_send_data_exit;
+	id = 0x5F;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		int32_t result;
+	};
+};
+
+event {
+	name = net_rx_time;
+	id = 0x60;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t priority;
+		uint32_t traffic_class;
+		uint32_t duration_us;
+	};
+};
+
+event {
+	name = net_tx_time;
+	id = 0x61;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t priority;
+		uint32_t traffic_class;
+		uint32_t duration_us;
+	};
+};
+
+event {
+	name = named_event;
+	id = 0x62;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t arg0;
+		uint32_t arg1;
+	};
+};
+
+event {
+	name = gpio_pin_configure_interrupt_enter;
+	id = 0x63;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t flags;
+	};
+};
+
+event {
+	name = gpio_pin_configure_interrupt_exit;
+	id = 0x64;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = gpio_pin_configure_enter;
+	id = 0x65;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t flags;
+	};
+};
+
+event {
+	name = gpio_pin_configure_exit;
+	id = 0x66;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = gpio_port_get_direction_enter;
+	id = 0x67;
+	fields := struct {
+		uint32_t port;
+		uint32_t map;
+		uint32_t inputs;
+		uint32_t outputs;
+	};
+};
+
+event {
+	name = gpio_port_get_direction_exit;
+	id = 0x68;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = gpio_pin_get_config_enter;
+	id = 0x69;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+	};
+};
+
+event {
+	name =  gpio_pin_get_config_exit;
+	id = 0x6A;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_port_get_raw_enter;
+	id = 0x6B;
+	fields := struct {
+		uint32_t port;
+		uint32_t value;
+	};
+};
+
+event {
+	name =  gpio_port_get_raw_exit;
+	id = 0x6C;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_port_set_masked_raw_enter;
+	id = 0x6D;
+	fields := struct {
+		uint32_t port;
+		uint32_t mask;
+		uint32_t value;
+	};
+};
+
+event {
+	name =  gpio_port_set_masked_raw_exit;
+	id = 0x6E;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_port_set_bits_raw_enter;
+	id = 0x6F;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+	};
+};
+
+event {
+	name =  gpio_port_set_bits_raw_exit;
+	id = 0x70;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_port_clear_bits_raw_enter;
+	id = 0x71;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+	};
+};
+
+event {
+	name =  gpio_port_clear_bits_raw_exit;
+	id = 0x72;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_port_toggle_bits_enter;
+	id = 0x73;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+	};
+};
+
+event {
+	name =  gpio_port_toggle_bits_exit;
+	id = 0x74;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_init_callback_enter;
+	id = 0x75;
+	fields := struct {
+		uint32_t callback;
+		uint32_t handler;
+		uint32_t pin_mask;
+	};
+};
+
+event {
+	name =  gpio_init_callback_exit;
+	id = 0x76;
+	fields := struct {
+		uint32_t callback;
+	};
+};
+
+event {
+	name =  gpio_add_callback_enter;
+	id = 0x77;
+	fields := struct {
+		uint32_t port;
+		uint32_t callback;
+	};
+};
+
+event {
+	name =  gpio_add_callback_exit;
+	id = 0x78;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_remove_callback_enter;
+	id = 0x79;
+	fields := struct {
+		uint32_t port;
+		uint32_t callback;
+	};
+};
+
+event {
+	name =  gpio_remove_callback_exit;
+	id = 0x7A;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_get_pending_int_enter;
+	id = 0x7B;
+	fields := struct {
+		uint32_t dev;
+	};
+};
+
+event {
+	name =  gpio_get_pending_int_exit;
+	id = 0x7C;
+	fields := struct {
+		uint32_t dev;
+		uint32_t ret;
+	};
+};
+
+event {
+	name =  gpio_fire_callbacks_enter;
+	id = 0x7D;
+	fields := struct {
+		uint32_t list;
+		uint32_t port;
+		uint32_t pins;
+	};
+};
+
+event {
+	name =  gpio_fire_callback;
+	id = 0x7E;
+	fields := struct {
+		uint32_t port;
+		uint32_t cb;
+	};
+};
+
+
+
+/* Memory Slabs */
+event {
+	name = mem_slab_init;
+	id = 0x81;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mem_slab_alloc_enter;
+	id = 0x82;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mem_slab_alloc_blocking;
+	id = 0x83;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mem_slab_alloc_exit;
+	id = 0x84;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mem_slab_free_enter;
+	id = 0x85;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = mem_slab_free_exit;
+	id = 0x86;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+/* Message Queues */
+
+event {
+	name = msgq_init;
+	id = 0x87;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = msgq_alloc_init_enter;
+	id = 0x88;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = msgq_alloc_init_exit;
+	id = 0x89;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = msgq_put_enter;
+	id = 0x8A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_put_blocking;
+	id = 0x8B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_put_exit;
+	id = 0x8C;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = msgq_get_enter;
+	id = 0x8D;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_get_blocking;
+	id = 0x8E;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_get_exit;
+	id = 0x8F;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = msgq_peek;
+	id = 0x90;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = msgq_purge;
+	id = 0x91;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = msgq_put_front_enter;
+	id = 0x92;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_put_front_blocking;
+	id = 0x94;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = msgq_put_front_exit;
+	id = 0x93;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = msgq_cleanup_enter;
+	id = 0x95;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = msgq_cleanup_exit;
+	id = 0x96;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+/* Condition Variables */
+event {
+	name = condvar_init;
+	id = 0x97;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = condvar_signal_enter;
+	id = 0x98;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = condvar_signal_blocking;
+	id = 0x99;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = condvar_signal_exit;
+	id = 0x9A;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = condvar_broadcast_enter;
+	id = 0x9B;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = condvar_broadcast_exit;
+	id = 0x9C;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = condvar_wait_enter;
+	id = 0x9D;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = condvar_wait_exit;
+	id = 0x9E;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+/* Work Queue Events */
+event {
+	name = work_init;
+	id = 0x9F;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_submit_to_queue_enter;
+	id = 0xA0;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_submit_to_queue_exit;
+	id = 0xA1;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t work_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_submit_enter;
+	id = 0xA2;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_submit_exit;
+	id = 0xA3;
+	fields := struct {
+		uint32_t work_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_flush_enter;
+	id = 0xA4;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_flush_blocking;
+	id = 0xA5;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_flush_exit;
+	id = 0xA6;
+	fields := struct {
+		uint32_t work_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_cancel_enter;
+	id = 0xA7;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_cancel_exit;
+	id = 0xA8;
+	fields := struct {
+		uint32_t work_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_cancel_sync_enter;
+	id = 0xA9;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t sync_id;
+	};
+};
+
+event {
+	name = work_cancel_sync_blocking;
+	id = 0xAA;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t sync_id;
+	};
+};
+
+event {
+	name = work_cancel_sync_exit;
+	id = 0xAB;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t sync_id;
+		int32_t ret;
+	};
+};
+
+/* Work Queue Management */
+event {
+	name = work_queue_init;
+	id = 0xAC;
+	fields := struct {
+		uint32_t queue_id;
+	};
+};
+
+event {
+	name = work_queue_start_enter;
+	id = 0xAD;
+	fields := struct {
+		uint32_t queue_id;
+	};
+};
+
+event {
+	name = work_queue_start_exit;
+	id = 0xAE;
+	fields := struct {
+		uint32_t queue_id;
+	};
+};
+
+event {
+	name = work_queue_stop_enter;
+	id = 0xAF;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_queue_stop_blocking;
+	id = 0xB0;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_queue_stop_exit;
+	id = 0xB1;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_queue_drain_enter;
+	id = 0xB2;
+	fields := struct {
+		uint32_t queue_id;
+	};
+};
+
+event {
+	name = work_queue_drain_exit;
+	id = 0xB3;
+	fields := struct {
+		uint32_t queue_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_queue_unplug_enter;
+	id = 0xB4;
+	fields := struct {
+		uint32_t queue_id;
+	};
+};
+
+event {
+	name = work_queue_unplug_exit;
+	id = 0xB5;
+	fields := struct {
+		uint32_t queue_id;
+		int32_t ret;
+	};
+};
+
+/* Delayable Work */
+event {
+	name = work_delayable_init;
+	id = 0xB6;
+	fields := struct {
+		uint32_t dwork_id;
+	};
+};
+
+event {
+	name = work_schedule_for_queue_enter;
+	id = 0xB7;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t dwork_id;
+		uint32_t delay;
+	};
+};
+
+event {
+	name = work_schedule_for_queue_exit;
+	id = 0xB8;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t dwork_id;
+		uint32_t delay;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_schedule_enter;
+	id = 0xB9;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t delay;
+	};
+};
+
+event {
+	name = work_schedule_exit;
+	id = 0xBA;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t delay;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_reschedule_for_queue_enter;
+	id = 0xBB;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t dwork_id;
+		uint32_t delay;
+	};
+};
+
+event {
+	name = work_reschedule_for_queue_exit;
+	id = 0xBC;
+	fields := struct {
+		uint32_t queue_id;
+		uint32_t dwork_id;
+		uint32_t delay;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_reschedule_enter;
+	id = 0xBD;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t delay;
+	};
+};
+
+event {
+	name = work_reschedule_exit;
+	id = 0xBE;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t delay;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_flush_delayable_enter;
+	id = 0xBF;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t sync_id;
+	};
+};
+
+event {
+	name = work_flush_delayable_exit;
+	id = 0xC0;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t sync_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_cancel_delayable_enter;
+	id = 0xC1;
+	fields := struct {
+		uint32_t dwork_id;
+	};
+};
+
+event {
+	name = work_cancel_delayable_exit;
+	id = 0xC2;
+	fields := struct {
+		uint32_t dwork_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_cancel_delayable_sync_enter;
+	id = 0xC3;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t sync_id;
+	};
+};
+
+event {
+	name = work_cancel_delayable_sync_exit;
+	id = 0xC4;
+	fields := struct {
+		uint32_t dwork_id;
+		uint32_t sync_id;
+		int32_t ret;
+	};
+};
+
+/* Poll Work */
+event {
+	name = work_poll_init_enter;
+	id = 0xC5;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_poll_init_exit;
+	id = 0xC6;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_poll_submit_to_queue_enter;
+	id = 0xC7;
+	fields := struct {
+		uint32_t work_q_id;
+		uint32_t work_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_poll_submit_to_queue_blocking;
+	id = 0xC8;
+	fields := struct {
+		uint32_t work_q_id;
+		uint32_t work_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_poll_submit_to_queue_exit;
+	id = 0xC9;
+	fields := struct {
+		uint32_t work_q_id;
+		uint32_t work_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_poll_submit_enter;
+	id = 0xCA;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = work_poll_submit_exit;
+	id = 0xCB;
+	fields := struct {
+		uint32_t work_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = work_poll_cancel_enter;
+	id = 0xCC;
+	fields := struct {
+		uint32_t work_id;
+	};
+};
+
+event {
+	name = work_poll_cancel_exit;
+	id = 0xCD;
+	fields := struct {
+		uint32_t work_id;
+		int32_t ret;
+	};
+};
+
+/* Poll API */
+event {
+	name = poll_event_init;
+	id = 0xCE;
+	fields := struct {
+		uint32_t event_id;
+	};
+};
+
+event {
+	name = poll_enter;
+	id = 0xCF;
+	fields := struct {
+		uint32_t events_id;
+	};
+};
+
+event {
+	name = poll_exit;
+	id = 0xD0;
+	fields := struct {
+		uint32_t events_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = poll_signal_init;
+	id = 0xD1;
+	fields := struct {
+		uint32_t signal_id;
+	};
+};
+
+event {
+	name = poll_signal_reset;
+	id = 0xD2;
+	fields := struct {
+		uint32_t signal_id;
+	};
+};
+
+event {
+	name = poll_signal_check;
+	id = 0xD3;
+	fields := struct {
+		uint32_t signal_id;
+	};
+};
+
+event {
+	name = poll_signal_raise;
+	id = 0xD4;
+	fields := struct {
+		uint32_t signal_id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = thread_foreach_enter;
+	id = 0xD5;
+	fields := struct {};
+};
+
+event {
+	name = thread_foreach_exit;
+	id = 0xD6;
+	fields := struct {};
+};
+
+event {
+	name = thread_foreach_unlocked_enter;
+	id = 0xD7;
+	fields := struct {};
+};
+
+event {
+	name = thread_foreach_unlocked_exit;
+	id = 0xD8;
+	fields := struct {};
+};
+
+event {
+	name = thread_heap_assign;
+	id = 0xD9;
+	fields := struct {
+		uint32_t thread_id;
+		uint32_t heap_id;
+	};
+};
+
+event {
+	name = thread_join_enter;
+	id = 0xDA;
+	fields := struct {
+		uint32_t thread_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = thread_join_blocking;
+	id = 0xDB;
+	fields := struct {
+		uint32_t thread_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = thread_join_exit;
+	id = 0xDC;
+	fields := struct {
+		uint32_t thread_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = thread_msleep_enter;
+	id = 0xDD;
+	fields := struct {
+		int32_t ms;
+	};
+};
+
+event {
+	name = thread_msleep_exit;
+	id = 0xDE;
+	fields := struct {
+		int32_t ms;
+		int32_t ret;
+	};
+};
+
+event {
+	name = thread_usleep_enter;
+	id = 0xDF;
+	fields := struct {
+		int32_t us;
+	};
+};
+
+event {
+	name = thread_usleep_exit;
+	id = 0xE0;
+	fields := struct {
+		int32_t us;
+		int32_t ret;
+	};
+};
+
+event {
+	name = thread_busy_wait_enter;
+	id = 0xE1;
+	fields := struct {
+		uint32_t usec_to_wait;
+	};
+};
+
+event {
+	name = thread_busy_wait_exit;
+	id = 0xE2;
+	fields := struct {
+		uint32_t usec_to_wait;
+	};
+};
+
+event {
+	name = thread_yield;
+	id = 0xE3;
+};
+
+event {
+	name = thread_suspend_exit;
+	id = 0xE4;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_lock;
+	id = 0xE5;
+};
+
+event {
+	name = thread_sched_unlock;
+	id = 0xE6;
+};
+
+event {
+	name = thread_sched_wakeup;
+	id = 0xE7;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_abort;
+	id = 0xE8;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_priority_set;
+	id = 0xE9;
+	fields := struct {
+		uint32_t thread_id;
+		int8_t prio;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_ready;
+	id = 0xEA;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_pend;
+	id = 0xEB;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_resume;
+	id = 0xEC;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = thread_sched_suspend;
+	id = 0xED;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = mbox_init;
+	id = 0xEE;
+	fields := struct {
+		uint32_t mbox_id;
+	};
+};
+
+event {
+	name = mbox_message_put_enter;
+	id = 0xEF;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mbox_message_put_blocking;
+	id = 0xF0;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mbox_message_put_exit;
+	id = 0xF1;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mbox_put_enter;
+	id = 0xF2;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mbox_put_exit;
+	id = 0xF3;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mbox_async_put_enter;
+	id = 0xF4;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t sem_id;
+	};
+};
+
+event {
+	name = mbox_async_put_exit;
+	id = 0xF5;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t sem_id;
+	};
+};
+
+event {
+	name = mbox_get_enter;
+	id = 0xF6;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mbox_get_blocking;
+	id = 0xF7;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = mbox_get_exit;
+	id = 0xF8;
+	fields := struct {
+		uint32_t mbox_id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = mbox_data_get;
+	id = 0xF9;
+	fields := struct {
+		uint32_t msg_id;
+	};
+};
+
+event {
+	name = event_init;
+	id = 0xFA;
+	fields := struct {
+		uint32_t event_id;
+	};
+};
+
+event {
+	name = event_post_enter;
+	id = 0xFB;
+	fields := struct {
+		uint32_t event_id;
+		uint32_t events;
+		uint32_t events_mask;
+	};
+};
+
+event {
+	name = event_post_exit;
+	id = 0xFC;
+	fields := struct {
+		uint32_t event_id;
+		uint32_t events;
+		uint32_t events_mask;
+	};
+};
+
+event {
+	name = event_wait_enter;
+	id = 0xFD;
+	fields := struct {
+		uint32_t event_id;
+		uint32_t events;
+		uint32_t options;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = event_wait_blocking;
+	id = 0xFE;
+	fields := struct {
+		uint32_t event_id;
+		uint32_t events;
+		uint32_t options;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = event_wait_exit;
+	id = 0xFF;
+	fields := struct {
+		uint32_t event_id;
+		uint32_t events;
+		int32_t ret;
+	};
+};
+
+event {
+	name = timer_expiry_enter;
+	id = 0x100;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_expiry_exit;
+	id = 0x101;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_stop_fn_expiry_enter;
+	id = 0x102;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = timer_stop_fn_expiry_exit;
+	id = 0x103;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = sys_init_enter;
+	id = 0x104;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t fn;
+		uint8_t level;
+	};
+};
+
+event {
+	name = sys_init_exit;
+	id = 0x105;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t fn;
+		uint8_t level;
+		int32_t result;
+	};
+};
+
+event {
+	name = queue_init;
+	id = 0x106;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_cancel_wait;
+	id = 0x107;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_queue_insert_enter;
+	id = 0x108;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+	};
+};
+
+event {
+	name = queue_queue_insert_blocking;
+	id = 0x109;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_queue_insert_exit;
+	id = 0x10A;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_append_enter;
+	id = 0x10B;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_exit;
+	id = 0x10C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_append_enter;
+	id = 0x10D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_append_exit;
+	id = 0x10E;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_prepend_enter;
+	id = 0x10F;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_prepend_exit;
+	id = 0x110;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_prepend_enter;
+	id = 0x111;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_prepend_exit;
+	id = 0x112;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_insert_enter;
+	id = 0x113;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_insert_exit;
+	id = 0x114;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_list_enter;
+	id = 0x115;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_list_exit;
+	id = 0x116;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_merge_slist_enter;
+	id = 0x117;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_merge_slist_exit;
+	id = 0x118;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_get_enter;
+	id = 0x119;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_get_blocking;
+	id = 0x11A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_get_exit;
+	id = 0x11B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = queue_remove_enter;
+	id = 0x11C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_remove_exit;
+	id = 0x11D;
+	fields := struct {
+		uint32_t id;
+		uint8_t ret;
+	};
+};
+
+event {
+	name = queue_unique_append_enter;
+	id = 0x11E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_unique_append_exit;
+	id = 0x11F;
+	fields := struct {
+		uint32_t id;
+		uint8_t ret;
+	};
+};
+
+event {
+	name = queue_peek_head;
+	id = 0x120;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = queue_peek_tail;
+	id = 0x121;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = fifo_init_enter;
+	id = 0x122;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_init_exit;
+	id = 0x123;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_cancel_wait_enter;
+	id = 0x124;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_cancel_wait_exit;
+	id = 0x125;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_put_enter;
+	id = 0x126;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_put_exit;
+	id = 0x127;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_alloc_put_enter;
+	id = 0x128;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_alloc_put_exit;
+	id = 0x129;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		int32_t ret;
+	};
+};
+
+event {
+	name = fifo_put_list_enter;
+	id = 0x12A;
+	fields := struct {
+		uint32_t id;
+		uint32_t head;
+		uint32_t tail;
+	};
+};
+
+event {
+	name = fifo_put_list_exit;
+	id = 0x12B;
+	fields := struct {
+		uint32_t id;
+		uint32_t head;
+		uint32_t tail;
+	};
+};
+
+event {
+	name = fifo_put_slist_enter;
+	id = 0x12C;
+	fields := struct {
+		uint32_t id;
+		uint32_t list;
+	};
+};
+
+event {
+	name = fifo_put_slist_exit;
+	id = 0x12D;
+	fields := struct {
+		uint32_t id;
+		uint32_t list;
+	};
+};
+
+event {
+	name = fifo_get_enter;
+	id = 0x12E;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = fifo_get_exit;
+	id = 0x12F;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = fifo_peek_head_enter;
+	id = 0x130;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_peek_head_exit;
+	id = 0x131;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = fifo_peek_tail_enter;
+	id = 0x132;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_peek_tail_exit;
+	id = 0x133;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = lifo_init_enter;
+	id = 0x134;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = lifo_init_exit;
+	id = 0x135;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = lifo_put_enter;
+	id = 0x136;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_put_exit;
+	id = 0x137;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_alloc_put_enter;
+	id = 0x138;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_alloc_put_exit;
+	id = 0x139;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		int32_t ret;
+	};
+};
+
+event {
+	name = lifo_get_enter;
+	id = 0x13A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = lifo_get_exit;
+	id = 0x13B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = stack_init;
+	id = 0x13C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_alloc_init_enter;
+	id = 0x13D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_alloc_init_exit;
+	id = 0x13E;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_cleanup_enter;
+	id = 0x13F;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_cleanup_exit;
+	id = 0x140;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_push_enter;
+	id = 0x141;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_push_exit;
+	id = 0x142;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_pop_enter;
+	id = 0x143;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = stack_pop_blocking;
+	id = 0x144;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = stack_pop_exit;
+	id = 0x145;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};
+
+event {
+	name = heap_init;
+	id = 0x146;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = heap_aligned_alloc_enter;
+	id = 0x147;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = heap_alloc_helper_blocking;
+	id = 0x148;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = heap_aligned_alloc_exit;
+	id = 0x149;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_alloc_enter;
+	id = 0x14A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = heap_alloc_exit;
+	id = 0x14B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_calloc_enter;
+	id = 0x14C;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = heap_calloc_exit;
+	id = 0x14D;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_free;
+	id = 0x14E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = heap_realloc_enter;
+	id = 0x14F;
+	fields := struct {
+		uint32_t id;
+		uint32_t ptr;
+		uint32_t bytes;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = heap_realloc_exit;
+	id = 0x150;
+	fields := struct {
+		uint32_t id;
+		uint32_t ptr;
+		uint32_t bytes;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_sys_k_aligned_alloc_enter;
+	id = 0x151;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = heap_sys_k_aligned_alloc_exit;
+	id = 0x152;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_sys_k_malloc_enter;
+	id = 0x153;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = heap_sys_k_malloc_exit;
+	id = 0x154;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_sys_k_calloc_enter;
+	id = 0x155;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = heap_sys_k_calloc_exit;
+	id = 0x156;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = heap_sys_k_free_enter;
+	id = 0x157;
+	fields := struct {
+		uint32_t id;
+		uint32_t heap_ref;
+	};
+};
+
+event {
+	name = heap_sys_k_free_exit;
+	id = 0x158;
+	fields := struct {
+		uint32_t id;
+		uint32_t heap_ref;
+	};
+};
+
+event {
+	name = heap_sys_k_realloc_enter;
+	id = 0x159;
+	fields := struct {
+		uint32_t id;
+		uint32_t ptr;
+	};
+};
+
+event {
+	name = heap_sys_k_realloc_exit;
+	id = 0x15A;
+	fields := struct {
+		uint32_t id;
+		uint32_t ptr;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = pipe_init;
+	id = 0x15B;
+	fields := struct {
+		uint32_t id;
+		uint32_t buffer;
+		uint32_t size;
+	};
+};
+
+event {
+	name = pipe_reset_enter;
+	id = 0x15C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pipe_reset_exit;
+	id = 0x15D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pipe_close_enter;
+	id = 0x15E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pipe_close_exit;
+	id = 0x15F;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pipe_write_enter;
+	id = 0x160;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		uint32_t len;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = pipe_write_blocking;
+	id = 0x161;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = pipe_write_exit;
+	id = 0x162;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pipe_read_enter;
+	id = 0x163;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		uint32_t len;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = pipe_read_blocking;
+	id = 0x164;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = pipe_read_exit;
+	id = 0x165;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = rtio_submit_enter;
+	id = 0x166;
+	fields := struct {
+		uint32_t id;
+		uint32_t wait_count;
+	};
+};
+
+event {
+	name = rtio_submit_exit;
+	id = 0x167;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_sqe_acquire_enter;
+	id = 0x168;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_sqe_acquire_exit;
+	id = 0x169;
+	fields := struct {
+		uint32_t id;
+		uint32_t sqe;
+	};
+};
+
+event {
+	name = rtio_sqe_cancel;
+	id = 0x16A;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_cqe_submit_enter;
+	id = 0x16B;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+		uint32_t flags;
+	};
+};
+
+event {
+	name = rtio_cqe_submit_exit;
+	id = 0x16C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_cqe_acquire_enter;
+	id = 0x16D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_cqe_acquire_exit;
+	id = 0x16E;
+	fields := struct {
+		uint32_t id;
+		uint32_t cqe;
+	};
+};
+
+event {
+	name = rtio_cqe_release;
+	id = 0x16F;
+	fields := struct {
+		uint32_t id;
+		uint32_t cqe;
+	};
+};
+
+event {
+	name = rtio_cqe_consume_enter;
+	id = 0x170;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = rtio_cqe_consume_exit;
+	id = 0x171;
+	fields := struct {
+		uint32_t id;
+		uint32_t cqe;
+	};
+};
+
+event {
+	name = rtio_txn_next_enter;
+	id = 0x172;
+	fields := struct {
+		uint32_t id;
+		uint32_t iodev_sqe;
+	};
+};
+
+event {
+	name = rtio_txn_next_exit;
+	id = 0x173;
+	fields := struct {
+		uint32_t id;
+		uint32_t iodev_sqe;
+	};
+};
+
+event {
+	name = rtio_chain_next_enter;
+	id = 0x174;
+	fields := struct {
+		uint32_t id;
+		uint32_t iodev_sqe;
+	};
+};
+
+event {
+	name = rtio_chain_next_exit;
+	id = 0x175;
+	fields := struct {
+		uint32_t id;
+		uint32_t iodev_sqe;
+	};
+};
+
+event {
+	name = pm_device_runtime_get_enter;
+	id = 0x176;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pm_device_runtime_get_exit;
+	id = 0x177;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pm_device_runtime_put_enter;
+	id = 0x178;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pm_device_runtime_put_exit;
+	id = 0x179;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pm_device_runtime_put_async_enter;
+	id = 0x17A;
+	fields := struct {
+		uint32_t id;
+		uint32_t delay;
+	};
+};
+
+event {
+	name = pm_device_runtime_put_async_exit;
+	id = 0x17B;
+	fields := struct {
+		uint32_t id;
+		uint32_t delay;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pm_device_runtime_enable_enter;
+	id = 0x17C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pm_device_runtime_enable_exit;
+	id = 0x17D;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pm_device_runtime_disable_enter;
+	id = 0x17E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = pm_device_runtime_disable_exit;
+	id = 0x17F;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = pm_system_suspend_enter;
+	id = 0x180;
+	fields := struct {
+		int32_t ticks;
+	};
+};
+
+event {
+	name = pm_system_suspend_exit;
+	id = 0x181;
+	fields := struct {
+		int32_t ticks;
+		uint8_t state;
+	};
+};
+
+event {
+	name = syscall_enter;
+	id = 0x182;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t name[20];
+	};
+};
+
+event {
+	name = syscall_exit;
+	id = 0x183;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = thread_sleep_ticks_enter;
+	id = 0x184;
+	fields := struct {
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = thread_sleep_ticks_exit;
+	id = 0x185;
+	fields := struct {
+		uint32_t timeout;
+		int32_t ret;
+	};
+};


### PR DESCRIPTION
  Add a CTF-local circular RAM capture path for preserving the most
  recent trace events across a failure.

  CTF events are written as complete records into fixed-size packets.
  When the capture buffer wraps, the oldest packet is overwritten. The
  packet header and context allow the host tool to order valid packets
  after a debugger dump.

  Require the RAM tracing backend selection for circular capture and
  route CTF events directly to the CTF-local writer. Keep the circular
  metadata synchronized with the standard CTF event table and use its
  16-bit event ID format.

  Document the required configuration and circular dump workflow.

  Tested with:
  west build -b qemu_riscv32 samples/hello_world -d ../build
  python3 scripts/tracing/sort_ctf_circular.py <dump> <trace-dir> \
    --packet-count 32 --force
  babeltrace2 <trace-dir>