### PR TITLE
Bluetooth: BAP: BSNK: Re-request broadcast code after bad code

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1191,6 +1191,18 @@ static int scan_delegator_mod_src(struct bt_conn *conn,
 	(void)memcpy(&backup_state, state, sizeof(backup_state));
 	backup_pa_sync_requested = internal_state->pa_sync_requested;
 
+	/* BAP_v1.0.1, 3.1.1.4: If the server has synchronized to a BIS and the server has
+	 * detected that the BIS is encrypted, and if the server does not have an encryption
+	 * key to decrypt the BIS, the server shall write a value of 0x01 (Broadcast_Code
+	 * required) to the BIG_Encryption field. If the client requests to sync to a BIS again
+	 * after a previous sync attempt failed due to a bad broadcast code, we shall therefore
+	 * request the broadcast code again instead of leaving the receive state at Bad_Code.
+	 */
+	if (aggregated_bis_syncs != 0U && state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE) {
+		state->encrypt_state = BT_BAP_BIG_ENC_STATE_BCODE_REQ;
+		state_changed = true;
+	}
+
 	if (state->num_subgroups != num_subgroups) {
 		state->num_subgroups = num_subgroups;
 		state_changed = true;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -726,6 +726,45 @@ static void test_bass_broadcast_code(const uint8_t broadcast_code[BT_ISO_BROADCA
 	LOG_INF("Broadcast code added");
 }
 
+/* Request BIS sync again after the server reported a bad broadcast code, without providing a
+ * new broadcast code first. The server shall request the broadcast code again rather than
+ * staying in the Bad_Code state, after which the correct code completes the sync.
+ */
+static void test_bass_retry_after_bad_code(void)
+{
+	struct bt_bap_broadcast_assistant_mod_src_param mod_src_param = { 0 };
+	struct bt_bap_bass_subgroup subgroup = { 0 };
+	int err;
+
+	LOG_INF("Modifying source to retry streaming after bad broadcast code");
+	UNSET_FLAG(flag_broadcast_code_requested);
+	UNSET_FLAG(flag_incorrect_broadcast_code);
+	UNSET_FLAG(flag_recv_state_updated_with_bis_sync);
+
+	mod_src_param.src_id = recv_state.src_id;
+	mod_src_param.num_subgroups = 1U;
+	mod_src_param.pa_sync = true;
+	mod_src_param.subgroups = &subgroup;
+	mod_src_param.pa_interval = g_broadcaster_info.interval;
+	subgroup.bis_sync = BT_ISO_BIS_INDEX_BIT(1U);
+	subgroup.metadata_len = recv_state.subgroups[0].metadata_len;
+	(void)memcpy(subgroup.metadata, recv_state.subgroups[0].metadata, sizeof(metadata));
+
+	err = bt_bap_broadcast_assistant_mod_src(default_conn, &mod_src_param);
+	if (err != 0) {
+		FAIL("Could not modify source (err %d)\n", err);
+		return;
+	}
+
+	LOG_INF("Waiting for the broadcast code to be requested again");
+	WAIT_FOR_FLAG(flag_broadcast_code_requested);
+
+	test_bass_broadcast_code(BROADCAST_CODE);
+
+	LOG_INF("Waiting for receive state with BIS sync");
+	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
+}
+
 static void test_bass_remove_source(void)
 {
 	int err;
@@ -867,6 +906,8 @@ static void test_main_client_sync_incorrect_code(void)
 	WAIT_FOR_FLAG(flag_broadcast_code_requested);
 	test_bass_broadcast_code(INCORRECT_BROADCAST_CODE);
 	WAIT_FOR_FLAG(flag_incorrect_broadcast_code);
+
+	test_bass_retry_after_bad_code();
 
 	test_bass_mod_source(false, 0);
 	test_bass_remove_source();

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -52,6 +52,7 @@ CREATE_FLAG(flag_pa_request);
 CREATE_FLAG(flag_bis_sync_requested);
 CREATE_FLAG(flag_big_sync_mic_failure);
 CREATE_FLAG(flag_sink_started);
+CREATE_FLAG(flag_broadcast_code_received);
 
 static struct bt_bap_broadcast_sink *g_sink;
 static size_t stream_sync_cnt;
@@ -454,6 +455,7 @@ static void broadcast_code_cb(struct bt_conn *conn,
 	req_recv_state = recv_state;
 
 	memcpy(recv_state_broadcast_code, broadcast_code, BT_ISO_BROADCAST_CODE_SIZE);
+	SET_FLAG(flag_broadcast_code_received);
 }
 
 static void scanning_state_cb(struct bt_conn *conn, bool is_scanning)
@@ -1259,11 +1261,38 @@ static void broadcast_sink_with_assistant_incorrect_code(void)
 
 	LOG_INF("Waiting for BIG sync request");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
+	/* Re-arm before syncing, as the assistant requests the BIS sync again as soon as it
+	 * observes the bad code state
+	 */
+	UNSET_FLAG(flag_bis_sync_requested);
+
+	LOG_INF("Waiting for the (incorrect) broadcast code");
+	WAIT_FOR_FLAG(flag_broadcast_code_received);
+	/* Re-arm before the sync fails, as the assistant provides the correct code as soon as
+	 * the broadcast code is requested again
+	 */
+	UNSET_FLAG(flag_broadcast_code_received);
+
 	test_broadcast_sync(recv_state_broadcast_code);
+
 	/* Wait for MIC failure */
 	WAIT_FOR_FLAG(flag_big_sync_mic_failure);
 
+	LOG_INF("Waiting for BIG sync to be requested again");
+	WAIT_FOR_FLAG(flag_bis_sync_requested);
+
+	LOG_INF("Waiting for the (correct) broadcast code");
+	WAIT_FOR_FLAG(flag_broadcast_code_received);
+
+	test_broadcast_sync(recv_state_broadcast_code);
+
+	WAIT_FOR_FLAG(flag_sink_started);
+
 	backchannel_sync_send_all(); /* let other devices know we have received data */
+
+	LOG_INF("Waiting for BIG sync terminate request");
+	WAIT_FOR_UNSET_FLAG(flag_bis_sync_requested);
+	test_broadcast_stop();
 
 	LOG_INF("Waiting for PA sync terminate request");
 	WAIT_FOR_UNSET_FLAG(flag_pa_request);


### PR DESCRIPTION
When a broadcast sink fails to decrypt a BIG due to a bad broadcast code, the BASS receive state is left at Bad_Code. If the broadcast assistant subsequently requests BIS sync again before providing a new broadcast code, the sink did not notify Broadcast_Code_Required again, leaving the assistant with no indication that a new code is expected.

Reset the receive state back to Broadcast_Code_Required whenever a new sync attempt is requested on a BIG known to be encrypted, matching the BASS requirement to request a Broadcast_Code whenever the server does not have a key to decrypt a BIS it is trying to sync to.

Extend the bsim BAP broadcast sink/assistant tests to cover the retry-after-bad-code scenario: the assistant requests BIS sync again before sending the correct code, and the test verifies the receive state changes back to Broadcast_Code_Required instead of staying at Bad_Code.

Tested by running the extended
bap_broadcast_audio_assistant_incorrect_code bsim test, which fails without the fix (times out waiting for the repeated Broadcast_Code notification) and passes with it. Not built or tested on hardware.

Fixes #111790