### PR TITLE
tests: dfu: mcuboot: Fix nRF52840 configuration

### DIFF
--- a/tests/subsys/dfu/mcuboot/boards/nrf52840dk_nrf52840.conf
+++ b/tests/subsys/dfu/mcuboot/boards/nrf52840dk_nrf52840.conf
@@ -1,1 +1,0 @@
-CONFIG_ARM_MPU=n

--- a/tests/subsys/dfu/mcuboot/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,36 @@
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+
+&flash0 {
+	partitions {
+		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x0 DT_SIZE_K(56)>;
+		};
+
+		slot0_partition: partition@e000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0xe000 DT_SIZE_K(468)>;
+		};
+
+		slot1_partition: partition@83000 {
+			compatible = "zephyr,mapped-partition";
+			reg = <0x83000 DT_SIZE_K(468)>;
+		};
+	};
+};
+
+/ {
+	chosen {
+		/*
+		 * Set the slot0_partition as the active slot.
+		 * The code will not be linked to slot1_partition, because the
+		 * USE_DT_CODE_PARTITION Kconfig option is not set.
+		 * The code will in fact use the boot_partition, but the build
+		 * will not check if the code fits inside it.
+		 * This check needs to be performed manually.
+		 */
+		zephyr,code-partition = &slot0_partition;
+	};
+};

--- a/tests/subsys/dfu/mcuboot/src/main.c
+++ b/tests/subsys/dfu/mcuboot/src/main.c
@@ -116,6 +116,13 @@ ZTEST(mcuboot_interface, test_write_confirm)
 		return;
 	}
 
+	/*
+	 * Under normal circumstances, it is not allowed to erase the active
+	 * slot. However, since the USE_DT_CODE_PARTITION Kconfig option is
+	 * not set, the code will in fact use the boot_partition.
+	 * As a result, it is possible to erase the slot0_partition, which
+	 * leads to more repeatable test results.
+	 */
 	zassert(boot_erase_img_bank(SLOT0_PARTITION_ID) == 0,
 		"pass", "fail");
 
@@ -133,6 +140,12 @@ ZTEST(mcuboot_interface, test_write_confirm)
 	ret = flash_area_write(fa, fa->fa_size - 32, &flag, sizeof(flag));
 	zassert_true(ret == 0, "Write to flash");
 
+	/*
+	 * Set the confirmed flag on the active slot.
+	 * This will mark the slot0_partition as confirmed, even though
+	 * the code uses the boot_partition, because whenever MCUboot is used,
+	 * the USE_DT_CODE_PARTITION Kconfig option is set.
+	 */
 	ret = boot_write_img_confirmed();
 	zassert(ret == 0, "pass", "fail (%d)", ret);
 


### PR DESCRIPTION
Fix the nRF52840 test configuration by increasing the gap between the beginning of the flash area and the slot0_partition. Additionally, add comments inside the files about the assumptions made in the test.