### PR TITLE
drivers: adc: ads1x4s0x: apply INPMUX defaults to correct variable

### DIFF
--- a/drivers/adc/adc_ads1x4s0x.c
+++ b/drivers/adc/adc_ads1x4s0x.c
@@ -630,7 +630,7 @@ static int ads1x4s0x_channel_setup(const struct device *dev,
 	uint16_t acquisition_time_value = ADC_ACQ_TIME_VALUE(channel_cfg->acquisition_time);
 	uint16_t acquisition_time_unit = ADC_ACQ_TIME_UNIT(channel_cfg->acquisition_time);
 
-	ADS1X4S0X_REGISTER_INPMUX_SET_DEFAULTS(gain);
+	ADS1X4S0X_REGISTER_INPMUX_SET_DEFAULTS(input_mux);
 	ADS1X4S0X_REGISTER_REF_SET_DEFAULTS(reference_control);
 	ADS1X4S0X_REGISTER_DATARATE_SET_DEFAULTS(data_rate);
 	ADS1X4S0X_REGISTER_PGA_SET_DEFAULTS(gain);


### PR DESCRIPTION
ads1x4s0x_channel_setup() applied ADS1X4S0X_REGISTER_INPMUX_SET_DEFAULTS to `gain` instead of `input_mux`, so the INPMUX default was written to the PGA accumulator (immediately overwritten by PGA_SET_DEFAULTS) rather than the INPMUX byte. The behavior is unchanged because input_mux has both MUX nibbles written unconditionally before use, but the code did not do what it reads as doing. Fix the target variable.