### PR TITLE
wifi: nxp: increase wlcmgr_mon_task stack size when recovery enabled

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -419,6 +419,7 @@ menu "Wi-Fi driver Stack configurations"
 config NXP_WIFI_MON_TASK_STACK_SIZE
 	int "Mon thread stack size"
 	depends on NXP_RW610 || NXP_IW610 || NXP_IW61X || NXP_IW416
+	default 5120 if NXP_WIFI_RECOVERY
 	default 3072
 	help
 	  This option specifies the size of the stack used by the mon task.


### PR DESCRIPTION
## Summary

Increase \`CONFIG_NXP_WIFI_MON_TASK_STACK_SIZE\` default to 5120 bytes
when \`CONFIG_NXP_WIFI_RECOVERY\` is enabled.

## Problem

When \`CONFIG_NXP_WIFI_RECOVERY\` is enabled, \`wlcmgr_mon_task\` handles
\`WIFI_RECOVERY_REQ\` by calling \`wlan_reset(CLI_RESET_WIFI)\` directly
on its own stack. This performs a full WiFi disable+re-enable sequence
including \`wlan_init()\`, \`wlan_start()\`, \`nxp_net_enable_all_networks()\`
and supplicant callbacks, whose cumulative stack consumption (~4200 bytes)
exceeds the default 3072 byte limit, causing a fatal stack overflow on
IW610 and RW612 platforms:

```
ZEPHYR FATAL ERROR 2: Stack overflow on CPU 0
Current thread: wlcmgr_mon_task
```

## Solution

Add a conditional default in \`Kconfig.nxp\`:

```kconfig
default 5120 if NXP_WIFI_RECOVERY
default 3072
```

Verified with \`kernel thread stacks\`: peak usage 4200/5120 (82%).
Non-recovery builds are unaffected (still 3072 bytes).

## Testing

- \`nxp_wifi recovery-test\` on IW610 Zephyr (mimxrt1060_evk): recovery
  completes without hang (FW hang -> Disable WiFi -> Enable WiFi -> Done)
- \`kernel thread stacks\`: \`wlcmgr_mon_task\` usage 4200/5120 (82%)