### PR TITLE
net: wifi: add a channel to frequency conversion helper

### DIFF
--- a/drivers/wifi/bflb/wifi6/bflb_wifi_wpa_supp.c
+++ b/drivers/wifi/bflb/wifi6/bflb_wifi_wpa_supp.c
@@ -14,6 +14,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -89,9 +90,6 @@ LOG_MODULE_DECLARE(bflb_wifi, CONFIG_WIFI_LOG_LEVEL);
 /* HT Capabilities Info: HT20 + Short GI for 20MHz (IEEE 802.11n Table 9-152) */
 #define BFLB_HT_CAP_HT20_SGI20 0x012CU
 
-#define BFLB_24GHZ_BASE_FREQ       2407U
-#define BFLB_24GHZ_CH14_FREQ       2484U
-#define BFLB_24GHZ_CH_SPACING      5U
 #define BFLB_DEFAULT_MAX_DBM       20
 #define BFLB_DEFAULT_BEACON_TU     100
 #define BFLB_DEFAULT_AP_CHANNEL    6
@@ -1273,9 +1271,7 @@ static int bflb_wpa_supp_get_wiphy(void *if_priv)
 			    band.wpa_supp_n_channels < WPA_SUPP_SBAND_MAX_CHANNELS;
 		     i++) {
 			uint8_t ch = country->channel24G_chan[i];
-			uint16_t freq =
-				(ch == 14) ? BFLB_24GHZ_CH14_FREQ
-					   : (BFLB_24GHZ_BASE_FREQ + ch * BFLB_24GHZ_CH_SPACING);
+			uint16_t freq = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, ch);
 
 			band.channels[band.wpa_supp_n_channels].center_frequency = freq;
 			band.channels[band.wpa_supp_n_channels].wpa_supp_max_power =
@@ -1287,7 +1283,7 @@ static int bflb_wpa_supp_get_wiphy(void *if_priv)
 		/* Default: channels 1-11 */
 		for (i = 1; i <= 11; i++) {
 			band.channels[band.wpa_supp_n_channels].center_frequency =
-				BFLB_24GHZ_BASE_FREQ + i * BFLB_24GHZ_CH_SPACING;
+				wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, i);
 			band.channels[band.wpa_supp_n_channels].wpa_supp_max_power =
 				BFLB_DEFAULT_MAX_DBM;
 			band.channels[band.wpa_supp_n_channels].ch_valid = 1;

--- a/drivers/wifi/hwsim/wifi_hwsim.c
+++ b/drivers/wifi/hwsim/wifi_hwsim.c
@@ -13,6 +13,7 @@
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/random/random.h>
 #include <string.h>
 
@@ -193,7 +194,7 @@ static int hwsim_mgmt_ap_enable(const struct device *dev, struct net_if *iface,
 
 	memcpy(radio->bssid, lla->addr, HWSIM_ETH_ALEN);
 	radio->channel = params->channel;
-	radio->freq_mhz = 2407 + (params->channel * 5);
+	radio->freq_mhz = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, params->channel);
 	radio->ssid_len = params->ssid_length;
 	memcpy(radio->ssid, params->ssid, params->ssid_length);
 	radio->security = (uint8_t)params->security;

--- a/drivers/wifi/hwsim/wifi_hwsim_medium.c
+++ b/drivers/wifi/hwsim/wifi_hwsim_medium.c
@@ -8,6 +8,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/random/random.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/net/wifi_utils.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -17,8 +18,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>
 #endif
-
-#define HWSIM_CHANNEL_TO_MHZ(ch) (2407 + ((ch) * 5))
 
 LOG_MODULE_DECLARE(wifi_hwsim, CONFIG_WIFI_HWSIM_LOG_LEVEL);
 
@@ -45,7 +44,8 @@ int hwsim_medium_register(struct hwsim_radio *radio, uint8_t idx)
 	}
 	medium.radios[idx] = radio;
 	radio->idx = idx;
-	radio->freq_mhz = HWSIM_CHANNEL_TO_MHZ(CONFIG_WIFI_HWSIM_DEFAULT_CHANNEL);
+	radio->freq_mhz =
+		wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, CONFIG_WIFI_HWSIM_DEFAULT_CHANNEL);
 	radio->tx_power_dbm = CONFIG_WIFI_HWSIM_DEFAULT_SIGNAL_DBM;
 	radio->loss_pct = 0U;
 	k_fifo_init(&radio->rx_queue);

--- a/drivers/wifi/hwsim/wifi_hwsim_supp.c
+++ b/drivers/wifi/hwsim/wifi_hwsim_supp.c
@@ -13,6 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_utils.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
@@ -344,7 +345,7 @@ static int hwsim_supp_get_scan_results2(void *if_priv)
 
 		entry->flags = 0;
 		memcpy(entry->bssid, r->bssid, ETH_ALEN);
-		entry->freq = HWSIM_2G_BASE_FREQ_MHZ + (r->channel * 5);
+		entry->freq = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, r->channel);
 		entry->max_cw = CHAN_WIDTH_20_NOHT;
 		entry->beacon_int = 100;
 		entry->qual = 0;
@@ -494,7 +495,7 @@ static int hwsim_supp_init_ap(void *if_priv,
 	} else {
 		radio->channel = 1;
 	}
-	radio->freq_mhz = HWSIM_2G_BASE_FREQ_MHZ + (radio->channel * 5);
+	radio->freq_mhz = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, radio->channel);
 	radio->ap_mode = true;
 	return 0;
 }
@@ -726,7 +727,7 @@ static int hwsim_supp_signal_poll(void *if_priv, struct wpa_signal_info *si,
 	struct hwsim_radio *radio = (struct hwsim_radio *)if_priv;
 
 	memset(si, 0, sizeof(*si));
-	si->frequency = HWSIM_2G_BASE_FREQ_MHZ + (radio->channel * 5);
+	si->frequency = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, radio->channel);
 	si->current_noise = -95;
 	si->data.last_ack_rssi = (s8)radio->tx_power_dbm;
 	if (radio->associated && bssid != NULL) {
@@ -782,7 +783,8 @@ static int hwsim_supp_get_wiphy(void *if_priv)
 	band.wpa_supp_n_bitrates = 8;
 	for (int i = 0; i < 14; i++) {
 		band.channels[i].ch_valid = 1;
-		band.channels[i].center_frequency = 2407 + (i + 1) * 5;
+		band.channels[i].center_frequency =
+			wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, i + 1);
 		band.channels[i].wpa_supp_max_power = 20;
 	}
 	/* 11b + 11g rates (100 kbps); need at least one > 200 for IEEE80211G mode */

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
+#include <zephyr/net/wifi_utils.h>
 #include <airoc_wifi.h>
 #include <airoc_whd_hal_common.h>
 #include <whd_wlioctl.h>
@@ -2416,17 +2417,6 @@ int airoc_wifi_wpa_supp_reg_mgmt_frame(void *if_priv, u16 frame_type, size_t mat
 #endif
 
 #if defined(CONFIG_WIFI_NM_WPA_SUPPLICANT)
-static inline unsigned short mhz_from_5g_channel(uint8_t ch)
-{
-	/* 5GHz channels: 36, 40, 44, 48, 149, 153, 157, 161, 165 */
-	return (unsigned short)(5000 + 5 * ch);
-}
-
-static inline unsigned short mhz_from_2g_channel(uint8_t ch)
-{
-	return (ch == 14) ? 2484 : (unsigned short)(2412 + 5 * (ch - 1));
-}
-
 static void airoc_build_band_5g_min(struct wpa_supp_event_supported_band *band)
 {
 	static const uint8_t chs[] = {36, 40, 44, 48, 149, 153, 157, 161, 165};
@@ -2439,7 +2429,8 @@ static void airoc_build_band_5g_min(struct wpa_supp_event_supported_band *band)
 
 	for (int i = 0; i < band->wpa_supp_n_channels; i++) {
 		band->channels[i].ch_valid = 1;
-		band->channels[i].center_frequency = mhz_from_5g_channel(chs[i]);
+		band->channels[i].center_frequency =
+			wifi_utils_chan_to_freq(WIFI_FREQ_BAND_5_GHZ, chs[i]);
 		band->channels[i].wpa_supp_flags = 0;
 		band->channels[i].wpa_supp_max_power = 20;
 		band->channels[i].dfs_state = 0;
@@ -2464,7 +2455,8 @@ static void airoc_build_band_2g_min(struct wpa_supp_event_supported_band *band)
 		int ch = i + 1; /* 1..11 */
 
 		band->channels[i].ch_valid = 1;
-		band->channels[i].center_frequency = mhz_from_2g_channel((uint8_t)ch);
+		band->channels[i].center_frequency =
+			wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, (uint8_t)ch);
 		band->channels[i].wpa_supp_flags = 0;
 		band->channels[i].wpa_supp_max_power = 20;
 		band->channels[i].dfs_state = 0;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -447,11 +447,7 @@ static int map_sdk_region_to_zephyr_channel_info(const sli_wifi_set_region_ap_re
 
 	for (int idx = 0; idx < *num_channels; idx++) {
 		channel = first_channel + idx;
-		freq = 2407 + channel * 5;
-
-		if (freq > 2472) {
-			freq = 2484; /* channel 14 */
-		}
+		freq = wifi_utils_chan_to_freq(WIFI_FREQ_BAND_2_4_GHZ, channel);
 
 		z_chan_info[idx].center_frequency = freq;
 		z_chan_info[idx].max_power = sdk_reg->channel_info[0].max_tx_power;

--- a/include/zephyr/net/wifi_utils.h
+++ b/include/zephyr/net/wifi_utils.h
@@ -170,6 +170,24 @@ bool wifi_utils_validate_chan_6g(uint16_t chan);
 enum wifi_frequency_bands wifi_utils_chan_to_band(uint16_t chan);
 
 /**
+ * @brief Convert a channel number to its center frequency.
+ *
+ * @details The band must be supplied because channel numbers are not unique
+ * across bands: 1-14 are valid in both the 2.4 GHz and the 6 GHz band, and the
+ * 5 GHz and 6 GHz numbering overlaps above 14. Use wifi_utils_chan_to_band()
+ * when the band is not already known.
+ *
+ * @param band Band the channel belongs to.
+ * @param chan Channel to convert.
+ *
+ * @return The center frequency in MHz.
+ * @retval 0 if the channel is not valid in the band, or the band has no
+ *           channel to frequency mapping, as is the case for
+ *           WIFI_FREQ_BAND_SUB_1_GHZ.
+ */
+uint16_t wifi_utils_chan_to_freq(enum wifi_frequency_bands band, uint16_t chan);
+
+/**
  * @}
  */
 

--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -126,6 +126,30 @@ enum wifi_frequency_bands wifi_utils_chan_to_band(uint16_t chan)
 	return WIFI_FREQ_BAND_UNKNOWN;
 }
 
+uint16_t wifi_utils_chan_to_freq(enum wifi_frequency_bands band, uint16_t chan)
+{
+	if (!wifi_utils_validate_chan(band, chan)) {
+		return 0;
+	}
+
+	switch (band) {
+	case WIFI_FREQ_BAND_2_4_GHZ:
+		/* Channel 14 is the exception to the 5 MHz spacing, it sits
+		 * 12 MHz above channel 13.
+		 */
+		return (chan == 14) ? 2484 : (2407 + chan * 5);
+	case WIFI_FREQ_BAND_5_GHZ:
+		return 5000 + chan * 5;
+	case WIFI_FREQ_BAND_6_GHZ:
+		/* Channel 2 does not follow the 5950 MHz base, it sits at
+		 * 5935 MHz on its own operating class.
+		 */
+		return (chan == 2) ? 5935 : (5950 + chan * 5);
+	default:
+		return 0;
+	}
+}
+
 /**
  * @brief Get the next Wi-Fi 6GHz channel based on the given (valid) channel.
  * The function handles the initial edge cases (1 -> 2, 2 -> 5) and then increments by 4.

--- a/tests/net/wifi/wifi_utils/src/main.c
+++ b/tests/net/wifi/wifi_utils/src/main.c
@@ -75,4 +75,72 @@ ZTEST(net_wifi_utils, test_chan_to_band_agrees_with_validators)
 	}
 }
 
+struct chan_to_freq_test {
+	enum wifi_frequency_bands band;
+	uint16_t chan;
+	uint16_t freq;
+};
+
+static const struct chan_to_freq_test chan_to_freq_tests[] = {
+	/* 2.4 GHz, including channel 14 which breaks the 5 MHz spacing. */
+	{WIFI_FREQ_BAND_2_4_GHZ, 1, 2412},
+	{WIFI_FREQ_BAND_2_4_GHZ, 13, 2472},
+	{WIFI_FREQ_BAND_2_4_GHZ, 14, 2484},
+
+	/* 5 GHz, spanning the low and high parts of the band. */
+	{WIFI_FREQ_BAND_5_GHZ, 36, 5180},
+	{WIFI_FREQ_BAND_5_GHZ, 108, 5540},
+	{WIFI_FREQ_BAND_5_GHZ, 165, 5825},
+
+	/* 6 GHz, where channel 2 is the odd one out and 233 is the top. */
+	{WIFI_FREQ_BAND_6_GHZ, 1, 5955},
+	{WIFI_FREQ_BAND_6_GHZ, 2, 5935},
+	{WIFI_FREQ_BAND_6_GHZ, 233, 7115},
+
+	/* Channels that are not valid in the band asked for. */
+	{WIFI_FREQ_BAND_2_4_GHZ, 0, 0},
+	{WIFI_FREQ_BAND_2_4_GHZ, 15, 0},
+	{WIFI_FREQ_BAND_5_GHZ, 14, 0},
+	{WIFI_FREQ_BAND_5_GHZ, 37, 0},
+	{WIFI_FREQ_BAND_6_GHZ, 234, 0},
+	{WIFI_FREQ_BAND_UNKNOWN, 1, 0},
+	{WIFI_FREQ_BAND_SUB_1_GHZ, 1, 0},
+};
+
+ZTEST(net_wifi_utils, test_chan_to_freq)
+{
+	for (int i = 0; i < ARRAY_SIZE(chan_to_freq_tests); i++) {
+		const struct chan_to_freq_test *t = &chan_to_freq_tests[i];
+
+		zexpect_equal(wifi_utils_chan_to_freq(t->band, t->chan), t->freq,
+			      "Channel %u in band %d is not %u MHz", t->chan, t->band, t->freq);
+	}
+}
+
+ZTEST(net_wifi_utils, test_chan_to_freq_agrees_with_validators)
+{
+	/* A channel that is valid in a band must produce a frequency, and one
+	 * that is not must produce none.
+	 */
+	static const enum wifi_frequency_bands bands[] = {
+		WIFI_FREQ_BAND_2_4_GHZ,
+		WIFI_FREQ_BAND_5_GHZ,
+		WIFI_FREQ_BAND_6_GHZ,
+	};
+
+	for (int i = 0; i < ARRAY_SIZE(bands); i++) {
+		for (uint16_t chan = 0; chan <= 300; chan++) {
+			uint16_t freq = wifi_utils_chan_to_freq(bands[i], chan);
+
+			if (wifi_utils_validate_chan(bands[i], chan)) {
+				zexpect_not_equal(freq, 0, "Channel %u in band %d has no frequency",
+						  chan, bands[i]);
+			} else {
+				zexpect_equal(freq, 0, "Channel %u in band %d has a frequency",
+					      chan, bands[i]);
+			}
+		}
+	}
+}
+
 ZTEST_SUITE(net_wifi_utils, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Wi-Fi drivers that report a channel list each open code the channel to center frequency arithmetic, and the copies disagree. One clamps every frequency above 2472 MHz to 2484 MHz, so it maps channel 15 and up onto channel 14, and most handle only the 2.4 GHz band. This adds wifi_utils_chan_to_freq() next to the existing channel validators so there is one place to get this right, including the channel 14 exception to the 5 MHz spacing, the 6 GHz band that none of the open coded copies cover, and the 6 GHz channel 2 special case at 5935 MHz. The band has to be supplied because channel numbers are ambiguous between bands, the same reason wifi_utils_chan_to_band() documents, and a channel that is not valid in the band returns 0 as decided by the per band validators.

