### PR TITLE
drivers: pinctrl: nRF add VPR VIO support

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -6,6 +6,8 @@ config NORDIC_VPR_LAUNCHER
 	default y
 	depends on DT_HAS_NORDIC_NRF_VPR_COPROCESSOR_ENABLED && \
 		   $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),execution-memory)
+	select PINCTRL if \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),pinctrl-0)
 	help
 	  When enabled, the VPR coprocessors will be automatically launched
 	  during system initialization.

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -13,6 +13,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
 #include <hal/nrf_vpr.h>
 #if (DT_ANY_INST_HAS_BOOL_STATUS_OKAY(enable_secure) || \
@@ -38,6 +41,9 @@ struct nordic_vpr_launcher_config {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
 	int32_t ram_block_id;
 #endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 /* Determine if all code that will be copied is 8 byte aligned. If yes then optimized
@@ -58,6 +64,18 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	if (config->exec_addr == 0) {
 		return 0;
 	}
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	/* Apply the pin configuration (routing, drive, pull) for VPR-owned pins. */
+	if (config->pcfg != NULL) {
+		int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state (%d)", ret);
+			return ret;
+		}
+	}
+#endif
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	if (config->size > 0U) {
@@ -123,6 +141,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
 				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0), (PINCTRL_DT_INST_DEFINE(inst);))        \
+                                                                                                   \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
@@ -134,6 +154,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))        \
 		IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block),                \
 			   (.ram_block_id = DT_INST_PROP_OR(inst, hibernation_ram_block, -1),))    \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
+			   (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),))                        \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -110,6 +110,16 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
+#if DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
+#if NRF_GPIO_HAS_SEL
+#define NRF_PSEL_VPR_VIO(psel) \
+	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
+#else
+/* Pin routing is controlled by the secure domain, via UICR. */
+#define NRF_PSEL_VPR_VIO(psel)
+#endif
+#endif /* DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0) */
+
 #if NRF_GPIO_HAS_RETENTION_SETCLEAR
 
 static void port_pin_retain_set(uint16_t pin_number, bool enable)
@@ -499,6 +509,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_mspi) */
+#if defined(NRF_PSEL_VPR_VIO)
+		case NRF_FUN_VPR_VIO:
+			NRF_PSEL_VPR_VIO(psel);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
+			break;
+#endif /* defined(NRF_PSEL_VPR_VIO) */
 #if defined(NRF_PSEL_TWIS)
 		case NRF_FUN_TWIS_SCL:
 			NRF_PSEL_TWIS(reg, SCL) = psel;

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -184,6 +184,8 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
+/** VPR VIO (pin controlled by a VPR through its VIO interface) */
+#define NRF_FUN_VPR_VIO          57U
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */


### PR DESCRIPTION
drivers: misc: nordic_vpr_launcher: apply pinctrl from devicetree
    
    Apply VPR VIO pin configurations from devicetree. This allows configuring
    the drive strength for the VPR VIO pins from devicetree on the app core in
    the same way as other peripherals. The VPR core accesses this pin using
    its VIO number and doesn't need to configure the pin through GPIO
    registers.

drivers: pinctrl: nrf: add VPR VIO pin function
    
    Add a generic NRF_FUN_VPR_VIO pinctrl function so that a pin can be
    assigned to a VPR core and driven directly through its VIO interface.
    
    Where the local core can select pin routing (NRF_GPIO_HAS_SEL) the pin is
    routed to the VPR here; otherwise routing is controlled by the secure
    domain via UICR and no action is needed at configure time.