### PR TITLE
FRDM-MCXL255: AON KPP support for CM33/CM0+

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -149,6 +149,11 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_kpp0))
+	CLOCK_AttachClk(kFRO16K_to_AON_KPP);
+	RESET_ReleasePeripheralReset(kAonKPP_RST_SHIFT_RSTn);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr0)) || \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr1))
 	CLOCK_AttachClk(kFROdiv4_to_AON_TMR);

--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -151,6 +151,7 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_kpp0))
 	CLOCK_AttachClk(kFRO16K_to_AON_KPP);
+	CLOCK_EnableClock(kCLOCK_GateAonKPP);
 	RESET_ReleasePeripheralReset(kAonKPP_RST_SHIFT_RSTn);
 #endif
 

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -99,7 +99,7 @@
 	pinmux_aon_kpp0: pinmux_aon_kpp0 {
 		row {
 			pinmux = <KPP_ROW_0_P0_12>,
-					<KPP_ROW_1_P0_13>;
+				 <KPP_ROW_1_P0_13>;
 			drive-strength = "low";
 			slew-rate = "fast";
 			bias-pull-up;
@@ -108,7 +108,7 @@
 
 		col {
 			pinmux = <KPP_COL_0_P0_2>,
-					<KPP_COL_1_P0_3>;
+				 <KPP_COL_1_P0_3>;
 			drive-strength = "low";
 			slew-rate = "fast";
 			drive-open-drain;

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -95,4 +95,24 @@
 			drive-open-drain;
 		};
 	};
+
+	pinmux_aon_kpp0: pinmux_aon_kpp0 {
+		row {
+			pinmux = <KPP_ROW_0_P0_12>,
+					<KPP_ROW_1_P0_13>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			bias-pull-up;
+			input-enable;
+		};
+
+		col {
+			pinmux = <KPP_COL_0_P0_2>,
+					<KPP_COL_1_P0_3>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			drive-open-drain;
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dts
@@ -12,3 +12,9 @@
 	model = "NXP FRDM_MCXL255 board";
 	compatible = "nxp,mcxl255", "nxp,mcx";
 };
+
+&aon_kpp0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_aon_kpp0>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -19,4 +19,5 @@ supported:
   - crc
   - watchdog
   - mbox
+  - input
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -53,3 +53,9 @@
 &mbox_b {
 	status = "okay";
 };
+
+&aon_kpp0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_aon_kpp0>;
+	pinctrl-names = "default";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -15,4 +15,5 @@ supported:
   - i2c
   - mbox
   - rtc
+  - input
 vendor: nxp

--- a/drivers/input/input_mcux_kpp.c
+++ b/drivers/input/input_mcux_kpp.c
@@ -20,7 +20,6 @@ LOG_MODULE_REGISTER(kpp, CONFIG_INPUT_LOG_LEVEL);
 
 #define INPUT_KPP_COLUMNNUM_MAX  KPP_KEYPAD_COLUMNNUM_MAX
 #define INPUT_KPP_ROWNUM_MAX     KPP_KEYPAD_ROWNUM_MAX
-#define INPUT_KPP_ROWNUM_MAX     KPP_KEYPAD_ROWNUM_MAX
 
 struct kpp_config {
 	KPP_Type *base;
@@ -176,26 +175,25 @@ static int input_kpp_init(const struct device *dev)
 	return 0;
 }
 
-#define INPUT_KPP_INIT(n)                                                               \
-	static struct kpp_data kpp_data_##n;                                            \
-                                                                                        \
-	PINCTRL_DT_INST_DEFINE(n);                                                      \
-                                                                                        \
-	static const struct kpp_config kpp_config_##n = {                               \
-		.base = (KPP_Type *)DT_INST_REG_ADDR(n),                                \
-		.clk_sub_sys =                                                          \
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(n, 0, name),	\
-		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                       \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                              \
-	};                                                                              \
-                                                                                        \
-	DEVICE_DT_INST_DEFINE(n,                                                        \
-			      input_kpp_init,                                           \
-			      NULL,                                                     \
-			      &kpp_data_##n,                                            \
-			      &kpp_config_##n,                                          \
-			      POST_KERNEL,                                              \
-			      CONFIG_INPUT_INIT_PRIORITY,                               \
-			      NULL);
+#define INPUT_KPP_CLK_SUBSYS(n)                                                                    \
+	COND_CODE_1(                            \
+		DT_PHA_HAS_CELL_AT_IDX(DT_DRV_INST(n), clocks, 0, name),    \
+		((clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(n, 0, name)), \
+		((clock_control_subsys_t)0))
+
+#define INPUT_KPP_INIT(n)                                                                          \
+	static struct kpp_data kpp_data_##n;                                                       \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+                                                                                                   \
+	static const struct kpp_config kpp_config_##n = {                                          \
+		.base = (KPP_Type *)DT_INST_REG_ADDR(n),                                           \
+		.clk_sub_sys = INPUT_KPP_CLK_SUBSYS(n),                                            \
+		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                  \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, input_kpp_init, NULL, &kpp_data_##n, &kpp_config_##n,             \
+			      POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY, NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(INPUT_KPP_INIT)

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
@@ -122,3 +122,19 @@
 &aon_lpuart0 {
 	interrupts = <130 0>;
 };
+
+&aon_peripheral {
+	aon_kpp_clock: aon-kpp-clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <16384>;
+	};
+
+	aon_kpp0: kpp@95000 {
+		compatible = "nxp,mcux-kpp";
+		reg = <0x95000 0x1000>;
+		interrupts = <148 0>;
+		clocks = <&aon_kpp_clock>;
+		status = "disabled";
+	};
+};

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl255_cm33.dtsi
@@ -123,18 +123,6 @@
 	interrupts = <130 0>;
 };
 
-&aon_peripheral {
-	aon_kpp_clock: aon-kpp-clock {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <16384>;
-	};
-
-	aon_kpp0: kpp@95000 {
-		compatible = "nxp,mcux-kpp";
-		reg = <0x95000 0x1000>;
-		interrupts = <148 0>;
-		clocks = <&aon_kpp_clock>;
-		status = "disabled";
-	};
+&aon_kpp0 {
+	interrupts = <148 0>;
 };

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl_aon.dtsi
@@ -165,3 +165,19 @@
 		#size-cells = <0>;
 	};
 };
+
+&aon_peripheral {
+	kpp_clock: kpp-clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <16384>;
+	};
+
+	aon_kpp0: kpp@95000 {
+		compatible = "nxp,mcux-kpp";
+		reg = <0x95000 0x1000>;
+		interrupts = <21 0>;
+		clocks = <&kpp_clock>;
+		status = "disabled";
+	};
+};


### PR DESCRIPTION
Add AON KPP support for the FRDM-MCXL255 board targets.

This PR adds the MCXL255 AON KPP devicetree node, models the KPP
input clock as a fixed-clock provider, and enables the KPP instance for
the FRDM-MCXL255 CPU0 and CPU1 board targets.

The fixed-clock provider is used so the KPP driver can be used from the
CM0+ AON CPU build without relying on the syscon clock provider. The CM33
interrupt number is kept as a SoC-specific override.

The MCUX KPP input driver is also updated to support clock providers
without a named clock cell, while preserving the previous behavior for
existing users with named clock cells.

Tested with:

- `samples/subsys/input/input_dump` on `frdm_mcxl255/mcxl255/cpu0`
- `samples/subsys/input/input_dump` on `frdm_mcxl255/mcxl255/cpu1`