### PR TITLE
drivers: ethernet: nxp_enet: single-flow throughput tuning for ENET_1G

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_sram_dtcm.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_sram_dtcm.overlay
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ZEP-6529: Optional memory-layout overlay for MIMXRT1170-EVK (CM7), mirroring
+ * the RT1180 frdm_imxrt1186 cm33_sram_dtcm.overlay pattern.
+ *
+ * The board default places general .data/.bss/heap/stacks in external SDRAM
+ * (zephyr,sram = &sdram0) - the slowest memory on the part. This overlay
+ * re-homes the general system RAM into the CM7 DTCM (single-cycle tightly-
+ * coupled RAM) for a latency win on CPU-owned data.
+ *
+ * DTCM is only 256K. Use this overlay ONLY for applications whose TOTAL data
+ * footprint (.data/.bss/stacks/heap AND any net_buf pools) fits in 256K.
+ * Deep-pool networking apps (e.g. zperf with large NET_BUF pools + a big
+ * zero-copy slab) MUST NOT use this overlay - keep their bulk data in SDRAM.
+ *
+ * IMPORTANT (ERR050396, Class A - NO software workaround): ENET_1G DMA
+ * descriptors and DMA buffers must NEVER live in TCM on Cortex-M7. This
+ * overlay only re-homes GENERAL CPU-owned data. The ENET_1G DMA region stays
+ * cache-coherent in OCRAM/SDRAM (CONFIG_ETH_NXP_ENET_USE_DTCM_FOR_DMA_BUFFER=n,
+ * its CM7 default). Do NOT set that option to y together with this overlay.
+ */
+
+/* Drop the zephyr,memory-region = "DTCM" reservation so the region can be
+ * re-declared as plain system RAM below.
+ */
+/delete-node/ &dtcm;
+
+/ {
+	chosen {
+		/* Repurpose the DTCM as general system RAM. Drop the
+		 * zephyr,dtcm hook so the DTCM-specific linker sections
+		 * (.dtcm_bss/.dtcm_noinit/.dtcm_data) that target the now
+		 * removed DTCM memory region are not generated.
+		 */
+		/delete-property/ zephyr,dtcm;
+		zephyr,sram = &dtcm;
+	};
+
+	soc {
+		dtcm: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -62,11 +62,16 @@ config ETH_NXP_ENET_RX_THREAD_STACK_SIZE
 	  ENET RX thread stack size in bytes.
 
 config ETH_NXP_ENET_RX_THREAD_PRIORITY
-	int "NXP ENET driver RX cooperative thread priority"
+	int "NXP ENET driver RX thread priority"
 	default 2
 	help
-	  ENET MAC Driver handles RX in cooperative workqueue thread.
-	  This options sets the priority of that thread.
+	  Priority level of the dedicated ENET RX workqueue thread.
+
+config ETH_NXP_ENET_RX_THREAD_PREEMPTIVE
+	bool "Run the NXP ENET RX drain thread at a preemptible priority"
+	help
+	  Run the RX drain thread at a preemptible priority instead of the
+	  default cooperative one.
 
 config ETH_NXP_ENET_RMII_EXT_CLK
 	bool "RMII clock from external sources"

--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -44,16 +44,16 @@ config ETH_NXP_ENET_HW_ACCELERATION
 config ETH_NXP_ENET_RX_BUFFERS
 	int "Number of RX buffers for ethernet driver"
 	default 6
-	range 6 16
+	range 6 128
 	help
-	  Set the number of RX buffers provided to the NXP ENET driver.
+	  Depth of the receive DMA buffer-descriptor ring.
 
 config ETH_NXP_ENET_TX_BUFFERS
 	int "Number of TX buffers for ethernet driver"
 	default 1
-	range 1 16
+	range 1 128
 	help
-	  Set the number of TX buffers provided to the NXP ENET driver.
+	  Depth of the transmit DMA buffer-descriptor ring.
 
 config ETH_NXP_ENET_RX_THREAD_STACK_SIZE
 	int "NXP ENET RX thread stack size"

--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -73,6 +73,54 @@ config ETH_NXP_ENET_RX_THREAD_PREEMPTIVE
 	  Run the RX drain thread at a preemptible priority instead of the
 	  default cooperative one.
 
+config ETH_NXP_ENET_RX_INT_COALESCE
+	bool "ENET hardware RX/TX interrupt coalescing"
+	help
+	  Program the ENET RXIC/TXIC registers so the MAC raises an interrupt
+	  only after a number of frames accumulate or a hardware timer expires,
+	  instead of once per frame.
+
+if ETH_NXP_ENET_RX_INT_COALESCE
+
+config ETH_NXP_ENET_RX_COALESCE_FRAMES
+	int "RX interrupt coalescing frame-count threshold"
+	default 8
+	range 1 255
+	help
+	  Number of received frames the MAC accumulates before raising a
+	  receive interrupt (RXIC ICFT, ring 0). Higher values mean fewer
+	  interrupts but more latency; ensure the ring is deep enough for this
+	  many in-flight frames.
+
+config ETH_NXP_ENET_RX_COALESCE_TICKS
+	int "RX interrupt coalescing timer threshold"
+	default 100
+	range 0 65535
+	help
+	  Maximum time the MAC waits (coalescing timer units, 64 bus-clock
+	  cycles each) before raising a receive interrupt if the frame-count
+	  threshold is not reached. Bounds worst-case latency. 0 disables it.
+
+config ETH_NXP_ENET_TX_COALESCE_FRAMES
+	int "TX interrupt coalescing frame-count threshold"
+	default 1
+	range 1 255
+	help
+	  Number of transmitted frames the MAC accumulates before raising a
+	  transmit interrupt (TXIC ICFT, ring 0). Keep at 1 unless the reclaim
+	  path tolerates batching.
+
+config ETH_NXP_ENET_TX_COALESCE_TICKS
+	int "TX interrupt coalescing timer threshold"
+	default 0
+	range 0 65535
+	help
+	  Maximum time the MAC waits (coalescing timer units, 64 bus-clock
+	  cycles each) before raising a transmit interrupt if the TX frame-count
+	  threshold is not reached. 0 disables it.
+
+endif # ETH_NXP_ENET_RX_INT_COALESCE
+
 config ETH_NXP_ENET_RMII_EXT_CLK
 	bool "RMII clock from external sources"
 	help

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -116,6 +116,18 @@ struct nxp_enet_mac_data {
 static K_THREAD_STACK_DEFINE(enet_rx_stack, CONFIG_ETH_NXP_ENET_RX_THREAD_STACK_SIZE);
 static struct k_work_q rx_work_queue;
 
+/* Priority of the dedicated ENET RX drain thread. Cooperative by default;
+ * on a sustained 1G receive path that can be delayed long enough for the RX
+ * DMA to overrun its descriptors (kStatus_ENET_RxFrameError). Selecting
+ * ETH_NXP_ENET_RX_THREAD_PREEMPTIVE runs it preemptibly so it recycles
+ * descriptors promptly.
+ */
+#if defined(CONFIG_ETH_NXP_ENET_RX_THREAD_PREEMPTIVE)
+#define ENET_RX_THREAD_PRIO K_PRIO_PREEMPT(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY)
+#else
+#define ENET_RX_THREAD_PRIO K_PRIO_COOP(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY)
+#endif
+
 static int rx_queue_init(void)
 {
 	struct k_work_queue_config cfg = {.name = "ENET_RX"};
@@ -123,7 +135,7 @@ static int rx_queue_init(void)
 	k_work_queue_init(&rx_work_queue);
 	k_work_queue_start(&rx_work_queue, enet_rx_stack,
 			   K_THREAD_STACK_SIZEOF(enet_rx_stack),
-			   K_PRIO_COOP(CONFIG_ETH_NXP_ENET_RX_THREAD_PRIORITY),
+			   ENET_RX_THREAD_PRIO,
 			   &cfg);
 
 	return 0;

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -729,6 +729,30 @@ static int eth_nxp_enet_init(const struct device *dev)
 	enet_config.callback = eth_callback;
 	enet_config.userData = (void *)dev;
 
+#if defined(CONFIG_ETH_NXP_ENET_RX_INT_COALESCE) &&					\
+	defined(FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE) &&				\
+	FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE
+	/* Program hardware RX/TX interrupt coalescing so the MAC raises an
+	 * interrupt only after a batch of frames (or a hardware timer) rather
+	 * than once per frame. This amortizes the fixed per-interrupt and
+	 * RX-thread wake cost across many standard frames on the 1G path. Ring 0
+	 * only; the other rings (AVB-classified) are left uncoalesced.
+	 */
+	{
+		static enet_intcoalesce_config_t intcoalesce_cfg;
+
+		intcoalesce_cfg.rxCoalesceFrameCount[0] =
+			CONFIG_ETH_NXP_ENET_RX_COALESCE_FRAMES;
+		intcoalesce_cfg.rxCoalesceTimeCount[0] =
+			CONFIG_ETH_NXP_ENET_RX_COALESCE_TICKS;
+		intcoalesce_cfg.txCoalesceFrameCount[0] =
+			CONFIG_ETH_NXP_ENET_TX_COALESCE_FRAMES;
+		intcoalesce_cfg.txCoalesceTimeCount[0] =
+			CONFIG_ETH_NXP_ENET_TX_COALESCE_TICKS;
+		enet_config.intCoalesceCfg = &intcoalesce_cfg;
+	}
+#endif
+
 	ENET_Up(data->base,
 		  &data->enet_handle,
 		  &enet_config,

--- a/drivers/ethernet/phy/Kconfig
+++ b/drivers/ethernet/phy/Kconfig
@@ -135,6 +135,16 @@ config PHY_REALTEK_RTL8211F
 	help
 	  Enable Realtek RTL8211F Ethernet PHY Driver
 
+config PHY_REALTEK_RTL8211F_FORCE_MASTER
+	bool "Force 1000BASE-T master role"
+	depends on PHY_REALTEK_RTL8211F
+	help
+	  Force a fixed 1000BASE-T master role instead of automatic
+	  master/slave resolution. Only for a fixed point-to-point link
+	  where auto-negotiation fails to converge and the link flaps. Do
+	  NOT enable it when the link partner may also be forced to master,
+	  as that prevents the gigabit link from coming up.
+
 config PHY_QUALCOMM_AR8031
 	bool "Qualcomm Atheros AR8031 Ethernet PHY Driver"
 	default y

--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -39,6 +39,10 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define PHY_RT_RTL8211F_PHYSR_LINKSPEED_100M  (1U)
 #define PHY_RT_RTL8211F_PHYSR_LINKSPEED_1000M (2U)
 
+/* 1000BASE-T control register (MII reg 0x9) manual master/slave bits. */
+#define PHY_RT_RTL8211F_1KTCR_MS_MANUAL_EN_MASK BIT(12)
+#define PHY_RT_RTL8211F_1KTCR_MS_VALUE_MASK     BIT(11)
+
 #define PHY_RT_RTL8211F_PAGSR_REG (0x1F)
 
 #define PHY_RT_RTL8211F_PAGE_MIICR_ADDR   (0xD08)
@@ -385,6 +389,33 @@ static int phy_rt_rtl8211f_cfg_link(const struct device *dev, enum phy_link_spee
 		LOG_ERR("Error setting C1KT register for phy (%d)", config->addr);
 		goto done;
 	}
+
+#if defined(CONFIG_PHY_REALTEK_RTL8211F_FORCE_MASTER)
+	/* Force a fixed 1000BASE-T master role. Only useful on a fixed
+	 * point-to-point link where auto master/slave resolution fails to
+	 * converge and the link flaps.
+	 */
+	if (PHY_LINK_IS_SPEED_1000M(speeds)) {
+		uint32_t c1kt = 0;
+
+		ret = phy_rt_rtl8211f_read(dev, MII_1KTCR, &c1kt);
+		if (ret) {
+			LOG_ERR("Error reading phy (%d) 1000BASE-T control register",
+				config->addr);
+			goto done;
+		}
+
+		c1kt |= PHY_RT_RTL8211F_1KTCR_MS_MANUAL_EN_MASK |
+			PHY_RT_RTL8211F_1KTCR_MS_VALUE_MASK;
+
+		ret = phy_rt_rtl8211f_write(dev, MII_1KTCR, c1kt);
+		if (ret) {
+			LOG_ERR("Error writing phy (%d) 1000BASE-T control register",
+				config->addr);
+			goto done;
+		}
+	}
+#endif /* CONFIG_PHY_REALTEK_RTL8211F_FORCE_MASTER */
 
 	/* (Re)start autonegotiation */
 	ret = phy_rt_rtl8211f_restart_autonegotiation(dev);


### PR DESCRIPTION
## Overview

This series improves single-flow throughput on the NXP ENET_1G MAC and adds the
board and PHY options needed to reach it, validated on the MIMXRT1170-EVKB
(MIMXRT1176, Cortex-M7) over a direct 1000BASE-T link with a Linux (Raspberry Pi)
iperf peer.

Each option is opt-in and defaults preserve current behaviour.

## Commits

1. **allow deeper DMA rings** – raise the `ETH_NXP_ENET_RX_BUFFERS` /
   `ETH_NXP_ENET_TX_BUFFERS` caps so the RX BD ring can be deepened well past 16,
   removing the descriptor-overrun (`RxFrameError`) losses seen at 1G.
2. **allow preemptible RX drain thread** – new
   `ETH_NXP_ENET_RX_THREAD_PREEMPTIVE`; runs the RX work queue at a preemptible
   high priority so descriptors are recycled promptly. Default keeps the current
   cooperative priority.
3. **add hardware interrupt coalescing** – new `ETH_NXP_ENET_RX_INT_COALESCE`
   plus RX/TX frame/tick counts, programmed on ring 0 before `ENET_Up`. Guarded by
   `FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE`. Reduces ISR entries at equal
   throughput (CPU saving).
4. **phy: rtl8211f: add optional forced master role** – new
   `PHY_REALTEK_RTL8211F_FORCE_MASTER` (default n). Forces manual 1000BASE-T
   master when 1000M is advertised, fixing the ~1 s link flap on a direct
   point-to-point gigabit link where automatic master/slave tie-break never
   converges. Opt-in because forcing master is unsafe against a master link
   partner.
5. **boards: nxp: mimxrt1170_evk: add optional CM7 DTCM system-RAM overlay** –
   optional overlay routing general data to DTCM (mirrors the RT1180
   `cm33_sram_dtcm.overlay` precedent). ENET DMA buffers are deliberately kept in
   SDRAM per ERR050396.

## Measured results (MIMXRT1176 CM7, direct 1000BASE-T, Linux iperf peer)

Stable 1 Gbit/s full-duplex link, 0% ping loss.

| Path            | Baseline (stock) | Tuned (this series) |
|-----------------|------------------|---------------------|
| UDP RX (down)   | 85 Mbps @1KB / 199 Mbps @1470B, heavy `RxFrameError` overrun loss | up to ~477 Mbps, overrun flood eliminated |
| TCP RX (down)   | ~69 Mbps         | ~137–169 Mbps       |
| UDP TX (up)     | ~40 Mbps         | ~200–512 Mbps       |
| TCP TX (up)     | —                | ~194–200 Mbps       |

The preemptible RX drain thread eliminates the `ENET_GetRxFrame ... 4004`
(RxFrameError / descriptor-overrun) flood entirely at 1G.

## Analysis / scope

The residual single-flow ceiling (~200–300 Mbps UDP, ~170 Mbps TCP) is a
per-packet net-stack (packets-per-second) limit on one Cortex-M7, not a link,
copy, or memory-placement limit: a bare-metal SDK reference on the same board
sustains ~916/670 Mbps UDP, and increasing the payload from 1 KB to 1470 B raises
UDP RX by +134% at the same offered bitrate. Multiple RX rings do not help an
untagged single flow on this IP (the extra rings are AVB/TSN VLAN-priority
classified, not a receive-side-scaling hash), so this series exhausts the
single-core MAC-driver levers.

## Testing

- checkpatch: 0 errors, 0 warnings on all commits.
- gitlint / KconfigBasic: clean.
- Twister on real `mimxrt1170_evk/mimxrt1176/cm7`
  (`tests/net/ethernet_mgmt`, `tests/drivers/ethernet`): all executed configs
  pass.
- Not run on any other board.

Fixes ZEP-6529
