### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -353,7 +353,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c84230d0329a2ce5e449bbd556d6854861a6eee7
+      revision: ccc7a8094566ba835da80176c565044b0516b614
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: fc0872109ec4c006d32843a202b129db33cf16b9


### PR DESCRIPTION
Update the HW models module to:
ccc7a8094566ba835da80176c565044b0516b614

Including the following:
ccc7a80 GPIO: file backend generalize to N instances
98eed5a GPIO: Generalize backend interface
066f9c4 GPIO: refactor file backend into its own file
fde8506 GPIO: cosmetic changes without any functional impact
613f96e GPIO: Indent file consistently with spaces
8db0e79 HW_utils: Multiple improvements to hwu_readline()
5d38c8d HW_utils: refactor readline out into common utils
88767f7 GPIOTE: Bugfix: Configuring disabled pin should not disown other pins
21ae109 docs UART: Minor clarification to fifo loopback section