### PR TITLE
Add RTC driver support for microchip pic32czca family

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -28,6 +28,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		eeprom-0 = &eeprom;
+		rtc = &rtc;
 	};
 
 	leds {
@@ -269,5 +270,10 @@ i2c0: &sercom9 {
 	cs-gpios = <&portc 10 GPIO_ACTIVE_LOW>;
 	dmas = <&dmac 3 10>, <&dmac 4 9>;
 	dma-names = "tx", "rx";
+	status = "okay";
+};
+
+&rtc {
+	prescaler = <1024>;
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
@@ -16,6 +16,7 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - rtc
   - spi
   - uart
   - watchdog

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
@@ -28,6 +28,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		eeprom-0 = &eeprom;
+		rtc = &rtc;
 	};
 
 	leds {
@@ -269,5 +270,10 @@ i2c0: &sercom9 {
 	cs-gpios = <&portc 10 GPIO_ACTIVE_LOW>;
 	dmas = <&dmac 3 10>, <&dmac 4 9>;
 	dma-names = "tx", "rx";
+	status = "okay";
+};
+
+&rtc {
+	prescaler = <1024>;
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
@@ -15,6 +15,7 @@ supported:
   - gpio
   - i2c
   - pinctrl
+  - rtc
   - spi
   - uart
   - watchdog

--- a/drivers/rtc/rtc_mchp_g1.c
+++ b/drivers/rtc/rtc_mchp_g1.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(rtc_mchp_g1, CONFIG_RTC_LOG_LEVEL);
 #define RTC_ALARM_PENDING           (1)
 
 /* Timeout values for WAIT_FOR macro */
-#define TIMEOUT_REG_SYNC 5000
+#define TIMEOUT_REG_SYNC 10000
 #define DELAY_US         1
 
 #ifdef CONFIG_RTC_ALARM
@@ -54,15 +54,6 @@ struct rtc_mchp_time {
 	uint32_t month;
 	uint32_t year;
 };
-
-/* Do the peripheral interrupt related configuration */
-#ifdef CONFIG_RTC_ALARM
-#define RTC_MCHP_IRQ_HANDLER(n)                                                                    \
-	static void rtc_mchp_irq_config_##n(const struct device *dev)                              \
-	{                                                                                          \
-		RTC_MCHP_IRQ_CONNECT(n, 0);                                                        \
-	}
-#endif /* CONFIG_RTC_ALARM */
 
 /* Clock configuration structure for RTC. */
 struct rtc_mchp_clock {
@@ -120,7 +111,7 @@ static inline void rtc_sync_busy(const rtc_registers_t *regs, uint32_t sync_flag
 {
 	if (WAIT_FOR(((regs->MODE2.RTC_SYNCBUSY & sync_flag) == 0), TIMEOUT_REG_SYNC,
 		     k_busy_wait(DELAY_US)) == false) {
-		LOG_ERR("RTC reset timed out");
+		LOG_ERR("Timeout waiting for RTC_SYNCBUSY to clear");
 	}
 }
 
@@ -918,7 +909,7 @@ static DEVICE_API(rtc, rtc_mchp_api) = {
 
 /* Defines the RTC interrupt configurations. */
 #ifdef CONFIG_RTC_ALARM
-#define RTC_MCHP_IRQ_CONNECT(n, m)                                                                 \
+#define RTC_MCHP_IRQ_CONNECT(m, n)                                                                 \
 	do {                                                                                       \
 		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, m, irq), DT_INST_IRQ_BY_IDX(n, m, priority),     \
 			    rtc_mchp_isr, DEVICE_DT_INST_GET(n), 0);                               \
@@ -937,7 +928,7 @@ static DEVICE_API(rtc, rtc_mchp_api) = {
 #define RTC_MCHP_IRQ_HANDLER(n)                                                                    \
 	static void rtc_mchp_irq_config_##n(const struct device *dev)                              \
 	{                                                                                          \
-		RTC_MCHP_IRQ_CONNECT(n, 0);                                                        \
+		LISTIFY(DT_INST_NUM_IRQS(n), RTC_MCHP_IRQ_CONNECT, (;), n);                        \
 	}
 #endif /* CONFIG_RTC_ALARM */
 

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
@@ -138,6 +138,20 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@44072000 {
+			compatible = "microchip,rtc-g1";
+			reg = <0x44072000 0x70>;
+			interrupts = <15 0>, <16 0>, <17 0>, <18 0>;
+			interrupt-names = "tamper", "ovf", "perx", "cmpx";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_RTC>,
+				 <&rtcclock CLOCK_MCHP_RTC_ID>;
+			clock-names = "mclk", "rtcclk";
+			prescaler = <1>;
+			alarms-count = <2>;
+			cal-constant = <1048576>;
+			status = "disabled";
+		};
+
 		pinctrl: pinctrl@44840000 {
 			compatible = "microchip,port-g1-pinctrl";
 			#address-cells = <1>;

--- a/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-rtc.yaml
+++ b/dts/bindings/clock/microchip/pic32cz_ca/microchip,pic32cz-ca-rtc.yaml
@@ -17,13 +17,13 @@ properties:
 
   rtc-src:
     type: int
-    default: 0
+    default: 1
     description: |
       RTC source clock selection
-      0: ulp1k
-      1: ulp32k
-      4: xosc1k
-      5: xosc32k
+      0: ulp32k
+      1: ulp1k
+      2: xosc32k
+      3: xosc1k
 
 clock-cells:
   - subsystem

--- a/dts/bindings/rtc/microchip,rtc-g1.yaml
+++ b/dts/bindings/rtc/microchip,rtc-g1.yaml
@@ -12,6 +12,7 @@ description: |
   Group g1 RTC driver supports following hardware peripherals:
     - module name="RTC" id="U2250" version="2.1.0"
     - module name="RTC" id="03608" version="3a1"
+    - module name="RTC" id="03608" version="3b0" name2="tmr_rtc_u2250_v3"
 
 examples:
   - |
@@ -84,5 +85,5 @@ properties:
     description: |
       Define the constant used to calculate the calibration.
 
-      More information can be found in the datasheet of each SoC series at
-      RTC Frequency Correction topic.
+      The RTC frequency correction is calculated as:
+      Correction (ppm) = (FREQCORR.VALUE * 1e6) / cal-constant

--- a/tests/drivers/rtc/rtc_api/boards/pic32cz_ca80_cult.conf
+++ b/tests/drivers/rtc/rtc_api/boards/pic32cz_ca80_cult.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=63
+CONFIG_RTC_CALIBRATION=y

--- a/tests/drivers/rtc/rtc_api/boards/pic32cz_ca90_cult.conf
+++ b/tests/drivers/rtc/rtc_api/boards/pic32cz_ca90_cult.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=63
+CONFIG_RTC_CALIBRATION=y

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: eb7765f7399129198f669394fcf2b430e38929c9
+      revision: pull/82/head
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
- Adds RTC node in dts
- Updates the binding yaml of rtc driver with the supported rtc ip version
- rtc-src enum mapping and default did not match the actual RTCSEL, corrected mapping and default clock source.
- Connect all RTC IRQ lines for PIC32CZ CA using LISTIFY instead of only index 0. because PIC32CZ CA supports multiple RTC interrupt lines, while the existing code connects only the first IRQ line.
- Increase the RTC synchronization timeout from 5 ms to 10 ms to accommodate the synchronization delay on PIC32CZ CA. Also update the timeout message to correctly indicate RTC synchronization rather than an RTC reset.
- Updates the rtc prescaler to 1024 to get 1Hz clock.
- Adds the rtc tag in board.yaml for enabling CI to detect it for tests.
- Adds .conf file for rtc_api test ptoject
