### PR TITLE
drivers: udc: fix multiple instance support in UDC drivers

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -956,13 +956,13 @@ static const struct udc_api udc_ambiq_api = {
 	{                                                                                          \
 		irq_disable(DT_INST_IRQN(n));                                                      \
 	}                                                                                          \
-	static struct udc_ep_config ep_cfg_out[DT_INST_PROP(n, num_bidir_endpoints)];              \
-	static struct udc_ep_config ep_cfg_in[DT_INST_PROP(n, num_bidir_endpoints)];               \
+	static struct udc_ep_config ep_cfg_out_##n[DT_INST_PROP(n, num_bidir_endpoints)];          \
+	static struct udc_ep_config ep_cfg_in_##n[DT_INST_PROP(n, num_bidir_endpoints)];           \
                                                                                                    \
 	static const struct udc_ambiq_config udc_ambiq_config_##n = {                              \
 		.num_endpoints = DT_INST_PROP(n, num_bidir_endpoints),                             \
-		.ep_cfg_in = ep_cfg_out,                                                           \
-		.ep_cfg_out = ep_cfg_in,                                                           \
+		.ep_cfg_in = ep_cfg_out_##n,                                                       \
+		.ep_cfg_out = ep_cfg_in_##n,                                                       \
 		.speed_idx = DT_ENUM_IDX(DT_DRV_INST(n), maximum_speed),                           \
 		.vddusb33_gpio = GPIO_DT_SPEC_GET_OR(DT_DRV_INST(n), vddusb33_gpios, {0}),         \
 		.vddusb0p9_gpio = GPIO_DT_SPEC_GET_OR(DT_DRV_INST(n), vddusb0p9_gpios, {0}),       \

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -3304,15 +3304,17 @@ static const struct udc_api udc_dwc2_api = {
 										\
 	UDC_DWC2_IRQ_DT_INST_DEFINE(n)						\
 										\
-	static struct udc_ep_config ep_cfg_out[DT_INST_PROP(n, num_out_eps)];	\
-	static struct udc_ep_config ep_cfg_in[DT_INST_PROP(n, num_in_eps)];	\
+	static struct udc_ep_config						\
+		ep_cfg_out_##n[DT_INST_PROP(n, num_out_eps)];			\
+	static struct udc_ep_config						\
+		ep_cfg_in_##n[DT_INST_PROP(n, num_in_eps)];			\
 										\
 	static const struct udc_dwc2_config udc_dwc2_config_##n = {		\
 		UDC_DWC2_DT_INST_REG_ADDR(n),					\
 		.num_out_eps = DT_INST_PROP(n, num_out_eps),			\
 		.num_in_eps = DT_INST_PROP(n, num_in_eps),			\
-		.ep_cfg_in = ep_cfg_in,						\
-		.ep_cfg_out = ep_cfg_out,					\
+		.ep_cfg_in = ep_cfg_in_##n,					\
+		.ep_cfg_out = ep_cfg_out_##n,					\
 		.make_thread = udc_dwc2_make_thread_##n,			\
 		.pcfg = UDC_DWC2_PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\
 		.irq_enable_func = udc_dwc2_irq_enable_func_##n,		\

--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1602,8 +1602,8 @@ static int it82xx2_usb_driver_preinit(const struct device *dev)
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
                                                                                                    \
-	static struct udc_ep_config ep_cfg_out[MAX_NUM_ENDPOINTS];                                 \
-	static struct udc_ep_config ep_cfg_in[MAX_NUM_ENDPOINTS];                                  \
+	static struct udc_ep_config ep_cfg_out_##n[MAX_NUM_ENDPOINTS];                             \
+	static struct udc_ep_config ep_cfg_in_##n[MAX_NUM_ENDPOINTS];                              \
                                                                                                    \
 	static struct usb_it82xx2_config udc_cfg_##n = {                                           \
 		.base = (struct usb_it82xx2_regs *)DT_INST_REG_ADDR(n),                            \
@@ -1611,8 +1611,8 @@ static int it82xx2_usb_driver_preinit(const struct device *dev)
 		.wuc = {.dev = IT8XXX2_DEV_WUC(0, n), .mask = IT8XXX2_DEV_WUC_MASK(0, n)},         \
 		.usb_irq = DT_INST_IRQ_BY_IDX(n, 0, irq),                                          \
 		.wu_irq = DT_INST_IRQ_BY_IDX(n, 1, irq),                                           \
-		.ep_cfg_in = ep_cfg_out,                                                           \
-		.ep_cfg_out = ep_cfg_in,                                                           \
+		.ep_cfg_in = ep_cfg_out_##n,                                                       \
+		.ep_cfg_out = ep_cfg_in_##n,                                                       \
 		.make_thread = udc_it82xx2_make_thread_##n,                                        \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -1029,9 +1029,9 @@ static const struct udc_api usbfsotg_api = {
 		bdt_##n[DT_INST_PROP(n, num_bidir_endpoints) * 2 * 2];		\
 										\
 	static struct udc_ep_config						\
-		ep_cfg_out[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_out_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 	static struct udc_ep_config						\
-		ep_cfg_in[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_in_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 										\
 	static struct usbfsotg_config priv_config_##n = {			\
 		.base = (USB_Type *)DT_INST_REG_ADDR(n),			\
@@ -1040,8 +1040,8 @@ static const struct udc_api usbfsotg_api = {
 		.irq_disable_func = udc_irq_disable_func##n,			\
 		.make_thread = usbfsotg_make_thread_##n,			\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),		\
-		.ep_cfg_in = ep_cfg_in,						\
-		.ep_cfg_out = ep_cfg_out,					\
+		.ep_cfg_in = ep_cfg_in_##n,					\
+		.ep_cfg_out = ep_cfg_out_##n,					\
 	};									\
 										\
 	static struct usbfsotg_data priv_data_##n = {				\

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -1185,16 +1185,16 @@ static const struct udc_api udc_rpi_pico_api = {
 		irq_disable(DT_INST_IRQN(n));						\
 	}										\
 											\
-	static struct udc_ep_config ep_cfg_out[USB_NUM_ENDPOINTS];			\
-	static struct udc_ep_config ep_cfg_in[USB_NUM_ENDPOINTS];			\
+	static struct udc_ep_config ep_cfg_out_##n[USB_NUM_ENDPOINTS];			\
+	static struct udc_ep_config ep_cfg_in_##n[USB_NUM_ENDPOINTS];			\
 											\
 	static const struct rpi_pico_config rpi_pico_config_##n = {			\
 		.base = (usb_hw_t *)DT_INST_REG_ADDR(n),				\
 		.dpram = (usb_device_dpram_t *)USBCTRL_DPRAM_BASE,			\
 		.mem_block = &rpi_pico_mb_##n,						\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),			\
-		.ep_cfg_in = ep_cfg_out,						\
-		.ep_cfg_out = ep_cfg_in,						\
+		.ep_cfg_in = ep_cfg_out_##n,						\
+		.ep_cfg_out = ep_cfg_in_##n,						\
 		.make_thread = udc_rpi_pico_make_thread_##n,				\
 		.irq_enable_func = udc_rpi_pico_irq_enable_func_##n,			\
 		.irq_disable_func = udc_rpi_pico_irq_disable_func_##n,			\

--- a/drivers/usb/udc/udc_sam0.c
+++ b/drivers/usb/udc/udc_sam0.c
@@ -1120,16 +1120,16 @@ static void udc_sam0_irq_disable_func_##n(const struct device *dev)		\
 	}									\
 										\
 	static struct udc_ep_config						\
-		ep_cfg_out[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_out_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 	static struct udc_ep_config						\
-		ep_cfg_in[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_in_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 										\
 	static const struct udc_sam0_config udc_sam0_config_##n = {		\
 		.base = (UsbDevice *)DT_INST_REG_ADDR(n),			\
 		.bdt = sam0_bdt_##n,						\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),		\
-		.ep_cfg_in = ep_cfg_out,					\
-		.ep_cfg_out = ep_cfg_in,					\
+		.ep_cfg_in = ep_cfg_out_##n,					\
+		.ep_cfg_out = ep_cfg_in_##n,					\
 		.irq_enable_func = udc_sam0_irq_enable_func_##n,		\
 		.irq_disable_func = udc_sam0_irq_disable_func_##n,		\
 		.pcfg = UDC_SAM0_PINCTRL_DT_INST_DEV_CONFIG_GET(n),		\

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -401,14 +401,14 @@ static const struct udc_api udc_skeleton_api = {
 			      CONFIG_UDC_SKELETON_STACK_SIZE);			\
 										\
 	static struct udc_ep_config						\
-		ep_cfg_out[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_out_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 	static struct udc_ep_config						\
-		ep_cfg_in[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_in_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 										\
 	static const struct udc_skeleton_config udc_skeleton_config_##n = {	\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),		\
-		.ep_cfg_in = ep_cfg_out,					\
-		.ep_cfg_out = ep_cfg_in,					\
+		.ep_cfg_in = ep_cfg_out_##n,					\
+		.ep_cfg_out = ep_cfg_in_##n,					\
 		.thread_stk = udc_skeleton_stack_##n,				\
 		.thread_stk_sz = K_THREAD_STACK_SIZEOF(udc_skeleton_stack_##n),	\
 		.speed_idx = DT_ENUM_IDX(DT_DRV_INST(n), maximum_speed),	\

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -563,9 +563,9 @@ static const struct udc_api udc_vrt_api = {
 	}									\
 										\
 	static struct udc_ep_config						\
-		ep_cfg_out[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_out_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 	static struct udc_ep_config						\
-		ep_cfg_in[DT_INST_PROP(n, num_bidir_endpoints)];		\
+		ep_cfg_in_##n[DT_INST_PROP(n, num_bidir_endpoints)];		\
 										\
 	static struct uvb_node udc_vrt_dev_node##n = {				\
 		.name = DT_NODE_FULL_NAME(DT_DRV_INST(n)),			\
@@ -574,8 +574,8 @@ static const struct udc_api udc_vrt_api = {
 										\
 	static const struct udc_vrt_config udc_vrt_config_##n = {		\
 		.num_of_eps = DT_INST_PROP(n, num_bidir_endpoints),		\
-		.ep_cfg_in = ep_cfg_out,					\
-		.ep_cfg_out = ep_cfg_in,					\
+		.ep_cfg_in = ep_cfg_out_##n,					\
+		.ep_cfg_out = ep_cfg_in_##n,					\
 		.make_thread = udc_vrt_make_thread_##n,				\
 		.dev_node = &udc_vrt_dev_node##n,				\
 		.speed_idx = DT_ENUM_IDX(DT_DRV_INST(n), maximum_speed),	\


### PR DESCRIPTION
The driver's endpoint configuration must be per instance.

Cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/112648, but then noticed there are more drivers with the same issue.