### PR TITLE
drivers: memc: flexspi: don't apply port address offset twice

### DIFF
--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -295,15 +295,15 @@ int memc_flexspi_transfer(const struct device *dev,
 	flexspi_transfer_t tmp;
 	struct memc_flexspi_data *data = dev->data;
 	status_t status;
-	uint32_t seq_off, addr_offset = 0U;
-	int i;
+	uint32_t seq_off;
 
-	/* Calculate sequence offset and address offset based on port */
+	/*
+	 * Calculate sequence offset based on port. The port address offset
+	 * is applied by FLEXSPI_TransferBlocking() in the HAL, which adds the
+	 * sizes of all preceding ports from FLSHCR0.
+	 */
 	seq_off = data->port_luts[transfer->port].lut_offset /
 				MEMC_FLEXSPI_CMD_PER_SEQ;
-	for (i = 0; i < transfer->port; i++) {
-		addr_offset += data->size[i];
-	}
 
 	/*
 	 * Lock IRQs while an IP command is active. If an ISR fires and its handler
@@ -313,11 +313,10 @@ int memc_flexspi_transfer(const struct device *dev,
 #if CONFIG_FLASH_MCUX_FLEXSPI_XIP
 	unsigned int key = irq_lock();
 #endif
-	if ((seq_off != 0) || (addr_offset != 0)) {
-		/* Adjust device address and sequence index for transfer */
+	if (seq_off != 0) {
+		/* Adjust sequence index for transfer */
 		memcpy(&tmp, transfer, sizeof(tmp));
 		tmp.seqIndex += seq_off;
-		tmp.deviceAddress += addr_offset;
 		status = FLEXSPI_TransferBlocking(base, &tmp);
 	} else {
 		/* Transfer does not need adjustment */


### PR DESCRIPTION
AI generated commit that appears to fix https://github.com/zephyrproject-rtos/zephyr/issues/118835, please triple check.

The HAL's FLEXSPI_TransferBlocking() now adds the sizes of all preceding ports (from FLSHCR0) to the transfer's device address. memc_flexspi_transfer() also adds the sizes of preceding ports, so the offset was applied twice for any device not on port A1.

On FRDM-RW612 this makes the APS6404L PSRAM on port B1 fail to initialize: the IP command is issued at 0x08000000 (64 MB + 64 MB) instead of 0x04000000, which is outside the 72 MB FlexSPI address space, the controller rejects it, and the driver returns -EIO ("Device aps6404l@2 is not ready"). Devices on port A1 are unaffected since their offset is zero.

Only adjust the LUT sequence index here and let the HAL handle the port address offset.

Ran memc on frdm rw612, ran wifi shell afterward to make sure it worked with memc not enabled.