### PR TITLE
west.yaml: hal_intel: update hal_intel revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_intel
-      revision: 7c8942c1ecb38b53dae0a02aeb4ab08371f4d4bf
+      revision: 71e18c0f225e5941cc1fc84f0ae35d61d9c654d0
       path: modules/hal/intel
       groups:
         - hal


### PR DESCRIPTION
two major changes:
- aon: Clean up SRAM deep-sleep entry/exit sequencing.
- Revert "pm: allow reset when reset type is set", which causes continuous ish rebooting in case PMU_RST_PREP_RESET_TYPE (Bits [9:2]) in PMU_RST_PREP latches PMU_RST_AP_REBOOT (0x40).