### PR TITLE
scripts: checkpatch: Recognize C++ template angle brackets

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -10,6 +10,8 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/checkpatch.pl'
+      - 'scripts/checkpatch/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
       - '.github/workflows/scripts_tests.yml'
@@ -19,6 +21,8 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/checkpatch.pl'
+      - 'scripts/checkpatch/**'
       - 'scripts/cmake/**'
       - 'scripts/kconfig/**'
       - '.github/workflows/scripts_tests.yml'
@@ -77,4 +81,4 @@ jobs:
           ZEPHYR_BASE: ./
         run: |
           echo "Run script tests"
-          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig
+          pytest ./scripts/build ./scripts/checkpatch ./scripts/cmake ./scripts/kconfig

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2013,6 +2013,154 @@ sub annotate_values {
 	return ($res, $var);
 }
 
+# Scan a confirmed C++ template argument list.
+# Return "closed", "open", or "abort" with the relevant offset or state.
+sub cxx_template_scan {
+	my ($opline, $start, $state, $skip) = @_;
+	my $len = length($opline);
+
+	for (my $i = $start; $i < $len; $i++) {
+		my $c = substr($opline, $i, 1);
+		my $lookahead = substr($opline, $i + 1, 1);
+
+		if ($c eq '(') {
+			$state->{parens}++;
+		} elsif ($c eq ')') {
+			if ($state->{parens} == 0) {
+				return ("abort", $i);
+			}
+			$state->{parens}--;
+		} elsif ($c eq '[') {
+			$state->{brackets}++;
+		} elsif ($c eq ']') {
+			if ($state->{brackets} == 0) {
+				return ("abort", $i);
+			}
+			$state->{brackets}--;
+		} elsif (($c eq '*' || $c eq '&') &&
+			 $i > 0 && substr($opline, $i - 1, 1) =~ /\s/ &&
+			 substr($opline, $i + 1) =~ /^\s*[\),>]/) {
+			# A pointer or reference at the end of a type is unary.
+			$skip->{$i} = 1;
+		} elsif ($state->{parens} > 0 || $state->{brackets} > 0) {
+			next;
+		} elsif ($c =~ /[;{}]/) {
+			# Prevent a false match from leaking to later lines.
+			return ("abort", $i);
+		} elsif ($c eq '<') {
+			my $before = substr($opline, 0, $i);
+
+			if ($lookahead eq '<' || $lookahead eq '=') {
+				return ("abort", $i);
+			}
+
+			# Require tight syntax to preserve spaced comparisons.
+			if ($before =~ /$Ident$/ ||
+			    $before =~ /\btemplate\s*$/) {
+				$state->{angles}++;
+				$skip->{$i} = 1;
+			}
+		} elsif ($c eq '>') {
+			# Ignore member access and comparison assignment.
+			next if ($i > 0 && substr($opline, $i - 1, 1) eq '-');
+			if ($lookahead eq '=') {
+				return ("abort", $i);
+			}
+			$state->{angles}--;
+			$skip->{$i} = 1;
+			if ($state->{angles} == 0) {
+				return ("closed", $i);
+			}
+		}
+	}
+
+	return ("open", $state);
+}
+
+# Angle brackets are ambiguous with C comparison operators. Start a list
+# only after a high-confidence C++ introducer and carry open lists across
+# lines. "template" is accepted only at a declaration boundary because it
+# is also a valid C identifier. Preprocessor lines preserve the open state.
+sub cxx_template_args {
+	my ($opline, $state) = @_;
+	my %skip = ();
+	my $pos = 0;
+	my $cxx_context = 0;
+	my $context_start = 0;
+
+	if (defined $state && $opline =~ /^\s*#/) {
+		return (\%skip, $state);
+	}
+
+	if (defined $state) {
+		my %candidate = ();
+		my ($status, $result) =
+			cxx_template_scan($opline, 0, $state, \%candidate);
+
+		if ($status eq "closed") {
+			$skip{$_} = 1 for keys %candidate;
+			$pos = $result + 1;
+			$cxx_context = 1;
+			$context_start = $pos;
+		} elsif ($status eq "open") {
+			$skip{$_} = 1 for keys %candidate;
+			return (\%skip, $result);
+		} else {
+			$pos = $result + 1;
+		}
+	}
+
+	while (($pos = index($opline, '<', $pos)) >= 0) {
+		my $before = substr($opline, 0, $pos);
+		my $is_template = ($before =~
+			/(?:^|[;{}>])\s*(?:export\s+)?template\s*$/);
+		my $is_cast = ($before =~
+			/\b(?:const|dynamic|reinterpret|static)_cast\s*$/);
+		my $is_qualified = ($before =~
+			/(?:\b$Ident\s*::\s*)+(?:template\s+)?$Ident$/);
+		my $is_dependent = ($before =~ /\btypename\s+$Ident\s*$/);
+		my $in_declaration = $cxx_context &&
+			(substr($opline, $context_start,
+				$pos - $context_start) !~ /[;{}]/);
+		my $is_introducer = $is_template || $is_cast || $is_qualified ||
+			$is_dependent ||
+			($in_declaration && $before =~ /(?<!\w)$Ident$/);
+
+		if (!$is_introducer || $before =~ /\boperator\s*$/ ||
+		    substr($opline, $pos + 1, 1) =~ /[<=]/) {
+			$pos++;
+			next;
+		}
+
+		my %candidate = ($pos => 1);
+		my $open = {
+			angles => 1,
+			parens => 0,
+			brackets => 0,
+		};
+		my ($status, $result) =
+			cxx_template_scan($opline, $pos + 1, $open, \%candidate);
+
+		if ($status eq "closed") {
+			if (substr($opline, $result + 1) =~ /^\w/) {
+				$pos++;
+				next;
+			}
+			$skip{$_} = 1 for keys %candidate;
+			$pos = $result + 1;
+			$cxx_context = 1;
+			$context_start = $pos;
+		} elsif ($status eq "open") {
+			$skip{$_} = 1 for keys %candidate;
+			return (\%skip, $result);
+		} else {
+			$pos = $result + 1;
+		}
+	}
+
+	return (\%skip, undef);
+}
+
 sub possible {
 	my ($possible, $line) = @_;
 	my $notPermitted = qr{(?:
@@ -2385,6 +2533,7 @@ sub process {
 	my $p1_prefix = '';
 
 	my $prev_values = 'E';
+	my $cxx_tmpl_state;
 
 	# suppression flags
 	my %suppress_ifbraces;
@@ -2521,6 +2670,7 @@ sub process {
 			}
 			annotate_reset();
 			$prev_values = 'E';
+			$cxx_tmpl_state = undef;
 
 			%suppress_ifbraces = ();
 			%suppress_whiletrailers = ();
@@ -3934,6 +4084,13 @@ sub process {
 		}
 		$prev_values = substr($curr_values, -1);
 
+		# C++ syntax currently reaches code checks only through .h files.
+		my $cxx_tmpl_skip = {};
+		if ($realfile =~ /\.h$/) {
+			($cxx_tmpl_skip, $cxx_tmpl_state) =
+				cxx_template_args($opline, $cxx_tmpl_state);
+		}
+
 #ignore lines not being added
 		next if ($line =~ /^[^\+]/);
 
@@ -4627,6 +4784,9 @@ sub process {
 				if ($op_type ne 'V' &&
 				    $ca =~ /\s$/ && $cc =~ /^\s*[,\)]/) {
 
+				# Ignore C++ template brackets.
+				} elsif ($cxx_tmpl_skip->{$off}) {
+
 #				# Ignore comments
 #				} elsif ($op =~ /^$;+$/) {
 
@@ -5072,9 +5232,17 @@ sub process {
 #	avoid cases like "foo + BAR < baz"
 #	only fix matches surrounded by parentheses to avoid incorrect
 #	conversions like "FOO < baz() + 5" being "misfixed" to "baz() > FOO + 5"
+#	Mask C++ template brackets before checking constant comparisons.
+		my $cmpline = $line;
+		foreach my $off (keys %{$cxx_tmpl_skip}) {
+			if ($off < length($cmpline) &&
+			    substr($cmpline, $off, 1) =~ /[<>]/) {
+				substr($cmpline, $off, 1) = ' ';
+			}
+		}
 		if ($perl_version_ok &&
-			!($line =~ /^\+(.*)($Constant|[A-Z_][A-Z0-9_]*)\s*($Compare)\s*(.*)($Constant|[A-Z_][A-Z0-9_]*)(.*)/) &&
-		    $line =~ /^\+(.*)\b($Constant|[A-Z_][A-Z0-9_]*)\s*($Compare)\s*($LvalOrFunc)/) {
+			!($cmpline =~ /^\+(.*)($Constant|[A-Z_][A-Z0-9_]*)\s*($Compare)\s*(.*)($Constant|[A-Z_][A-Z0-9_]*)(.*)/) &&
+		    $cmpline =~ /^\+(.*)\b($Constant|[A-Z_][A-Z0-9_]*)\s*($Compare)\s*($LvalOrFunc)/) {
 			my $lead = $1;
 			my $const = $2;
 			my $comp = $3;

--- a/scripts/checkpatch/test_checkpatch.py
+++ b/scripts/checkpatch/test_checkpatch.py
@@ -1,0 +1,507 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for C++ template angle brackets in checkpatch."""
+
+import re
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+ZEPHYR_BASE = Path(__file__).resolve().parents[2]
+CHECKPATCH = ZEPHYR_BASE / "scripts" / "checkpatch.pl"
+TEST_FILE = "include/zephyr/checkpatch_test.h"
+DIAGNOSTIC_RE = re.compile(
+    r"^.*?\b(?:ERROR|WARNING|CHECK):(?P<type>[A-Z0-9_]+):(?P<msg>[^\n]*)\n"
+    r"#\d+: FILE: [^:\n]+:(?P<line>\d+):",
+    re.MULTILINE,
+)
+OPERATOR_RE = re.compile(r"that '([^']+)'")
+ANGLE_OPS = frozenset("<>")
+
+
+def checkpatch_diagnostics(patch):
+    """Return (kind, line, operator-or-None) tuples from checkpatch."""
+    result = subprocess.run(
+        [CHECKPATCH, "--no-tree", "--show-types", "-"],
+        input=patch,
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=ZEPHYR_BASE,
+    )
+    # Without the summary line the run failed, and every "no diagnostics"
+    # assertion below would pass without checking anything.
+    assert "lines checked" in result.stdout, result.stderr
+    diagnostics = []
+    for match in DIAGNOSTIC_RE.finditer(result.stdout):
+        operator = OPERATOR_RE.search(match.group("msg"))
+        diagnostics.append(
+            (
+                match.group("type"),
+                int(match.group("line")),
+                operator.group(1) if operator else None,
+            )
+        )
+    return diagnostics
+
+
+def run_checkpatch(lines, context_lines=None, test_file=TEST_FILE):
+    """Run checkpatch on added lines, optionally preceded by context lines."""
+    context_lines = context_lines or []
+    patch_lines = [f" {line}" for line in context_lines]
+    patch_lines.extend(f"+{line}" for line in lines)
+    old_count = len(context_lines)
+    new_count = len(patch_lines)
+    patch = (
+        f"diff --git a/{test_file} b/{test_file}\n"
+        f"--- a/{test_file}\n"
+        f"+++ b/{test_file}\n"
+        f"@@ -1,{old_count} +1,{new_count} @@\n" + "\n".join(patch_lines) + "\n"
+    )
+
+    return checkpatch_diagnostics(patch)
+
+
+def angle_counts(diagnostics):
+    """Count SPACING on '<' / '>' and CONSTANT_COMPARISON, ignoring other operators."""
+    counts = Counter()
+    for kind, line, operator in diagnostics:
+        if kind == "CONSTANT_COMPARISON":
+            counts[(kind, line, None)] += 1
+        elif kind == "SPACING" and operator in ANGLE_OPS:
+            counts[(kind, line, operator)] += 1
+    return counts
+
+
+def assert_no_angle_diagnostics(diagnostics):
+    assert angle_counts(diagnostics) == Counter()
+
+
+@pytest.mark.parametrize(
+    "lines",
+    [
+        pytest.param(["template<typename T> struct value {};"], id="tight-template"),
+        pytest.param(["template <typename T> struct value {};"], id="spaced-template"),
+        pytest.param(["template <> struct value<int> {};"], id="explicit-specialization"),
+        pytest.param(["template <typename T = int> struct value {};"], id="default-type"),
+        pytest.param(["template <int N = -1> struct value {};"], id="default-negative"),
+        pytest.param(
+            ["template <bool E = (N > 0)> struct value {};"],
+            id="parenthesized-comparison",
+        ),
+        pytest.param(
+            ["template <bool E = ((N) > (0))> struct value {};"],
+            id="nested-parenthesized-comparison",
+        ),
+        pytest.param(
+            ["template <bool E = a < b> struct value {};"],
+            id="spaced-less-does-not-nest",
+        ),
+        pytest.param(["std::vector<int> value;"], id="qualified-name"),
+        pytest.param(
+            ["std::vector<std::pair<int, int>> value;"],
+            id="nested-closing-angles",
+        ),
+        pytest.param(
+            ["std::vector<std::vector<std::pair<int, int>>> value;"],
+            id="triple-closing-angles",
+        ),
+        pytest.param(
+            ["auto value = static_cast<uint8_t *>(ptr);"],
+            id="static-cast",
+        ),
+        pytest.param(
+            ["auto value = const_cast<int *>(ptr);"],
+            id="const-cast",
+        ),
+        pytest.param(
+            ["auto value = reinterpret_cast<uint8_t *>(ptr);"],
+            id="reinterpret-cast",
+        ),
+        pytest.param(
+            ["auto value = dynamic_cast<Derived *>(ptr);"],
+            id="dynamic-cast",
+        ),
+        pytest.param(["typename value_type<T>::type value;"], id="dependent-name"),
+        pytest.param(
+            ["using type = typename T::template rebind<U>::other;"],
+            id="dependent-template-keyword",
+        ),
+        pytest.param(
+            ["std::array<int, value->size> array;"],
+            id="member-access-inside-list",
+        ),
+        pytest.param(
+            ["std::integral_constant<int, arr[i > j]> value;"],
+            id="subscript-inside-list",
+        ),
+        pytest.param(
+            ["std::function<void(const char *, int &)> value;"],
+            id="unary-pointer-and-reference",
+        ),
+        pytest.param(
+            ["std::array<int, (N << 2)> value;"],
+            id="shift-inside-parentheses",
+        ),
+        pytest.param(
+            ["std::array<uint8_t, MAX_LEN> buffer;"],
+            id="constant-as-template-argument",
+        ),
+        pytest.param(
+            ["template <template <typename> class T> struct value {};"],
+            id="template-template-parameter",
+        ),
+        pytest.param(
+            ["template <typename... Ts> struct value {};"],
+            id="parameter-pack",
+        ),
+        pytest.param(
+            ["template <typename T> void func(std::vector<T> &&value);"],
+            id="rvalue-reference",
+        ),
+        pytest.param(
+            ["template <typename T, typename = std::enable_if_t<A && B>> struct X {};"],
+            id="logical-and-inside-list",
+        ),
+        pytest.param(
+            [
+                "template <typename... Ts> constexpr size_t n ="
+                " std::integral_constant<size_t, sizeof...(Ts)>::value;"
+            ],
+            id="sizeof-pack-inside-list",
+        ),
+        pytest.param(
+            ["template <typename T> using V = std::vector<T>;"],
+            id="alias-template",
+        ),
+        pytest.param(
+            ["std::ostream &operator<<(std::ostream &os, const Foo &f);"],
+            id="operator-shift",
+        ),
+        pytest.param(
+            ["#include <zephyr/kernel.h>"],
+            id="include-directive",
+        ),
+        pytest.param(
+            ['const char *s = "std::vector<int>";'],
+            id="angles-inside-string",
+        ),
+        pytest.param(
+            ["template <int N> constexpr int value = N << 2;"],
+            id="shift-after-closed-list",
+        ),
+        pytest.param(
+            ["int value = static_cast<int>(left) < right;"],
+            id="cast-then-spaced-comparison",
+        ),
+        pytest.param(
+            ["#define VALUE std::array<int, 4>"],
+            id="template-in-define",
+        ),
+        pytest.param(
+            ["export template <typename T> struct value {};"],
+            id="export-template",
+        ),
+        pytest.param(
+            ["template <typename T> template <typename U> void X<T>::f();"],
+            id="member-template-after-close",
+        ),
+        pytest.param(
+            ["namespace ns { template <typename T> struct X {}; }"],
+            id="template-after-brace",
+        ),
+        pytest.param(
+            [
+                "template <typename T,",
+                "          typename U>",
+                "struct value {};",
+            ],
+            id="multiline-declaration",
+        ),
+        pytest.param(
+            [
+                "template <bool E =",
+                "          (N > 0)>",
+                "struct value {};",
+            ],
+            id="multiline-parenthesized-comparison",
+        ),
+        pytest.param(
+            [
+                "std::vector<",
+                "    std::pair<int, int>> value;",
+            ],
+            id="multiline-qualified-name",
+        ),
+        pytest.param(
+            ["template <typename T", ">", "struct value {};"],
+            id="closing-angle-alone-on-line",
+        ),
+        pytest.param(
+            [
+                "template <bool E = (N >",
+                "                    0)>",
+                "struct value {};",
+            ],
+            id="parentheses-span-lines",
+        ),
+        pytest.param(
+            [
+                "template <typename T,",
+                "#if OPTION > 0",
+                "          typename U = int,",
+                "#endif",
+                "          typename V>",
+                "struct value {};",
+            ],
+            id="preprocessor-if-inside-list",
+        ),
+        pytest.param(
+            [
+                "template <typename T,",
+                "#define OPTION 1",
+                "\ttypename U>",
+                "struct value {};",
+            ],
+            id="preprocessor-define-inside-list",
+        ),
+        pytest.param(
+            [
+                "template <typename T,",
+                "\ttypename U> struct X : Base<T> {",
+            ],
+            id="another-list-after-multiline-close",
+        ),
+    ],
+)
+def test_cxx_template_brackets_are_not_operators(lines):
+    assert_no_angle_diagnostics(run_checkpatch(lines))
+
+
+def test_template_opener_in_context_line():
+    diagnostics = run_checkpatch(
+        ["          typename U>", "struct value {};"],
+        context_lines=["template <typename T,"],
+    )
+
+    assert_no_angle_diagnostics(diagnostics)
+
+
+def test_template_state_is_reset_between_hunks():
+    patch = (
+        f"diff --git a/{TEST_FILE} b/{TEST_FILE}\n"
+        f"--- a/{TEST_FILE}\n"
+        f"+++ b/{TEST_FILE}\n"
+        "@@ -0,0 +1 @@\n"
+        "+template <typename T,\n"
+        "@@ -99,0 +100 @@\n"
+        "+int value = left>right;\n"
+    )
+
+    assert angle_counts(checkpatch_diagnostics(patch)) == Counter({("SPACING", 100, ">"): 1})
+
+
+def test_removed_template_opener_does_not_change_state():
+    patch = (
+        f"diff --git a/{TEST_FILE} b/{TEST_FILE}\n"
+        f"--- a/{TEST_FILE}\n"
+        f"+++ b/{TEST_FILE}\n"
+        "@@ -1 +1 @@\n"
+        "-template <typename T,\n"
+        "+int value = left>right;\n"
+    )
+
+    assert angle_counts(checkpatch_diagnostics(patch)) == Counter({("SPACING", 1, ">"): 1})
+
+
+def test_template_identifier_in_c_file_is_not_treated_as_cxx():
+    diagnostics = run_checkpatch(
+        ["template < limit", "    && left>right;"],
+        test_file="src/checkpatch_test.c",
+    )
+
+    assert angle_counts(diagnostics) == Counter({("SPACING", 2, ">"): 1})
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected"),
+    [
+        pytest.param(
+            ["if (left<right) {", "}"],
+            {("SPACING", 1, "<"): 1},
+            id="tight-comparison",
+        ),
+        pytest.param(
+            ["if (MAX<value> limit) {", "}"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1, ("CONSTANT_COMPARISON", 1, None): 1},
+            id="constant-on-left",
+        ),
+        pytest.param(
+            ["if (left<right, upper> lower) {", "}"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="comma-separated-comparisons",
+        ),
+        pytest.param(
+            ["if (left<(middle)> right) {", "}"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="parenthesized-operand",
+        ),
+        pytest.param(
+            ["for (i=0; i<n; i++) {", "}"],
+            {("SPACING", 1, "<"): 1},
+            id="for-loop",
+        ),
+        pytest.param(
+            ["int x = a<b ? a : b;"],
+            {("SPACING", 1, "<"): 1},
+            id="ternary",
+        ),
+        pytest.param(
+            ['std::cout << "value";', "int value = left>right;"],
+            {("SPACING", 2, ">"): 1},
+            id="shift-does-not-leak",
+        ),
+        pytest.param(
+            ["bool value = ns::field <= 3;", "int other = left>right;"],
+            {("SPACING", 2, ">"): 1},
+            id="less-equal-does-not-leak",
+        ),
+        pytest.param(
+            ["if (template < limit", "    && left>right) {", "}"],
+            {("SPACING", 2, ">"): 1},
+            id="template-c-identifier",
+        ),
+        pytest.param(
+            ["if (ns::left<right>limit) {", "}"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="word-after-closing-angle",
+        ),
+        pytest.param(
+            ["bool v = static_cast<int>(a)>b;"],
+            {("SPACING", 1, ">"): 1},
+            id="cast-then-tight-comparison",
+        ),
+        pytest.param(
+            [
+                "int value = arr[std::max<int>(left, right) + a<b];",
+                "int other = left>right;",
+            ],
+            {("SPACING", 1, "<"): 1, ("SPACING", 2, ">"): 1},
+            id="unmatched-bracket-aborts-nested-list",
+        ),
+        pytest.param(
+            ["bool value = ns::field<", "\tlimit;", "int other = left>right;"],
+            {("SPACING", 3, ">"): 1},
+            id="continuation-abort-does-not-leak",
+        ),
+        pytest.param(
+            [
+                "int value = f(std::max<int>(left, right) + g(a<b));",
+                "int other = left>right;",
+            ],
+            {("SPACING", 1, "<"): 1, ("SPACING", 2, ">"): 1},
+            id="unmatched-paren-aborts",
+        ),
+    ],
+)
+def test_comparison_operators_are_still_checked(lines, expected):
+    assert angle_counts(run_checkpatch(lines)) == Counter(expected)
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected"),
+    [
+        pytest.param(
+            ["template <typename T> bool less(T left, T right) { return left<right; }"],
+            {("SPACING", 1, "<"): 1},
+            id="comparison-in-one-line-body",
+        ),
+        pytest.param(
+            ["template <typename T> struct value {}; int result = left<right;"],
+            {("SPACING", 1, "<"): 1},
+            id="comparison-after-semicolon",
+        ),
+        pytest.param(
+            ["template <> struct value<int> { static constexpr bool v = a<b; };"],
+            {("SPACING", 1, "<"): 1},
+            id="comparison-in-specialization-body",
+        ),
+        pytest.param(
+            ["int value = func(std::max<int>(left, right) + func(a<b));"],
+            {("SPACING", 1, "<"): 1},
+            id="comparison-after-qualified-template",
+        ),
+        pytest.param(
+            ["bool value = Type::operator<(const Type &other) const;"],
+            {("SPACING", 1, "<"): 1},
+            id="operator-less",
+        ),
+        pytest.param(
+            [
+                "template <typename T> static inline constexpr int foo(T x) { return -42; }",
+                "bool value = (a<b) && (c>d);",
+            ],
+            {("SPACING", 2, "<"): 1, ("SPACING", 2, ">"): 1},
+            id="issue-54023-example",
+        ),
+    ],
+)
+def test_mixed_line_reports_only_the_comparison(lines, expected):
+    assert angle_counts(run_checkpatch(lines)) == Counter(expected)
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected"),
+    [
+        pytest.param(
+            ["std::vector <int> value;"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="space-before-qualified-angle",
+        ),
+        pytest.param(
+            ["Foo<int> value;"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="unqualified-template-id",
+        ),
+        pytest.param(
+            ["template <bool E = N > 0> struct value {};"],
+            {("SPACING", 1, ">"): 1, ("CONSTANT_COMPARISON", 1, None): 1},
+            id="unparenthesized-greater",
+        ),
+        pytest.param(
+            ["template <bool E = a<b> struct value {};"],
+            {("SPACING", 1, "<"): 2, ("SPACING", 1, ">"): 1},
+            id="unparenthesized-tight-less-looks-nested",
+        ),
+        pytest.param(
+            ["template <auto V = Foo{}> struct value {};"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="brace-in-nttp-aborts",
+        ),
+        pytest.param(
+            ["template <typename T,", "int value = left>right;"],
+            {},
+            id="open-list-swallows-rest-of-hunk",
+        ),
+        pytest.param(
+            ["template <int N = 1 << 2> struct value {};"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="unparenthesized-shift-aborts",
+        ),
+        pytest.param(
+            ["template <bool E = N >= 0> struct value {};"],
+            {("SPACING", 1, "<"): 1, ("SPACING", 1, ">"): 1},
+            id="unparenthesized-greater-equal-aborts",
+        ),
+        pytest.param(
+            ["template < limit", "    && left>right;"],
+            {},
+            id="template-c-identifier-at-declaration-boundary",
+        ),
+    ],
+)
+def test_known_limitations_are_unchanged(lines, expected):
+    assert angle_counts(run_checkpatch(lines)) == Counter(expected)


### PR DESCRIPTION
`checkpatch.pl` treated C++ template angle brackets in `.h` files as comparison operators (false `SPACING` and `CONSTANT_COMPARISON`). This marks high-confidence template lists (`template <...>`, named casts, qualified names such as `std::vector<T>`, `typename`) and ignores only those offsets. Real comparisons on the same line are still reported. `.c` files and `.cpp`/`.hpp` filters are unchanged.

Regression tests live in `scripts/checkpatch/test_checkpatch.py` and run in the scripts-tests workflow.

Fixes #54023

**Intentional limits** (locked by tests, not in scope here):

- Unqualified `Foo<T>` (ambiguous with C `MAX<value`)
- Space before a qualified list: `std::vector <int>`
- Unparenthesized non-type template parameters: `N > 0`, `a<b`, `<<`, `>=` (parenthesized forms are fine)
- `Foo{}` as a non-type template argument (`{` / `}` abort the candidate)
- An unclosed list can swallow later `<>` until the end of the hunk
- `operator<` / `operator>`
- A C identifier `template <` at a declaration boundary in a `.h` file