### PR TITLE
drivers: gnss: u-blox: fix gnss warm/cold start for F9P & M10 drivers

### DIFF
--- a/drivers/gnss/u_blox/gnss_u_blox_f9p.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_f9p.c
@@ -147,12 +147,12 @@ static int ubx_f9p_start(const struct device *dev, enum gnss_start_mode mode)
 
 	case GNSS_WARM_START:
 		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_WARM_START;
-		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
 		break;
 
 	case GNSS_COLD_START:
 		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_COLD_START;
-		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
 		break;
 
 	default:

--- a/drivers/gnss/u_blox/gnss_u_blox_m10.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_m10.c
@@ -116,12 +116,12 @@ static int ubx_m10_start(const struct device *dev, enum gnss_start_mode mode)
 
 	case GNSS_WARM_START:
 		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_WARM_START;
-		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
 		break;
 
 	case GNSS_COLD_START:
 		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_COLD_START;
-		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
 		break;
 
 	default:


### PR DESCRIPTION
When gnss start/stop api first implemented, wrong reset type was set in driver implementation for warm and cold start operations,  causing unwanted loss of RAM/BBR CFG layers.

Changes tested on both F9P and M10 targets

Reported from https://github.com/zephyrproject-rtos/zephyr/issues/118536