### PR TITLE
drivers: modem: fix ST87MXX context type

### DIFF
--- a/drivers/modem/vendor_standalone/st87mxx/st87mxx.c
+++ b/drivers/modem/vendor_standalone/st87mxx/st87mxx.c
@@ -63,7 +63,7 @@ typedef enum  {
  * Static Data for ST87MXX
  */
 struct st87mxx_register {
-	struct mdm_receiver_context *mctx;
+	struct modem_context *mctx;
 	struct gpio_dt_spec *reset_gpio;
 	struct gpio_dt_spec *ring_gpio;
 };
@@ -895,7 +895,7 @@ static int modem_init(const struct device *dev)
 
 	struct st87mxx_register reg;
 
-	reg.mctx = (struct mdm_receiver_context *)&mctx;
+	reg.mctx = &mctx;
 	reg.reset_gpio = (struct gpio_dt_spec *)(&reset_gpio);
 	reg.ring_gpio = (struct gpio_dt_spec *)(&ring_gpio);
 	st87mxx_init(&reg);

--- a/drivers/modem/vendor_standalone/st87mxx/st87mxx.h
+++ b/drivers/modem/vendor_standalone/st87mxx/st87mxx.h
@@ -179,7 +179,7 @@ struct st87mxx_data {
 
 	int current_sock_written;
 
-	struct mdm_receiver_context *mctx;
+	struct modem_context *mctx;
 	struct gpio_dt_spec *reset_gpio;
 	struct gpio_dt_spec *ring_gpio;
 


### PR DESCRIPTION
Store the modem context using its actual type so future accesses through the registration data remain type-correct. Remove the incompatible cast.

Fixes #113551

Assisted-by: Codex:gpt-5