### PR TITLE
tests: mem_protect/mem_map: add ARM64 to arch allow list, and remove Intel ADSP from exclude lit

### DIFF
--- a/tests/kernel/mem_protect/mem_map/tests.yaml
+++ b/tests/kernel/mem_protect/mem_map/tests.yaml
@@ -7,6 +7,7 @@ tests:
   kernel.memory_protection.mem_map:
     arch_allow:
       - arm
+      - arm64
       - x86
     filter: CONFIG_MMU and not CONFIG_X86_64 and not CONFIG_SOC_FAMILY_INTEL_ADSP
     extra_sections: _TRANSPLANTED_FUNC

--- a/tests/kernel/mem_protect/mem_map/tests.yaml
+++ b/tests/kernel/mem_protect/mem_map/tests.yaml
@@ -9,14 +9,13 @@ tests:
       - arm
       - arm64
       - x86
-    filter: CONFIG_MMU and not CONFIG_X86_64 and not CONFIG_SOC_FAMILY_INTEL_ADSP
+    filter: CONFIG_MMU and not CONFIG_X86_64
     extra_sections: _TRANSPLANTED_FUNC
     extra_configs:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=0
       - CONFIG_CBPRINTF_REDUCED_INTEGRAL=y
     platform_exclude:
       - qemu_x86_64
-      - intel_adsp/ace30/ptl
     integration_platforms:
       - qemu_x86
   kernel.memory_protection.mem_map.x86_64:


### PR DESCRIPTION
- Add ARM64 to architecture allow list so that we can run CI with QEMU.
- Also remove Intel ADSP from the filter and exclude list as the arch allow list does not have Xtensa. 