### PR TITLE
drivers: i2c: rtio: Add priority-based mpsc scheduling  

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -142,6 +142,13 @@ config I2C_RTIO_FALLBACK_MSGS
 		an issue where you are using RTIO, your driver does not implement submit natively,
 		and get an error relating to not enough i2c msgs this is the Kconfig to manipulate.
 
+config I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
+	bool "Priority-based scheduling for the I2C RTIO submission queue"
+
+config I2C_RTIO_PRIORITY_LEVELS
+	int "Number of priority levels"
+	default 4
+	depends on I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
 endif # I2C_RTIO
 
 

--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -96,12 +96,16 @@ struct rtio_sqe *i2c_rtio_copy_reg_burst_read(struct rtio *r, struct rtio_iodev 
 void i2c_rtio_init(struct i2c_rtio *ctx, const struct device *dev)
 {
 	k_sem_init(&ctx->lock, 1, 1);
+#ifdef CONFIG_I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
+	mpsc_priority_init(&ctx->io_pq, &ctx->io_queues, CONFIG_I2C_RTIO_PRIORITY_LEVELS);
+#else
 	mpsc_init(&ctx->io_q);
 	ctx->txn_curr = NULL;
 	ctx->txn_head = NULL;
 	ctx->dt_spec.bus = dev;
 	ctx->iodev.data = &ctx->dt_spec;
 	ctx->iodev.api = &i2c_iodev_api;
+#endif
 }
 
 /**
@@ -121,7 +125,12 @@ static bool i2c_rtio_next(struct i2c_rtio *ctx, bool completion)
 		return false;
 	}
 
-	struct mpsc_node *next = mpsc_pop(&ctx->io_q);
+	struct mpsc_node *next =
+#ifdef CONFIG_I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
+		mpsc_priority_pop(&ctx->io_pq);
+#else
+		mpsc_pop(&ctx->io_q);
+#endif
 
 	/* Nothing left to do */
 	if (next == NULL) {
@@ -158,7 +167,11 @@ bool i2c_rtio_complete(struct i2c_rtio *ctx, int status)
 }
 bool i2c_rtio_submit(struct i2c_rtio *ctx, struct rtio_iodev_sqe *iodev_sqe)
 {
+#ifdef CONFIG_I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
+	mpsc_priority_push(&ctx->io_pq, &iodev_sqe->q, iodev_sqe->sqe->prio);
+#else
 	mpsc_push(&ctx->io_q, &iodev_sqe->q);
+#endif
 	return i2c_rtio_next(ctx, false);
 }
 

--- a/drivers/i2c/i2c_rtio.c
+++ b/drivers/i2c/i2c_rtio.c
@@ -100,12 +100,13 @@ void i2c_rtio_init(struct i2c_rtio *ctx, const struct device *dev)
 	mpsc_priority_init(&ctx->io_pq, &ctx->io_queues, CONFIG_I2C_RTIO_PRIORITY_LEVELS);
 #else
 	mpsc_init(&ctx->io_q);
+#endif
 	ctx->txn_curr = NULL;
 	ctx->txn_head = NULL;
 	ctx->dt_spec.bus = dev;
 	ctx->iodev.data = &ctx->dt_spec;
 	ctx->iodev.api = &i2c_iodev_api;
-#endif
+
 }
 
 /**

--- a/include/zephyr/drivers/i2c/rtio.h
+++ b/include/zephyr/drivers/i2c/rtio.h
@@ -22,7 +22,12 @@ struct i2c_rtio {
 	struct k_sem lock;
 	struct k_spinlock slock;
 	struct rtio *r;
+#ifdef CONFIG_I2C_RTIO_SUBMISSION_QUEUE_PRIORITY
+	struct mpsc_priority io_pq;
+	struct mpsc io_queues[CONFIG_I2C_RTIO_PRIORITY_LEVELS];
+#else
 	struct mpsc io_q;
+#endif
 	struct rtio_iodev iodev;
 	struct rtio_iodev_sqe *txn_head;
 	struct rtio_iodev_sqe *txn_curr;

--- a/include/zephyr/rtio/sqe.h
+++ b/include/zephyr/rtio/sqe.h
@@ -53,12 +53,12 @@ extern "C" {
 /**
  * @brief Normal priority
  */
-#define RTIO_PRIO_NORM 127U
+#define RTIO_PRIO_NORM 1U
 
 /**
  * @brief High priority
  */
-#define RTIO_PRIO_HIGH 255U
+#define RTIO_PRIO_HIGH 2U
 
 /**
  * @}

--- a/include/zephyr/sys/mpsc_lockfree_priority.h
+++ b/include/zephyr/sys/mpsc_lockfree_priority.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_
+#define ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_
+
+/**
+ * @file
+ * @brief Priority-aware lock-free multiple-producer, single-consumer queue.
+ */
+
+#include <zephyr/sys/mpsc_lockfree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Priority MPSC queue
+ * @param queues Array containing one MPSC queue per priority
+ * @param num_priorities Number of elements in @p queues
+ */
+struct mpsc_priority {
+	/** @brief Array containing one MPSC queue per priority. */
+	struct mpsc *queues;
+
+	/** @brief Number of priorities. */
+	uint8_t num_priorities;
+};
+
+/**
+ * @brief Initialize a priority MPSC queue
+ *
+ * @param q Priority queue to initialize
+ * @param queues Array containing one MPSC queue per priority
+ * @param num_priorities Number of elements in @p queues
+ */
+static inline void mpsc_priority_init(struct mpsc_priority *q, struct mpsc *queues,
+				      uint8_t num_priorities)
+{
+	__ASSERT_NO_MSG(q != NULL);
+	__ASSERT_NO_MSG(queues != NULL);
+	__ASSERT_NO_MSG(num_priorities > 0U);
+
+	q->queues = queues;
+	q->num_priorities = num_priorities;
+
+	for (uint8_t priority = 0U; priority < num_priorities; priority++) {
+		mpsc_init(&queues[priority]);
+	}
+}
+
+/**
+ * @brief Push a node into a priority MPSC queue
+ *
+ * @param q Priority queue
+ * @param node Node to push
+ * @param priority Node priority, where 0 is the highest priority
+ */
+static ALWAYS_INLINE void mpsc_priority_push(struct mpsc_priority *q, struct mpsc_node *node,
+					     uint8_t priority)
+{
+	__ASSERT_NO_MSG(q != NULL);
+	__ASSERT_NO_MSG(node != NULL);
+	__ASSERT_NO_MSG(priority < q->num_priorities);
+
+	mpsc_push(&q->queues[priority], node);
+}
+
+/**
+ * @brief Pop the highest-priority available node
+ *
+ * This function must only be called from one execution context. If producers
+ * are active concurrently, the returned node is the highest-priority node
+ * observable while the queues are scanned.
+ *
+ * @param q Priority queue
+ *
+ * @retval NULL When no node is available
+ * @retval node Highest-priority available node
+ */
+static inline struct mpsc_node *mpsc_priority_pop(struct mpsc_priority *q)
+{
+	__ASSERT_NO_MSG(q != NULL);
+
+	for (uint8_t priority = 0U; priority < q->num_priorities; priority++) {
+		struct mpsc_node *node = mpsc_pop(&q->queues[priority]);
+
+		if (node != NULL) {
+			return node;
+		}
+	}
+
+	return NULL;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_PRIORITY_H_ */

--- a/tests/lib/lockfree/src/test_mpsc.c
+++ b/tests/lib/lockfree/src/test_mpsc.c
@@ -11,6 +11,7 @@
 #include <zephyr/timing/timing.h>
 #include <zephyr/sys/spsc_lockfree.h>
 #include <zephyr/sys/mpsc_lockfree.h>
+#include <zephyr/sys/mpsc_lockfree_priority.h>
 
 static struct mpsc push_pop_q;
 static struct mpsc_node push_pop_nodes[2];
@@ -66,6 +67,52 @@ ZTEST(mpsc, test_push_pop)
 
 	node = mpsc_pop(&push_pop_q);
 	zassert_is_null(node, "Pop on empty queue should return null");
+}
+
+
+/*
+ * @brief Test for MPSC priority ordering
+ *
+ * This test verifies that elements pushed into the MPSC priority queue
+ * are popped in the correct priority order.
+ */
+#define MPSC_PRIORITY_LEVELS 3
+
+struct test_mpsc_priority_node {
+	struct mpsc_node node;
+	uint32_t value;
+};
+
+ZTEST(mpsc, test_priority_ordering)
+{
+	struct mpsc queues[MPSC_PRIORITY_LEVELS];
+	struct mpsc_priority priority_q;
+	struct test_mpsc_priority_node nodes[] = {
+		{ .value = 0U },
+		{ .value = 1U },
+		{ .value = 2U },
+		{ .value = 3U },
+	};
+	const uint32_t expected[] = { 1U, 2U, 0U, 3U };
+
+	mpsc_priority_init(&priority_q, queues, ARRAY_SIZE(queues));
+	zassert_is_null(mpsc_priority_pop(&priority_q));
+
+	mpsc_priority_push(&priority_q, &nodes[0].node, 2U);
+	mpsc_priority_push(&priority_q, &nodes[1].node, 0U);
+	mpsc_priority_push(&priority_q, &nodes[2].node, 1U);
+	mpsc_priority_push(&priority_q, &nodes[3].node, 2U);
+
+	for (size_t i = 0U; i < ARRAY_SIZE(expected); i++) {
+		struct mpsc_node *node = mpsc_priority_pop(&priority_q);
+		struct test_mpsc_priority_node *priority_node;
+
+		zassert_not_null(node);
+		priority_node = CONTAINER_OF(node, struct test_mpsc_priority_node, node);
+		zassert_equal(priority_node->value, expected[i]);
+	}
+
+	zassert_is_null(mpsc_priority_pop(&priority_q));
 }
 
 #define MPSC_FREEQ_SZ 8


### PR DESCRIPTION
This adds support for priority aware mpsc in scheduling i2c transactions through rtio subsystem