### PR TITLE
drivers: ethernet: nxp_imx_netc: Fixed deadlock in NETC with gPTP

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -577,8 +577,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 #endif
 
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
-	if (net_pkt_is_tx_timestamping(pkt) &&
-	    (netc_eth_get_ptp_clock(dev, data->iface) != NULL)) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 		opt.flags |= kEP_TX_OPT_REQ_TS;
 	}
 #endif


### PR DESCRIPTION
When using gPTP with NETC, tx transfer would cause deadlock. 

Changed if condition so that blocked tx write gets executed correctly, returning timestamp and therefore not deadlocking.