### PR TITLE
Bluetooth: OTS: Client: call checksum cb on error responses

### DIFF
--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
+#include <zephyr/net/buf.h>
 #include <zephyr/types.h>
 
 #include <zephyr/device.h>
@@ -399,17 +400,24 @@ static void oacp_ind_handler(struct bt_conn *conn,
 		}
 
 		if (req_opcode == BT_GATT_OTS_OACP_PROC_CHECKSUM_CALC) {
-			if (net_buf.len == sizeof(checksum)) {
-				checksum = net_buf_simple_pull_le32(&net_buf);
-				LOG_DBG("Object checksum 0x%08x\n", checksum);
-				if (otc_inst->cb->obj_checksum_calculated) {
-					otc_inst->cb->obj_checksum_calculated(
-						otc_inst, conn, result_code, checksum);
+			if (result_code == BT_GATT_OTS_OACP_RES_SUCCESS) {
+				if (net_buf.len == sizeof(checksum)) {
+					checksum = net_buf_simple_pull_le32(&net_buf);
+					LOG_DBG("Object checksum 0x%08x", checksum);
+				} else {
+					LOG_DBG("Invalid indication data len %u after opcode and "
+						"result pulled",
+						net_buf.len);
+					return;
 				}
 			} else {
-				LOG_ERR("Invalid indication data len %u after opcode and result "
-					"pulled", net_buf.len);
-				return;
+				/* The checksum is omitted in error responses */
+				checksum = 0U;
+			}
+
+			if (otc_inst->cb != NULL && otc_inst->cb->obj_checksum_calculated != NULL) {
+				otc_inst->cb->obj_checksum_calculated(otc_inst, conn, result_code,
+								      checksum);
 			}
 		}
 


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/14b440ecad73817b9c6edc21af0d37511a1186bf from https://github.com/zephyrproject-rtos/zephyr/pull/117110.

The oacp_ind_handler only invoked the obj_checksum_calculated callback when the indication contained a 32-bit checksum. Error responses to BT_GATT_OTS_OACP_PROC_CHECKSUM_CALC omit the checksum, so the callback was never called and the application had no way to learn that the procedure failed.

Only parse the checksum when the result code is success, and always invoke the callback with the result code, passing a checksum of 0 for error responses. This matches the documented behavior of the callback.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/117018