### PR TITLE
net: ocpp: NUL-terminate remaining strncpy destinations

### DIFF
--- a/subsys/net/lib/ocpp/core.c
+++ b/subsys/net/lib/ocpp/core.c
@@ -212,7 +212,8 @@ int ocpp_authorize(ocpp_session_handle_t hndl, char *idtag,
 		}
 	}
 
-	strncpy(sh->idtag, idtag, sizeof(sh->idtag));
+	strncpy(sh->idtag, idtag, sizeof(sh->idtag) - 1);
+	sh->idtag[sizeof(sh->idtag) - 1] = '\0';
 	ui = &ctx->ui;
 	fn = ctx->cfn[PDU_AUTHORIZE];
 	ret = fn(buf, sizeof(buf), sh);

--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -568,12 +568,14 @@ static int parse_idtag_info(char *json, struct ocpp_idtag_info *idtag_info)
 
 	if (parsed.json_id_tag_info.parent_id_tag != NULL) {
 		strncpy(idtag_info->p_idtag, parsed.json_id_tag_info.parent_id_tag,
-			sizeof(idtag_info->p_idtag));
+			sizeof(idtag_info->p_idtag) - 1);
+		idtag_info->p_idtag[sizeof(idtag_info->p_idtag) - 1] = '\0';
 	}
 
 	if (parsed.json_id_tag_info.expiry_date != NULL) {
 		strncpy(idtag_info->exptime, parsed.json_id_tag_info.expiry_date,
-			sizeof(idtag_info->exptime));
+			sizeof(idtag_info->exptime) - 1);
+		idtag_info->exptime[sizeof(idtag_info->exptime) - 1] = '\0';
 	}
 
 	return 0;
@@ -744,8 +746,10 @@ static int parse_changeconfig_msg(char *json, char *key, char *val)
 		return -EINVAL;
 	}
 
-	strncpy(key, payload.val1, CISTR50);
-	strncpy(val, payload.val2, CISTR500);
+	strncpy(key, payload.val1, CISTR50 - 1);
+	key[CISTR50 - 1] = '\0';
+	strncpy(val, payload.val2, CISTR500 - 1);
+	val[CISTR500 - 1] = '\0';
 
 	return 0;
 }


### PR DESCRIPTION
Four places were copying data to fixed-size buffers using the full buffer size as the strncpy bound, so a source string at least as long as the destination left it without a terminator:

- ocpp_authorize() copying idtag into sh->idtag
- parse_idtag_info() copying parent_id_tag and expiry_date
- parse_changeconfig_msg() copying the key and value payloads

Bound each copy at size - 1 and set the last byte to '\0', matching the fix already applied to parse_remote_start_txn_msg().