### PR TITLE
drivers: can: reject wrongly sized RX message queues

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -109,6 +109,8 @@ static void can_msgq_put(const struct device *dev, struct can_frame *frame, void
 	ARG_UNUSED(dev);
 
 	__ASSERT_NO_MSG(msgq);
+	/* k_msgq_put() copies msgq->msg_size bytes from the frame */
+	__ASSERT_NO_MSG(msgq->msg_size == sizeof(struct can_frame));
 
 	ret = k_msgq_put(msgq, frame, K_NO_WAIT);
 	if (ret) {
@@ -119,6 +121,11 @@ static void can_msgq_put(const struct device *dev, struct can_frame *frame, void
 int z_impl_can_add_rx_filter_msgq(const struct device *dev, struct k_msgq *msgq,
 				  const struct can_filter *filter)
 {
+	if (msgq->msg_size != sizeof(struct can_frame)) {
+		LOG_ERR("msgq %p message size %zu, expected %zu", msgq, msgq->msg_size,
+			sizeof(struct can_frame));
+		return -EINVAL;
+	}
 
 	return DEVICE_API_GET(can, dev)->add_rx_filter(dev, can_msgq_put, msgq, filter);
 }

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1401,7 +1401,9 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
  * The same message queue can be used for multiple filters.
  *
  * @note The message queue must be initialized before calling this function and
- * the caller must have appropriate permissions on it.
+ * the caller must have appropriate permissions on it. Its message size must
+ * equal @c sizeof(struct can_frame); use @a CAN_MSGQ_DEFINE() to get this
+ * right.
  *
  * @warning The CAN controller driver retains the message queue pointer for as
  * long as the filter is installed. The message queue must therefore remain
@@ -1422,7 +1424,8 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
  *
  * @retval filter_id on success.
  * @retval -ENOSPC if there are no free filters.
- * @retval -EINVAL if the requested filter type is invalid.
+ * @retval -EINVAL if the requested filter type is invalid or if the message
+ *                 queue message size differs from @c sizeof(struct can_frame).
  * @retval -ENOTSUP if the requested filter type is not supported.
  * @retval -EIO General input/output error, failed to add filter.
  */

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -11,6 +11,11 @@
 
 #include "common.h"
 
+/* Message queue with a deliberately wrong element size, see
+ * test_add_rx_filter_msgq_wrong_msg_size().
+ */
+K_MSGQ_DEFINE(wide_msgq, sizeof(struct can_frame) + 16, 5, 4);
+
 /**
  * @addtogroup t_can_driver
  * @{
@@ -762,6 +767,23 @@ ZTEST_USER(can_classic, test_add_rx_filter_msgq_dynamic)
 }
 
 /**
+ * @brief Test that a message queue with a wrong message size is rejected.
+ *
+ * The RX callback passes a pointer to a single struct can_frame to k_msgq_put(),
+ * which copies the number of bytes the message queue was initialized with. A
+ * message queue with a larger message size makes the copy read past the end of
+ * the frame, into whatever the driver happens to have on its stack next to it.
+ */
+ZTEST_USER(can_classic, test_add_rx_filter_msgq_wrong_msg_size)
+{
+	int err;
+
+	err = can_add_rx_filter_msgq(can_dev, &wide_msgq, &test_std_filter_1);
+	zassert_equal(err, -EINVAL, "message queue with wrong message size accepted (err %d)",
+		      err);
+}
+
+/**
  * @brief Test that no message is received when nothing was sent.
  */
 ZTEST_USER(can_classic, test_receive_timeout)
@@ -1399,6 +1421,8 @@ ZTEST_USER(can_classic, test_set_mode_while_started)
 
 void *can_classic_setup(void)
 {
+	k_object_access_grant(&wide_msgq, k_current_get());
+
 	can_common_test_setup(CAN_MODE_LOOPBACK);
 
 	return NULL;


### PR DESCRIPTION
`can_add_rx_filter_msgq()` never checked the message queue's message size, so a
queue wider than `struct can_frame` made `k_msgq_put()` copy past the end of the
frame and into the driver's stack. Reject anything other than
`sizeof(struct can_frame)` with `-EINVAL` at registration, in the implementation
so supervisor callers are covered too.