### PR TITLE
tests: benchmarks: thread_metric: raise a real interrupt where possible

### DIFF
--- a/tests/benchmarks/thread_metric/Kconfig
+++ b/tests/benchmarks/thread_metric/Kconfig
@@ -28,8 +28,9 @@ config TM_COOPERATIVE
 
 config TM_INTERRUPT
 	bool "Interrupt processing"
+	depends on ARCH_HAS_IRQ_PENDING_OPS && GEN_SW_ISR_TABLE_ARRAY
 	select TEST
-	select IRQ_OFFLOAD
+	select DYNAMIC_INTERRUPTS
 	help
 	  The interrupt processing benchmark has a single thread that causes
 	  an interrupt which results in its ISR incrementing a counter and then
@@ -39,8 +40,9 @@ config TM_INTERRUPT
 
 config TM_INTERRUPT_PREEMPTION
 	bool "Interrupt processing preemption"
+	depends on ARCH_HAS_IRQ_PENDING_OPS && GEN_SW_ISR_TABLE_ARRAY
 	select TEST
-	select IRQ_OFFLOAD
+	select DYNAMIC_INTERRUPTS
 	help
 	  The interrupt preemption benchmark counts the number of times that
 	  an ISR from a software generated interrupt results in the preemption

--- a/tests/benchmarks/thread_metric/src/tm_porting_layer_zephyr.c
+++ b/tests/benchmarks/thread_metric/src/tm_porting_layer_zephyr.c
@@ -24,6 +24,10 @@
 #include "tm_api.h"
 
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/irq.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/sys/barrier.h>
 
 #define TM_TEST_NUM_THREADS        10
 #define TM_TEST_STACK_SIZE         1024
@@ -175,13 +179,56 @@ int tm_semaphore_put(int semaphore_id)
 	return TM_SUCCESS;
 }
 
+#if defined(CONFIG_TM_INTERRUPT) || defined(CONFIG_TM_INTERRUPT_PREEMPTION)
+
 /* This function is defined by the benchmark. */
-extern void tm_interrupt_handler(const void *);
+extern void tm_interrupt_handler(const void *arg);
+
+/* These scenarios need an interrupt that can preempt the thread raising it,
+ * which means a real interrupt line.
+ */
+static int tm_irq_line = -1;
+
+static void tm_irq_dispatch(const void *arg)
+{
+	tm_interrupt_handler(arg);
+}
+
+/* Claim any line the platform left unconnected. */
+static int tm_interrupt_line_claim(void)
+{
+	for (int i = CONFIG_NUM_IRQS - 1; i >= 0; i--) {
+		if (_sw_isr_table[i].isr != z_irq_spurious) {
+			continue;
+		}
+
+		if (irq_connect_dynamic(i, 0, tm_irq_dispatch, NULL, 0) < 0) {
+			continue;
+		}
+
+		irq_enable(i);
+		tm_irq_line = i;
+		return 0;
+	}
+
+	return -ENODEV;
+}
+SYS_INIT(tm_interrupt_line_claim, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 void tm_cause_interrupt(void)
 {
-	irq_offload(tm_interrupt_handler, NULL);
+	__ASSERT(tm_irq_line >= 0, "no spare interrupt line to claim");
+
+	k_irq_set_pending((unsigned int)tm_irq_line);
+
+	/* Make sure the line is latched and taken before we return, rather
+	 * than some way into the caller's next iteration.
+	 */
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
 }
+
+#endif /* CONFIG_TM_INTERRUPT || CONFIG_TM_INTERRUPT_PREEMPTION */
 
 /*
  * This function creates the specified memory pool that can support one or more

--- a/tests/benchmarks/thread_metric/tests.yaml
+++ b/tests/benchmarks/thread_metric/tests.yaml
@@ -47,10 +47,12 @@ tests:
 
   benchmark.thread_metric.interrupt:
     min_ram: 24
+    filter: CONFIG_ARCH_HAS_IRQ_PENDING_OPS and CONFIG_GEN_SW_ISR_TABLE_ARRAY
     extra_configs:
       - CONFIG_TM_INTERRUPT=y
 
   benchmark.thread_metric.interrupt_preemption:
+    filter: CONFIG_ARCH_HAS_IRQ_PENDING_OPS and CONFIG_GEN_SW_ISR_TABLE_ARRAY
     extra_configs:
       - CONFIG_TM_INTERRUPT_PREEMPTION=y
 


### PR DESCRIPTION
## Problem

`arch_irq_offload()` holds the scheduler lock across the trap it raises. With the scheduler locked, `ready_q.cache` cannot diverge from `_current`, so an interrupt delivered that way cannot preempt the thread that caused it — the switch is deferred to `k_sched_unlock()` and taken as an ordinary cooperative switch.

Thread-Metric defines the preemption test as one whose *"interrupt handler ... resumes a higher priority thread, which causes thread preemption"*. Recording inside the handler whether a preemption was actually pending when it returned, over one 30 s period on an MXChip AZ3166 (STM32F412, Cortex-M4F):

| delivery | ISR invocations that could preempt |
|---|---|
| `irq_offload()` | 0 of 3920393 |
| real IRQ line | 5830926 of 5830926 |

Instrumented build, so these don't line up with the throughput numbers below — the ratio is the point.

So `benchmark.thread_metric.interrupt_preemption` has not been measuring what it is named for, on any architecture, and neither interrupt scenario ever reaches the interrupt-exit switch path.

## Change

Claim a spare interrupt line at init — scanning the software ISR table from the top for an entry still pointing at `z_irq_spurious` — and latch it with `k_irq_set_pending()`. No per-board configuration needed (but maybe we should make it a build time config?)

Both scenarios now `depend on ARCH_HAS_IRQ_PENDING_OPS && GEN_SW_ISR_TABLE_ARRAY` and `select DYNAMIC_INTERRUPTS` in place of `select IRQ_OFFLOAD`, so platforms that cannot raise a real interrupt simply do not offer these tests. There is deliberately no `irq_offload()` fallback: it would quietly go on measuring the wrong thing.

## Impact on scores

Scores move both because preemption now happens and because `irq_offload()`'s lock and trap are no longer being measured. Same board, `CONFIG_USE_SWITCH=n`, operations/second:

| scenario | before | after |
|---|---|---|
| interrupt_preemption | 145452 | 209648 |
| interrupt | 260166 | 533593 |

## Testing

Both interrupt scenarios built and run on AZ3166 hardware. Remaining scenarios built on qemu_x86 and qemu_riscv32 to confirm the guard keeps them portable to architectures without the pending-state operations.