### PR TITLE
boards: renesas: ek_ra8p1: hook up the DA7212 audio CODEC

### DIFF
--- a/boards/renesas/ek_ra8p1/doc/index.rst
+++ b/boards/renesas/ek_ra8p1/doc/index.rst
@@ -71,6 +71,7 @@ Cortex®-M33 core running up to 250 MHz with the following features:
 - Ethernet (RJ45 RGMII interface)
 - USB High Speed Host and Device (USB-C connector)
 - 512 Mb (64 MB) External Octo-SPI Flash (present in the MCU Native Pin Access area of the EK-RA8P1 board)
+- DA7212 audio CODEC with a speaker connector (J33)
 
 Hardware
 ********
@@ -94,6 +95,28 @@ Supported Features
      +-------------+-------------+----------------+---------------+-----------+------------+-------------+-------------+
      |     OFF     |     OFF     |      OFF       |     OFF       |     OFF   |     ON     |     OFF     |    OFF      |
      +-------------+-------------+----------------+---------------+-----------+------------+-------------+-------------+
+
+Audio CODEC
+===========
+
+The DA7212 CODEC is controlled over ``iic1`` at address 0x1a and carries audio over SSIE0:
+BCLK on P403, WCLK on P404, data to the CODEC on P405 and data from it on P406. Its speaker
+output is on connector J33; the headphone and line pin header J38 is not populated.
+
+P405 and P406 are shared with the parallel camera, so the CODEC and the camera cannot be used
+at the same time. The links on J41 connect them to the CODEC and are fitted by default; remove
+them to use the parallel camera.
+
+GPT2 drives AUDIO_MCLK on PD06, which is both the CODEC's master clock and, over the internal
+GPT route, the SSIE audio clock from which the bit clock is divided.
+
+.. note::
+
+   The DA7212 expects a 12.288 MHz SYSCLK for the 48 kHz sample rate family, and the Zephyr
+   driver runs the CODEC with its PLL bypassed, so SYSCLK is whatever MCLK is. 12.288 MHz is
+   not an integer division of this board's 300 MHz GPTCLK, so ``audio_clock`` runs at
+   12.5 MHz and every sample rate lands 1.7% high. Using the CODEC's PLL would remove the
+   constraint but the driver does not support it yet.
 
 Dual Core Operation
 *******************

--- a/boards/renesas/ek_ra8p1/ek_ra8p1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1-pinctrl.dtsi
@@ -95,6 +95,24 @@
 		};
 	};
 
+	ssie0_default: ssie0_default {
+		group1 {
+			psels = <RA_PSEL(RA_PSEL_SSIE, 4, 3)>, /* AUDIO_BCLK */
+				<RA_PSEL(RA_PSEL_SSIE, 4, 4)>, /* AUDIO_WCLK */
+				<RA_PSEL(RA_PSEL_SSIE, 4, 5)>, /* AUDIO_SSITX */
+				<RA_PSEL(RA_PSEL_SSIE, 4, 6)>; /* AUDIO_SSIRX */
+			drive-strength = "medium";
+		};
+	};
+
+	pwm2_default: pwm2_default {
+		group1 {
+			/* GTIOC2A, AUDIO_MCLK */
+			psels = <RA_PSEL(RA_PSEL_GPT1, 13, 6)>;
+			drive-strength = "medium";
+		};
+	};
+
 	usbhs_default: usbhs_default {
 		group1 {
 			psels = <RA_PSEL(RA_PSEL_USBHS, 4, 8)>; /* VBUS */

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.dts
@@ -97,6 +97,14 @@
 	interrupts = <14 1>, <15 1>, <16 1>, <17 1>;
 	interrupt-names = "rxi", "txi", "tei", "eri";
 	status = "okay";
+
+	audio_codec: da7212@1a {
+		compatible = "dlg,da7212";
+		reg = <0x1a>;
+		clocks = <&audio_clock 0>;
+		clock-names = "mclk";
+		clock-source = "MCLK";
+	};
 };
 
 &port_irq13 {
@@ -203,6 +211,37 @@
 	interrupt-names = "drw";
 	interrupts = <31 12>;
 	status = "okay";
+};
+
+&i2s0 {
+	pinctrl-0 = <&ssie0_default>;
+	pinctrl-names = "default";
+	interrupts = <32 12>, <33 12>, <34 12>;
+	interrupt-names = "ssi_txi", "ssi_rxi", "ssi_if";
+	clocks = <&pclkb MSTPC 8>, <&audio_clock 0>;
+	clock-names = "pclk", "audio-clock";
+	status = "okay";
+};
+
+&pwm2 {
+	pinctrl-0 = <&pwm2_default>;
+	pinctrl-names = "default";
+	interrupts = <35 1>, <36 1>;
+	interrupt-names = "gtioca", "overflow";
+	status = "okay";
+
+	/*
+	 * Drives AUDIO_MCLK on PD06 and, over the internal GPT route, the SSIE
+	 * audio clock. 12.288 MHz, the rate the DA7212 expects as SYSCLK, is
+	 * not an integer division of the 300 MHz GPTCLK; 12.5 MHz is the
+	 * closest reachable rate and puts sample rates 1.7% high.
+	 */
+	audio_clock: pwmclock {
+		compatible = "pwm-clock";
+		#clock-cells = <1>;
+		pwms = <&pwm2 0 PWM_HZ(12500000) PWM_POLARITY_NORMAL>;
+		status = "okay";
+	};
 };
 
 zephyr_lcdif: &lcdif {};

--- a/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.yaml
+++ b/boards/renesas/ek_ra8p1/ek_ra8p1_r7ka8p1kflcac_cm85.yaml
@@ -13,4 +13,6 @@ supported:
   - spi
   - sdhc
   - netif:eth
+  - i2s
+  - pwm
 vendor: renesas

--- a/drivers/audio/da7212.c
+++ b/drivers/audio/da7212.c
@@ -657,8 +657,8 @@ static DEVICE_API(audio_codec, da7212_driver_api) = {
 		.i2c = I2C_DT_SPEC_INST_GET(n),						\
 		.clock_source = DT_INST_ENUM_IDX(n, clock_source),			\
 		.mclk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_NAME(n, mclk)),	\
-		.mclk_name = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n,	\
-								 mclk, name)};		\
+		.mclk_name = (clock_control_subsys_t)DT_INST_PHA_BY_NAME_OR(n,		\
+								 clocks, mclk, name, 0)};	\
 											\
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &da7212_device_config_##n,		\
 		POST_KERNEL, CONFIG_AUDIO_CODEC_INIT_PRIORITY, &da7212_driver_api);


### PR DESCRIPTION
Enables the DA7212 audio CODEC fitted on the EK-RA8P1: the control interface on `iic1` at 0x1a, the DAI on SSIE0, and the master clock on GPT2.

Independent of #118803 (PDM microphones), but note both branches allocate board interrupt slots starting at 32 — whichever lands second needs renumbering, since git will not conflict on it.

### Wiring

| Signal | Pin | Function |
| --- | --- | --- |
| SDA / SCL | P511 / P512 | IIC1 |
| BCLK | P403 | SSIE0 SSIBCK0 |
| WCLK | P404 | SSIE0 SSILRCK0 |
| DATIN | P405 | SSIE0 SSITXD0 |
| DATOUT | P406 | SSIE0 SSIRXD0 |
| MCLK | PD06 | GPT2 GTIOC2A |

P405 and P406 are shared with the parallel camera behind the J41 links, so the CODEC and the camera are mutually exclusive. Speaker output is on J33; the headphone/line header J38 is not populated.

This makes EK-RA8P1 the first board in tree to enable `renesas,ra-i2s-ssie`.

### The clocking is not exact, and that is the interesting part

PD06's only output function is GTIOC2A, so the CODEC master clock has to come from GPT2 — and the same GPT2 output feeds the SSIE audio clock over the internal route, which is what the pin choice is clearly designed around: at 12.288 MHz, a bit-clock divider of 8 gives 1.536 MHz, exactly 48 kHz for 16-bit stereo.

The problem is that 12.288 MHz is not reachable. GPTCLK on this board is PLL2P/2 = 300 MHz and the GPT period is an integer count, so the neighbours are 300/24 = 12.5 MHz and 300/25 = 12 MHz. The 24 MHz crystal cannot produce the 24.576 MHz audio family by integer division at all, and re-sourcing GPTCLK to reach it would break the 12 MHz camera clock on `pwm12`.

Zephyr's `da7212` driver runs the CODEC with its PLL bypassed, so SYSCLK is simply MCLK. This branch therefore sets `audio_clock` to 12.5 MHz, the closest reachable rate, which puts every sample rate 1.7% high (~29 cents). Fine for voice, wrong for music. The proper fix is DA7212 PLL support in the driver, which would accept 12 MHz and synthesize a correct SYSCLK — worth doing as a follow-up, but it needs the datasheet's feedback-divider formula, which I did not want to guess at.

### Two other things reviewers should weigh

- **`RA_PSEL_GPT1` for PD06.** Every RA board in tree uses `RA_PSEL_GPT1` (0x3) for GTIOCnA/B pins and none uses `RA_PSEL_GPT0` (0x2), so that is what this uses. Not confirmed against the RA8P1 PFS table for this specific pin.
- **Footprint.** `CONFIG_CLOCK_CONTROL_PWM` is `default y` when a `pwm-clock` node is enabled and it `select`s `PWM`, so enabling the CODEC's clock pulls both into every build of this board. Gating the audio chain behind an overlay instead would avoid that, at the cost of the CODEC not being usable out of the box.

### Driver change

`da7212` read the MCLK specifier with a hardcoded `name` cell, which only exists on controllers modelled like the NXP syscon; a `pwm-clock` names its cell `id` and failed to build. It now falls back to subsystem 0 when there is no `name` cell. No change for the two existing NXP users.

### Testing

Not built and not run on hardware. `check_compliance.py` passes, and the devicetree was parsed with `edtlib` to confirm the nodes, clocks, pinctrl and interrupts all resolve. Nothing here has been verified against real audio.
