### PR TITLE
drivers: ethernet: e1000: enable broadcast accept mode

### DIFF
--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -326,7 +326,8 @@ static const struct ethernet_api e1000_api = {
 									\
 		irq_enable(DT_INST_IRQN(inst));				\
 		iow32(dev, CTRL, CTRL_SLU); /* Set link up */		\
-		iow32(dev, RCTL, RCTL_EN | RCTL_MPE | DT_INST_PROP(inst, rdmts) << RDMTS_OFFSET); \
+		iow32(dev, RCTL, RCTL_EN | RCTL_MPE | RCTL_BAM |		\
+		      DT_INST_PROP(inst, rdmts) << RDMTS_OFFSET);	\
 		iow32(dev, ITR, DT_INST_PROP(inst, itr) & (uint32_t)GENMASK(15, 0)); \
 	}								\
 									\

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -15,6 +15,7 @@ extern "C" {
 
 #define TCTL_EN		(1 << 1)
 #define RCTL_EN		(1 << 1)
+#define RCTL_BAM	(1 << 15) /* Broadcast Accept Mode */
 
 #define ICR_TXDW	     (1) /* Transmit Descriptor Written Back */
 #define ICR_TXQE	(1 << 1) /* Transmit Queue Empty */


### PR DESCRIPTION
RCTL.BAM (bit 15) is required for the 8254x MAC to accept Ethernet broadcast frames. Multicast promiscuous mode (RCTL.MPE) does not cover broadcasts, so ARP, DHCP and other broadcast traffic is dropped in hardware.

Set RCTL_BAM when programming RCTL at interface bring-up. With this change, QEMU e1000 in TAP mode can complete ARP/DHCP and pass traffic.