### PR TITLE
soc: arm: mps3,mps4: Increase idle stack size when USE_SWITCH=y

### DIFF
--- a/soc/arm/mps3/Kconfig
+++ b/soc/arm/mps3/Kconfig
@@ -40,3 +40,7 @@ config ARMV8_1_M_PMU_EVENTCNT
 	int
 	default 8 if SOC_CORSTONE300
 	default 8 if SOC_CORSTONE310
+
+# USE_SWITCH requires additional idle stack space on Cortex-M
+configdefault IDLE_STACK_SIZE
+	default 512 if USE_SWITCH && (SOC_CORSTONE300 || SOC_CORSTONE310)

--- a/soc/arm/mps4/Kconfig
+++ b/soc/arm/mps4/Kconfig
@@ -32,3 +32,7 @@ config ARMV8_1_M_PMU_EVENTCNT
 	int
 	default 8 if SOC_CORSTONE315
 	default 8 if SOC_CORSTONE320
+
+# USE_SWITCH requires additional idle stack space on Cortex-M
+configdefault IDLE_STACK_SIZE
+	default 512 if USE_SWITCH && (SOC_CORSTONE315 || SOC_CORSTONE320)


### PR DESCRIPTION
With USE_SWITCH=y, a context restore can be preempted by an interrupt. This interrupt may switch contexts, pushing a second stack frame on top of the frame that was part-restored.

If this frame is later restored by a cooperative
arm_m_switch call, and this restore is preempted, a third frame is pushed on top. In the `kernel.memory_protection.sys_sem` test, the stars happen to align so that the idle thread overflows its stack.

Increasing the idle stack size on Corstone targets (which AFAIK are the only ones with USE_SWITCH by default) unblocks CI. A more long term fix will be needed later.