### PR TITLE
tests: tfm: regression: exclude lpcxpresso55s69 from SFN test

### DIFF
--- a/tests/modules/tf-m/regression/tests.yaml
+++ b/tests/modules/tf-m/regression/tests.yaml
@@ -60,6 +60,7 @@ tests:
   tfm.regression.sfn:
     platform_exclude:
       - kit_pse84_eval/pse846gps2dbzc4a/m33/ns
+      - lpcxpresso55s69/lpc55s69/cpu0/ns
     filter: CONFIG_TFM_PROFILE_TYPE_SMALL or CONFIG_TFM_PROFILE_TYPE_NOT_SET
     extra_args:
       - CONFIG_TFM_SFN=y


### PR DESCRIPTION
Add lpcxpresso55s69/lpc55s69/cpu0/ns to the platform_exclude list for the tfm.regression.sfn test configuration.

The test is not applicable for this platform and should be excluded from automated execution as board supports Medium profile by default.
Addresses: https://github.com/zephyrproject-rtos/zephyr/pull/118853