### PR TITLE
drivers: sensor: realtek: add AmebaG2 (RTL8721F) on-die temperature sensor

### DIFF
--- a/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
+++ b/boards/realtek/rtl8721f_evb/rtl8721f_evb.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&coretemp {
+	status = "okay";
+};
+
 &gpioa {
 	status = "okay";
 };

--- a/drivers/sensor/realtek/CMakeLists.txt
+++ b/drivers/sensor/realtek/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, Realtek, SIBG-SD7
 # SPDX-License-Identifier: Apache-2.0
 
+add_subdirectory_ifdef(CONFIG_TEMP_AMEBA ameba_temp)
 add_subdirectory_ifdef(CONFIG_QDEC_BEE qdec_bee)
 add_subdirectory_ifdef(CONFIG_TACH_RTS5912 rts5912)

--- a/drivers/sensor/realtek/Kconfig
+++ b/drivers/sensor/realtek/Kconfig
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, Realtek, SIBG-SD7
 # SPDX-License-Identifier: Apache-2.0
 
+source "drivers/sensor/realtek/ameba_temp/Kconfig"
 source "drivers/sensor/realtek/qdec_bee/Kconfig"
 source "drivers/sensor/realtek/rts5912/Kconfig"

--- a/drivers/sensor/realtek/ameba_temp/CMakeLists.txt
+++ b/drivers/sensor/realtek/ameba_temp/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(ameba_temp.c)

--- a/drivers/sensor/realtek/ameba_temp/Kconfig
+++ b/drivers/sensor/realtek/ameba_temp/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+config TEMP_AMEBA
+	bool "AMEBA Temperature Sensor"
+	default y
+	depends on DT_HAS_REALTEK_AMEBA_TEMP_ENABLED
+	depends on SOC_FAMILY_REALTEK_AMEBA
+	help
+	  Enable driver for temperature sensor on certain ameba targets.

--- a/drivers/sensor/realtek/ameba_temp/ameba_temp.c
+++ b/drivers/sensor/realtek/ameba_temp/ameba_temp.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT realtek_ameba_temp
+
+#include <soc.h>
+#include <ameba_soc.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(ameba_temp, CONFIG_SENSOR_LOG_LEVEL);
+
+struct ameba_temp_data {
+	struct k_mutex mutex; /* serializes access to c_temp */
+	float c_temp;         /* Celsius degree of float type */
+};
+
+static int ameba_temp_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct ameba_temp_data *data = dev->data;
+	uint32_t tm;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_DIE_TEMP) {
+		return -ENOTSUP;
+	}
+
+	tm = TM_GetTempResult();
+	if (tm == TM_INVALID_VALUE) {
+		LOG_ERR("failed to read temperature");
+		return -EIO;
+	}
+
+	k_mutex_lock(&data->mutex, K_FOREVER);
+	data->c_temp = TM_GetCdegree(tm);
+	k_mutex_unlock(&data->mutex);
+
+	return 0;
+}
+
+static int ameba_temp_channel_get(const struct device *dev, enum sensor_channel chan,
+				  struct sensor_value *val)
+{
+	struct ameba_temp_data *data = dev->data;
+	int rc;
+
+	if (chan != SENSOR_CHAN_DIE_TEMP) {
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&data->mutex, K_FOREVER);
+	rc = sensor_value_from_float(val, data->c_temp);
+	k_mutex_unlock(&data->mutex);
+
+	return rc;
+}
+
+static DEVICE_API(sensor, ameba_temp_driver_api) = {
+	.sample_fetch = ameba_temp_sample_fetch,
+	.channel_get = ameba_temp_channel_get,
+};
+
+static int ameba_temp_init(const struct device *dev)
+{
+	struct ameba_temp_data *data = dev->data;
+	TM_InitTypeDef TM_InitStruct;
+
+	k_mutex_init(&data->mutex);
+
+	TM_StructInit(&TM_InitStruct);
+	TM_Init(&TM_InitStruct);
+
+	/* disable high_pt & high_wt & low_wt */
+	TM_INTConfig(TM_BIT_IMR_TM_HIGH_WT | TM_BIT_IMR_TM_LOW_WT, DISABLE);
+	TM_HighPtConfig(0x0, DISABLE);
+	TM_HighWtConfig(0x0, DISABLE);
+	TM_LowWtConfig(0x0, DISABLE);
+
+	return 0;
+}
+
+#define AMEBA_TEMP_DEFINE(inst)                                                                    \
+	static struct ameba_temp_data ameba_temp_dev_data_##inst = {};                             \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, ameba_temp_init, NULL, &ameba_temp_dev_data_##inst,     \
+				     NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,               \
+				     &ameba_temp_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMEBA_TEMP_DEFINE)

--- a/dts/arm/realtek/amebag2/amebag2.dtsi
+++ b/dts/arm/realtek/amebag2/amebag2.dtsi
@@ -205,6 +205,13 @@
 			status = "disabled";
 		};
 
+		coretemp: coretemp@40816000 {
+			compatible = "realtek,ameba-temp";
+			reg = <0x40816000 0x30>;
+			friendly-name = "coretemp";
+			status = "disabled";
+		};
+
 		timer0: counter@40819000 {
 			compatible = "realtek,ameba-counter";
 			reg = <0x40819000 0x30>;

--- a/dts/bindings/sensor/realtek,ameba-temp.yaml
+++ b/dts/bindings/sensor/realtek,ameba-temp.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Realtek Semiconductor Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: AMEBA temperature sensor
+
+compatible: "realtek,ameba-temp"
+
+include: sensor-device.yaml

--- a/samples/sensor/die_temp_polling/boards/rtl8721f_evb.overlay
+++ b/samples/sensor/die_temp_polling/boards/rtl8721f_evb.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		die-temp0 = &coretemp;
+	};
+};

--- a/tests/drivers/sensor/temp_sensor/boards/rtl8721f_evb.overlay
+++ b/tests/drivers/sensor/temp_sensor/boards/rtl8721f_evb.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Realtek Semiconductor Corp.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+temp_sensor: &coretemp {
+	status = "okay";
+};


### PR DESCRIPTION
### Description

Add a sensor driver for the on-die thermal meter (TM) on Realtek Ameba
SoCs, and enable it on the AmebaG2 (RTL8721F) family. The driver reads
the die temperature via the HAL `TM_*` API and exposes it through
`SENSOR_CHAN_DIE_TEMP`.

Split into four commits: devicetree binding + SoC node, the driver,
board enablement on `rtl8721f_evb`, and sample/test overlays.

### Testing

On `rtl8721f_evb`: the `die_temp_polling` sample reports a stable die
temperature, and the `temp_sensor` driver test passes.
