### PR TITLE
doc: draw mermaid diagrams at their natural size

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -62,6 +62,13 @@ legend,
     max-width: 480px;
 }
 
+/* sphinxcontrib-mermaid stretches every diagram to the width of the page. Keep the size Mermaid
+   computed for a diagram that turns off "useMaxWidth". */
+pre.mermaid > svg,
+.mermaid-container > pre > svg {
+    width: auto !important;
+}
+
 p,
 article ul,
 article ol,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -454,7 +454,7 @@ sitemap_url_scheme = "{link}"
 
 #-- Options for sphinxcontrib-mermaid -------------------------------------
 
-mermaid_version = "11.14.0"
+mermaid_version = "11.16.1"
 d3_version = "7.9.0"
 
 # Without this, every diagram is drawn in a box of a fixed height and centered in it.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -457,6 +457,9 @@ sitemap_url_scheme = "{link}"
 mermaid_version = "11.14.0"
 d3_version = "7.9.0"
 
+# Without this, every diagram is drawn in a box of a fixed height and centered in it.
+mermaid_height = "auto"
+
 if tags.has("no-external-deps"): # pylint: disable=undefined-variable  # noqa: F821
     mermaid_use_local = "js/mermaid/mermaid.esm.mjs"
     d3_use_local = "js/d3/d3.min.js"

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -858,6 +858,11 @@ To include a mermaid diagram in a document, use the :rst:dir:`mermaid` directive
             through maybe_active and maybe_inactive intermediate states before each state becomes
             stable.
 
+      ---
+      config:
+        state:
+          useMaxWidth: false
+      ---
       stateDiagram-v2
 
           State inactive {
@@ -886,6 +891,11 @@ Would render as:
          through maybe_active and maybe_inactive intermediate states before each state becomes
          stable.
 
+   ---
+   config:
+     state:
+       useMaxWidth: false
+   ---
    stateDiagram-v2
 
        State inactive {
@@ -905,6 +915,12 @@ Would render as:
        maybe_active --> active : After(x ms)
        maybe_inactive --> inactive : After(x ms)
 
+
+A diagram is drawn across the width of the page and its height follows from its aspect ratio, so a
+diagram that is taller than it is wide ends up much larger than it needs to be. Turning off
+``useMaxWidth``, as in the example above, keeps the diagram at the size Mermaid computed for it; it
+still shrinks to fit a narrow screen. The setting belongs to the diagram type, ``state`` here and
+``flowchart``, ``sequence`` or another type elsewhere.
 
 For references about supported diagrams, syntax, and samples; please refer to the `Mermaid documentation`_.
 For fast iteration when creating or updating diagrams, you can use the `Mermaid live editor`_.


### PR DESCRIPTION
sphinxcontrib-mermaid draws every diagram inside a box of `mermaid_height` (500px by default) and centers it there, ignoring the diagram's own aspect ratio.

A short, wide diagram ends up with hundreds of pixels of empty space above and below it, and a tall one is scaled down until its labels are hard to read. Setting `mermaid_height = "auto"` makes the height follow from the width.

The extension also stretches every diagram to the full width of the page, which makes a tall diagram larger than it needs to be. Mermaid's own `useMaxWidth` setting is the way out of that one, per diagram: the last commit lets a diagram that turns it off keep the size mermaid computed for it, turns it off for the state diagram in the documentation guidelines, which takes that diagram from 537x1031 to 363x690, and documents the setting right next to it.

The three diagrams currently in the docs, before and after:

| Diagram | Before | After |
| --- | --- | --- |
| Release process, sequence diagram | [current docs](https://docs.zephyrproject.org/latest/project/release_process.html#long-term-support-and-maintenance) | [this PR](https://builds.zephyrproject.io/zephyr/pr/118824/docs/project/release_process.html#long-term-support-and-maintenance) |
| Documentation guidelines, state diagram | [current docs](https://docs.zephyrproject.org/latest/contribute/documentation/guidelines.html#mermaid) | [this PR](https://builds.zephyrproject.io/zephyr/pr/118824/docs/contribute/documentation/guidelines.html#mermaid) |
| System power management, state diagram | [current docs](https://docs.zephyrproject.org/latest/services/pm/system.html#introduction) | [this PR](https://builds.zephyrproject.io/zephyr/pr/118824/docs/services/pm/system.html#introduction) |