### PR TITLE
scripts: twisterlib: fix snippet filtering

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1203,7 +1203,7 @@ class TestPlan:
 
                             for this_board in found_snippets[this_snippet].board2appends:
                                 if this_board.startswith('/'):
-                                    match = re.search(this_board[1:-1], plat.name)
+                                    match = re.fullmatch(this_board[1:-1], plat.name)
                                     if match is not None:
                                         matched_snippet_board = True
                                         break


### PR DESCRIPTION
The generated cmake snippet logic in `snippets_generated.cmake` requires a full board name match, enforced by the anchoring characters `^...$`, to apply the relevent overlays.

The python `testplan.py` `required_snippets` filtering currently enforces a looser filtering of `re.search`. This allows boards to pass the twister filtering that don't actually support the required snippet.

For example a snippet with board regex of `/nrf54l15dk/nrf54l15/cpuapp/` when compiled for `nrf54l15dk/nrf54l15/cpuapp/ns` would pass the twister filtering step, but not apply any snippet in cmake.

Switch `re.search` to `re.fullmatch` to duplicate the CMake logic.