### PR TITLE
drivers: usb: uhc_dwc2: bound a control IN data stage by its buffer

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -721,7 +721,8 @@ static inline void ch_process_control(struct uhc_dwc2_channel *ch)
 			 * for OUT - xfer->buf->len
 			 */
 			if (next_dir_is_in) {
-				size = sys_le16_to_cpu(setup->wLength);
+				size = MIN(sys_le16_to_cpu(setup->wLength),
+					   net_buf_tailroom(xfer->buf));
 
 				LOG_DBG("Control DATA IN prog=%u, tailroom=%zu",
 					size, net_buf_tailroom(xfer->buf));


### PR DESCRIPTION
The data stage programs the transfer size from the setup packet's wLength alone and points DMA at the buffer's tail, so a buffer with less room than the request asks for is written past its end. The note above the code already gives both wLength and the tailroom as the bounds.

Take the smaller of the two. The host stack allocates a buffer of exactly wLength, so its own requests are unaffected.
