### PR TITLE
modem: backends: name the UART device in log messages

### DIFF
--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -66,7 +66,8 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 
 	case UART_TX_ABORTED:
 		if (modem_backend_uart_async_is_open(backend)) {
-			LOG_WRN("Transmit aborted (%zu sent)", evt->data.tx.len);
+			LOG_WRN("%s: Transmit aborted (%zu sent)", backend->uart->name,
+				evt->data.tx.len);
 		}
 		atomic_clear_bit(&backend->async.common.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMITTING_BIT);
@@ -91,7 +92,7 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 			break;
 		}
 
-		LOG_WRN("No receive buffer available");
+		LOG_WRN("%s: No receive buffer available", backend->uart->name);
 		break;
 
 	case UART_RX_BUF_RELEASED:
@@ -109,7 +110,7 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 			break;
 		}
 
-		LOG_WRN("Unknown receive buffer released");
+		LOG_WRN("%s: Unknown receive buffer released", backend->uart->name);
 		break;
 
 	case UART_RX_RDY:
@@ -124,7 +125,7 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 			ring_buf_reset(&backend->async.receive_rb);
 			k_spin_unlock(&backend->async.receive_rb_lock, key);
 
-			LOG_WRN("Receive buffer overrun (dropped %u + %u)",
+			LOG_WRN("%s: Receive buffer overrun (dropped %u + %u)", backend->uart->name,
 				buf_size - received, (unsigned int)evt->data.rx.len);
 			break;
 		}
@@ -139,7 +140,8 @@ static void modem_backend_uart_async_event_handler(const struct device *dev,
 		break;
 
 	case UART_RX_STOPPED:
-		LOG_WRN("Receive stopped for reasons: %u", (uint8_t)evt->data.rx_stop.reason);
+		LOG_WRN("%s: Receive stopped for reasons: %u", backend->uart->name,
+			(uint8_t)evt->data.rx_stop.reason);
 		break;
 
 	default:
@@ -250,7 +252,8 @@ static int modem_backend_uart_async_transmit_chain(void *data,
 #endif
 
 	if (ret != 0) {
-		LOG_ERR("Failed to %s %u bytes. (%d)", "start async transmit for", offset, ret);
+		LOG_ERR("%s: Failed to %s %u bytes. (%d)", backend->uart->name,
+			"start async transmit for", offset, ret);
 		return ret;
 	}
 

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -144,7 +144,8 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 
 	case UART_TX_ABORTED:
 		if (modem_backend_uart_async_hwfc_is_open(backend)) {
-			LOG_WRN("Transmit aborted (%zu sent)", evt->data.tx.len);
+			LOG_WRN("%s: Transmit aborted (%zu sent)", backend->uart->name,
+				evt->data.tx.len);
 		}
 		atomic_clear_bit(&backend->async.common.state,
 				 MODEM_BACKEND_UART_ASYNC_STATE_TRANSMIT_BIT);
@@ -162,7 +163,7 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 		err = uart_rx_buf_rsp(backend->uart, buf->buf,
 				      backend->async.rx_buf_size - sizeof(struct rx_buf_t));
 		if (err) {
-			LOG_ERR("uart_rx_buf_rsp: %d", err);
+			LOG_ERR("%s: uart_rx_buf_rsp: %d", backend->uart->name, err);
 			rx_buf_unref(&backend->async, buf->buf);
 		}
 		break;
@@ -180,8 +181,8 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 			rx_event.len = evt->data.rx.len;
 			err = k_msgq_put(&backend->async.rx_queue, &rx_event, K_NO_WAIT);
 			if (err) {
-				LOG_WRN("RX queue overflow: %d (dropped %u)", err,
-					evt->data.rx.len);
+				LOG_WRN("%s: RX queue overflow: %d (dropped %u)",
+					backend->uart->name, err, evt->data.rx.len);
 				rx_buf_unref(&backend->async, evt->data.rx.buf);
 				break;
 			}
@@ -201,7 +202,8 @@ static void modem_backend_uart_async_hwfc_event_handler(const struct device *dev
 		break;
 
 	case UART_RX_STOPPED:
-		LOG_WRN("Receive stopped for reasons: %u", (uint8_t)evt->data.rx_stop.reason);
+		LOG_WRN("%s: Receive stopped for reasons: %u", backend->uart->name,
+			(uint8_t)evt->data.rx_stop.reason);
 		break;
 
 	default:
@@ -306,7 +308,8 @@ static int modem_backend_uart_async_hwfc_transmit_chain(
 #endif
 
 	if (ret != 0) {
-		LOG_ERR("Failed to %s %u bytes. (%d)", "start async transmit for", offset, ret);
+		LOG_ERR("%s: Failed to %s %u bytes. (%d)", backend->uart->name,
+			"start async transmit for", offset, ret);
 		return ret;
 	}
 

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -38,7 +38,7 @@ static void modem_backend_uart_isr_irq_handler_receive_ready(struct modem_backen
 		 * - or a too small receive_buf_size
 		 * relatively to the (too high) baud rate and amount of incoming data.
 		 */
-		LOG_WRN("Receive buffer overrun");
+		LOG_WRN("%s: Receive buffer overrun", backend->uart->name);
 		ring_buf_reset(receive_rb);
 		size = ring_buf_put_ptr(receive_rb, &buffer, 0);
 	}


### PR DESCRIPTION
A system typically instantiates these backends more than once, for the modem and for other UART peripherals, so a warning about a dropped buffer or an aborted transmit does not say which UART it came from.

Prefix the warnings and errors in the three UART backends with the device name, using the "%s: " form already used by modem_chat and modem_stats. The name is read from backend->uart, as the modem_stats buffer names in these files already do. The runtime PM messages in the same files report the device name since commit 79861deac415 ("modem: backends: Unify runtime PM log messages"), so this makes the rest of them agree.