### PR TITLE
boards: microchip: document PIC32CM GC00 Curiosity Pro hardware

### DIFF
--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/doc/index.rst
@@ -13,33 +13,58 @@ Hardware
 ********
 
 - 100-pin TQFP PIC32CM5112GC00100 microcontroller
-- Arm® Cortex®-M23 Microcontroller
-- 32.768 kHz crystal oscillator
-- 12 MHz crystal oscillator
+- Arm® Cortex®-M23 core running at up to 72 MHz
 - 512 KiB flash memory and 128 KiB of RAM
+- Up to 80 I/O lines with external interrupt capability
+- 12 MHz crystal oscillator
+- 32.768 kHz crystal oscillator
 - Two user LEDs (Red and Green)
 - One green board power LED
-- Two mechanical user push buttons
-- One reset button
-- Micro USB interface (Type-AB)
-- Virtual COM port (VCOM)
-- Programming and debugging of on-board PIC32CM GC through Serial Wire Debug (SWD) and on-board PKoB4 debugger
-- Arduino UNO R3 Shield Headers
-- mikroBUS™ Headers
-- Two CAN interfaces
-- 10 kOhms Potentiometer
-- CryptoAuthentication device, TA101
-- Touch Button
+- Two mechanical user push buttons, one touch button and one reset button
+- 10 kOhms thumb wheel potentiometer on PB06
+- 3.3V high-precision voltage reference (MCP1501)
+- TA101 CryptoAuthentication footprint, unpopulated on the shipping board
+- Micro USB interface (Type-AB) wired to the microcontroller
+- Programming and debugging through Serial Wire Debug (SWD), from the on-board
+  PKoB4 debugger or from the Cortex® 10-pin debug header
+- Virtual COM port (VCOM) provided by the PKoB4
+- Two Xplained Pro extension headers, EXT1 (J400) and EXT2 (J401)
+- One extension power header
+- One mikroBUS™ socket
+- One Arduino UNO R3 compatible shield interface
+- Two CAN interfaces with ATA6561 transceivers
+- USERLDO header and RTC header
 
 Supported Features
 ==================
 
 .. zephyr:board-supported-hw::
 
+Limitations
+-----------
+
+- **No entropy source.** The die carries no hardware random number generator,
+  so ``CONFIG_ENTROPY_GENERATOR`` has nothing to bind to on this board.
+  Anything needing random numbers has to bring its own source.
+- **Flash erase stalls the core.** The flash controller has a single panel
+  (``PFM_NUM_PANELS`` is 1), so there is no read-while-write: instruction fetch
+  stops for the whole duration of an erase. A page erase was measured on this
+  board at 20 ms, interrupts included. Erasing from a path with a deadline -
+  including a settings write that triggers a garbage collection - will miss it.
+
 Connections and IOs
 ===================
 
-The `PIC32CM SG00/GC00 Curiosity Pro User Guide`_ has detailed information about board connections.
+The `PIC32CM SG00/GC00 Curiosity Pro User Guide`_ has detailed information about
+board connections.
+
+.. warning::
+
+   PC07 is SWDIO and PC08 is SWCLK. Configuring either as a GPIO clears
+   ``PINCFG.PMUXEN`` and takes the debug interface away from the running
+   system, which leaves the board unable to accept another programming
+   session until it is erased through an external probe holding the target in
+   reset.
 
 Programming & Debugging
 ***********************


### PR DESCRIPTION
The `pic32cm_gc00_cpro` page names almost none of what is on the board.

This fills in the Hardware section - core clock, both crystals, the LEDs, the
buttons including the touch button, the potentiometer, the MCP1501 voltage
reference, the extension, mikroBUS and Arduino connectors, the two CAN
transceivers, and the debug path through the on-board PKoB4 or the Cortex
10-pin header.

It adds two limitations, both properties of the silicon rather than of a
configuration: there is no entropy source on this part, and the flash has a
single panel, so an erase stalls the core for its whole duration.

It also warns that PC07 and PC08 carry SWDIO and SWCLK. Reconfiguring either as
GPIO takes the debug interface away from a running system, recoverable only
with an external probe.

Every claim was checked against the board user guide (DS70005578) and the
part's ATDF. One did not survive: the TA101 CryptoAuthentication device is not
populated on the shipping board, per section 3.11 and the BOM, so the page now
names the footprint rather than the part.

Verified: `check_compliance.py` clean, `samples/hello_world` still builds for
`pic32cm_gc00_cpro/pic32cm5112gc00100`. Nothing executes an .rst file, so there
is no test beyond that.
