### PR TITLE
drivers: eeprom: simulator: reject out-of-range offsets

### DIFF
--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -95,11 +95,11 @@ static int eeprom_range_is_valid(const struct device *dev, off_t offset,
 {
 	const struct eeprom_sim_config *config = dev->config;
 
-	if ((offset + len) <= config->size) {
-		return 1;
+	if ((offset < 0) || (((size_t)offset + len) > config->size)) {
+		return 0;
 	}
 
-	return 0;
+	return 1;
 }
 
 static int eeprom_sim_read(const struct device *dev, off_t offset, void *data,


### PR DESCRIPTION
eeprom_range_is_valid() tested only (offset + len) <= size. off_t is signed and len unsigned, so a negative offset with a compensating len wrapped the sum into range while the subsequent memcpy() addressed memory before mock_eeprom, letting an unprivileged thread read or write kernel SRAM. Reject negative offsets and bound-check without overflow.

Fixes: #119410