### PR TITLE
frdm_imx91: fix some twister building failure

### DIFF
--- a/boards/nxp/frdm_imx91/dts/usdhc1.overlay
+++ b/boards/nxp/frdm_imx91/dts/usdhc1.overlay
@@ -13,7 +13,7 @@
 &usdhc1 {
 	status = "okay";
 
-	sdmmc {
+	mmc {
 		status = "okay";
 	};
 };

--- a/samples/subsys/fs/fs_sample/boards/frdm_imx91.overlay
+++ b/samples/subsys/fs/fs_sample/boards/frdm_imx91.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &usdhc1;
+	};
+};
+
+&usdhc1 {
+	status = "okay";
+
+	mmc {
+		status = "okay";
+	};
+};

--- a/tests/drivers/disk/disk_access/boards/frdm_imx91.overlay
+++ b/tests/drivers/disk/disk_access/boards/frdm_imx91.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &usdhc1;
+	};
+};
+
+&usdhc1 {
+	status = "okay";
+
+	mmc {
+		status = "okay";
+	};
+};

--- a/tests/drivers/disk/disk_performance/boards/frdm_imx91.overlay
+++ b/tests/drivers/disk/disk_performance/boards/frdm_imx91.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &usdhc1;
+	};
+};
+
+&usdhc1 {
+	status = "okay";
+
+	mmc {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Fix the following twister building failure on frdm_imx91:
`drivers.disk.disk_performance.sdhc.disk_performance.random_read` — errored: Build failure
`drivers.disk.disk_performance.sdhc.disk_performance.random_write` — errored: Build failure
`drivers.disk.disk_performance.sdhc.disk_performance.sequential_read` — errored: Build failure
`drivers.disk.disk_performance.sdhc.disk_performance.sequential_write` — errored: Build failure
`sample.filesystem.fat_fs` — errored: Build failure

Fixing: #116467