### PR TITLE
drivers serial uart_nrfx_uarte: Set frametimeout config when needed

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -689,6 +689,8 @@ static int uarte_nrfx_configure(const struct device *dev,
 
 #ifdef UARTE_HAS_FRAME_TIMEOUT
 	uarte_cfg.frame_timeout = NRF_UARTE_FRAME_TIMEOUT_EN;
+#elif NRF_UARTE_HAS_FRAME_TIMEOUT
+	uarte_cfg.frame_timeout = NRF_UARTE_FRAME_TIMEOUT_DIS;
 #endif
 
 #if NRF_UARTE_HAS_FRAME_SIZE


### PR DESCRIPTION
Even if the driver does not support the frame timeout configuration due to DT configuration, if the HW peripheral does, we need to set the frame_timeout configuration to disabled. Otherwise the value is just random garbage which corrupts the whole uart configuration as it will be OR'ed with the rest.