### PR TITLE
soc: st: stm32u5: wait for the regulator switch before using the new supply

### DIFF
--- a/soc/st/stm32/stm32u5x/soc.c
+++ b/soc/st/stm32/stm32u5x/soc.c
@@ -32,6 +32,44 @@ LOG_MODULE_REGISTER(soc);
 #define SELECTED_POWER_SUPPLY LL_PWR_SMPS_SUPPLY
 #endif
 
+/*
+ * Time out for the VCORE regulator switch, expressed the way ST's
+ * HAL_PWREx_ConfigSupply() expresses it: a microsecond budget scaled by the
+ * core clock into a bounded loop count. This code runs before the kernel and
+ * before any clock configuration, so no timer API is available yet.
+ */
+#define REGULATOR_SWITCH_TIMEOUT_US 50U
+
+/*
+ * RM0456 requires PWR_SVMSR.REGS to be polled after writing PWR_CR3.REGSEL:
+ * the switch is not instantaneous, and until REGS agrees with REGSEL the
+ * supply actually feeding VCORE is the previous one. Without this wait the
+ * clock driver goes straight on to raise the voltage scaling range, enable the
+ * EPOD booster and lock the PLL against a regulator that may still be in
+ * transition.
+ */
+static void stm32_wait_regulator_supply(uint32_t supply)
+{
+	uint32_t timeout =
+		((REGULATOR_SWITCH_TIMEOUT_US * (SystemCoreClock / 1000U)) / 1000U) + 1U;
+	const uint32_t expected = (supply == LL_PWR_SMPS_SUPPLY) ? 1U : 0U;
+
+	while ((LL_PWR_IsActiveFlag_REGULATOR() != expected) && (timeout != 0U)) {
+		timeout--;
+	}
+
+	if (LL_PWR_IsActiveFlag_REGULATOR() != expected) {
+		/*
+		 * The requested regulator never reported ready - on a board
+		 * wired for the LDO, or one whose SMPS network is not fitted,
+		 * SMPS can never become ready. Fall back to the LDO, which is
+		 * the reset default and always available, rather than proceed
+		 * against a supply whose state is unknown.
+		 */
+		LL_PWR_SetRegulatorSupply(LL_PWR_LDO_SUPPLY);
+	}
+}
+
 extern void stm32_power_init(void);
 /**
  * @brief Perform basic hardware initialization at boot.
@@ -73,6 +111,7 @@ void soc_early_init_hook(void)
 
 	/* Power Configuration */
 	LL_PWR_SetRegulatorSupply(SELECTED_POWER_SUPPLY);
+	stm32_wait_regulator_supply(SELECTED_POWER_SUPPLY);
 
 #if CONFIG_PM
 	stm32_power_init();


### PR DESCRIPTION
RM0456 requires PWR_SVMSR.REGS to be polled after writing PWR_CR3.REGSEL. The switch is not instantaneous, and until REGS agrees with REGSEL the supply actually feeding VCORE is the previous one. ST's own HAL does this: HAL_PWREx_ConfigSupply() sets REGSEL, spins on REGS with a timeout, and returns HAL_TIMEOUT if it never settles.

soc_early_init_hook() set REGSEL and moved straight on. It runs before PRE_KERNEL_1, so the very next code to touch the supply is the RCC driver, which raises the voltage scaling range, enables the EPOD booster and locks PLL1 - all against a regulator that may still be in transition.

On an STM32U575VIT6Q board selecting SMPS, this draws 280 mA with a hot MCU instead of the expected 15 mA. The A/B is a single image pair from the same tree, same devicetree, same configuration, differing only by this poll loop, 24 bytes of binary: without it the board overheats within seconds of boot, with it the board runs at 15.4 mA awake and 1.95-2.3 mA asleep. The supply network was verified against AN5373 first, and reading REGS from a shell seconds after boot reports SMPS either way - the failure is confined to the microseconds during which the clock driver acts.

Poll REGS with a bounded budget, expressed the way the HAL expresses it, since this runs before the kernel and no timer API is available yet. On timeout fall back to the LDO: a board wired for the LDO, or one whose SMPS network is not fitted, can never make SMPS ready, and the reset default is always available. Proceeding against an unknown supply state is worse, and a pre-kernel hook has no way to report the failure.

Fixes #118845

Assisted-by: Claude:claude-opus-5
Signed-off-by: Joel Simmons <jsimmons22250@gmail.com>