### PR TITLE
drivers: gpio: mcp23xxx: use the chip's interrupt features

### DIFF
--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -11,6 +11,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/byteorder.h>
@@ -24,37 +25,35 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_mcp230xx);
 
-static int mcp230xx_read_port_regs(const struct device *dev, uint8_t reg, uint16_t *buf)
+static int mcp230xx_read_regs(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len)
 {
 	const struct mcp23xxx_config *config = dev->config;
-	uint16_t port_data = 0;
 	int ret;
 
-	uint8_t nread = (config->ngpios == 8) ? 1 : 2;
-
-	ret = i2c_burst_read_dt(&config->bus.i2c, reg, (uint8_t *)&port_data, nread);
+	ret = i2c_burst_read_dt(&config->bus.i2c, reg, buf, len);
 	if (ret < 0) {
 		LOG_ERR("i2c_read failed!");
 		return ret;
 	}
 
-	*buf = sys_le16_to_cpu(port_data);
-
 	return 0;
 }
 
-static int mcp230xx_write_port_regs(const struct device *dev, uint8_t reg, uint16_t value)
+static int mcp230xx_write_regs(const struct device *dev, uint8_t reg, const uint8_t *buf,
+			       size_t len)
 {
 	const struct mcp23xxx_config *config = dev->config;
+	uint8_t tx[1 + MCP23XXX_MAX_BURST];
 	int ret;
 
-	uint8_t nwrite = (config->ngpios == 8) ? 2 : 3;
-	uint8_t buf[3];
+	if (len > MCP23XXX_MAX_BURST) {
+		return -EINVAL;
+	}
 
-	buf[0] = reg;
-	sys_put_le16(value, &buf[1]);
+	tx[0] = reg;
+	memcpy(&tx[1], buf, len);
 
-	ret = i2c_write_dt(&config->bus.i2c, buf, nwrite);
+	ret = i2c_write_dt(&config->bus.i2c, tx, 1 + len);
 	if (ret < 0) {
 		LOG_ERR("i2c_write failed!");
 		return ret;
@@ -92,8 +91,8 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                    \
 		.ngpios =  num_gpios,                                                              \
 		.is_open_drain = open_drain,                                                       \
-		.read_fn = mcp230xx_read_port_regs,                                                \
-		.write_fn = mcp230xx_write_port_regs,                                              \
+		.read_fn = mcp230xx_read_regs,                                                     \
+		.write_fn = mcp230xx_write_regs,                                                   \
 		.bus_fn = mcp230xx_bus_is_ready,                                                   \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp##model##_##inst##_drvdata,      \

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -91,6 +91,7 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                    \
 		.ngpios =  num_gpios,                                                              \
 		.is_open_drain = open_drain,                                                       \
+		.int_open_drain = DT_INST_PROP(inst, int_open_drain),                              \
 		.read_fn = mcp230xx_read_regs,                                                     \
 		.write_fn = mcp230xx_write_regs,                                                   \
 		.bus_fn = mcp230xx_bus_is_ready,                                                   \

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -88,6 +88,7 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 			.i2c = I2C_DT_SPEC_INST_GET(inst),                                         \
 		},                                                                                 \
 		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),                        \
+		.gpio_intb = MCP23XXX_INTB_DT_SPEC_INST_GET(inst),                                 \
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                    \
 		.ngpios =  num_gpios,                                                              \
 		.is_open_drain = open_drain,                                                       \

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -11,6 +11,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/sys/byteorder.h>
@@ -24,21 +25,20 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_mcp23sxx);
 
-static int mcp23sxx_read_port_regs(const struct device *dev, uint8_t reg, uint16_t *buf)
+static int mcp23sxx_read_regs(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len)
 {
 	const struct mcp23xxx_config *config = dev->config;
-	uint16_t port_data = 0;
+	uint8_t buffer_tx[2 + MCP23XXX_MAX_BURST] = {MCP23SXX_ADDR | MCP23SXX_READBIT, reg};
+	uint8_t buffer_rx[2 + MCP23XXX_MAX_BURST];
 	int ret;
 
-	uint8_t nread = (config->ngpios == 8) ? 1 : 2;
-
-	uint8_t addr = MCP23SXX_ADDR | MCP23SXX_READBIT;
-	uint8_t buffer_tx[4] = { addr, reg, 0, 0 };
-	uint8_t buffer_rx[4] = { 0 };
+	if (len > MCP23XXX_MAX_BURST) {
+		return -EINVAL;
+	}
 
 	const struct spi_buf tx_buf = {
 		.buf = buffer_tx,
-		.len = 4,
+		.len = 2 + len,
 	};
 	const struct spi_buf_set tx = {
 		.buffers = &tx_buf,
@@ -46,7 +46,7 @@ static int mcp23sxx_read_port_regs(const struct device *dev, uint8_t reg, uint16
 	};
 	const struct spi_buf rx_buf = {
 		.buf = buffer_rx,
-		.len = 2 + nread,
+		.len = 2 + len,
 	};
 	const struct spi_buf_set rx = {
 		.buffers = &rx_buf,
@@ -59,37 +59,31 @@ static int mcp23sxx_read_port_regs(const struct device *dev, uint8_t reg, uint16
 		return ret;
 	}
 
-	port_data = ((uint16_t)buffer_rx[3] << 8 | buffer_rx[2]);
-
-	*buf = sys_le16_to_cpu(port_data);
+	memcpy(buf, &buffer_rx[2], len);
 
 	return 0;
 }
 
-static int mcp23sxx_write_port_regs(const struct device *dev, uint8_t reg, uint16_t value)
+static int mcp23sxx_write_regs(const struct device *dev, uint8_t reg, const uint8_t *buf,
+			       size_t len)
 {
 	const struct mcp23xxx_config *config = dev->config;
+	uint8_t buffer_tx[2 + MCP23XXX_MAX_BURST] = {MCP23SXX_ADDR, reg};
 	int ret;
 
-	uint8_t nwrite = (config->ngpios == 8) ? 1 : 2;
-	uint16_t port_data = sys_cpu_to_le16(value);
-	uint8_t port_a_data = port_data & 0xFF;
-	uint8_t port_b_data = (port_data >> 8) & 0xFF;
+	if (len > MCP23XXX_MAX_BURST) {
+		return -EINVAL;
+	}
 
-	port_data = sys_cpu_to_le16(value);
+	memcpy(&buffer_tx[2], buf, len);
 
-	uint8_t addr = MCP23SXX_ADDR;
-	uint8_t buffer_tx[4] = { addr, reg, port_a_data, port_b_data };
-
-	const struct spi_buf tx_buf[1] = {
-		{
-			.buf = buffer_tx,
-			.len = nwrite + 2,
-		}
+	const struct spi_buf tx_buf = {
+		.buf = buffer_tx,
+		.len = 2 + len,
 	};
 	const struct spi_buf_set tx = {
-		.buffers = tx_buf,
-		.count = ARRAY_SIZE(tx_buf),
+		.buffers = &tx_buf,
+		.count = 1,
 	};
 
 	ret = spi_write_dt(&config->bus.spi, &tx);
@@ -132,8 +126,8 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),               \
 		.ngpios =  num_gpios,				                              \
 		.is_open_drain = open_drain,                                                  \
-		.read_fn = mcp23sxx_read_port_regs,                                           \
-		.write_fn = mcp23sxx_write_port_regs,                                         \
+		.read_fn = mcp23sxx_read_regs,                                                \
+		.write_fn = mcp23sxx_write_regs,                                              \
 		.bus_fn = mcp23sxx_bus_is_ready                                               \
 	};                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, gpio_mcp23xxx_init, NULL, &mcp##model##_##inst##_drvdata, \

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -123,6 +123,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 				SPI_MODE_CPHA | SPI_WORD_SET(8))                              \
 		},                                                                            \
 		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),                   \
+		.gpio_intb = MCP23XXX_INTB_DT_SPEC_INST_GET(inst),                            \
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),               \
 		.ngpios =  num_gpios,				                              \
 		.is_open_drain = open_drain,                                                  \

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -126,6 +126,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 		.gpio_reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),               \
 		.ngpios =  num_gpios,				                              \
 		.is_open_drain = open_drain,                                                  \
+		.int_open_drain = DT_INST_PROP(inst, int_open_drain),                         \
 		.read_fn = mcp23sxx_read_regs,                                                \
 		.write_fn = mcp23sxx_write_regs,                                              \
 		.bus_fn = mcp23sxx_bus_is_ready                                               \

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -614,14 +614,24 @@ int gpio_mcp23xxx_init(const struct device *dev)
 
 	/* If the INT line is available, configure the callback for it. */
 	if (config->gpio_int.port) {
+		uint8_t iocon = 0;
+
 		if (config->ngpios == 16) {
 			/* send both ports' interrupts through one IRQ pin */
-			err = write_iocon(dev, REG_IOCON_MIRROR);
+			iocon |= REG_IOCON_MIRROR;
+		}
 
-			if (err != 0) {
-				LOG_ERR("Failed to enable mirrored IRQ pins: %d", err);
-				return -EIO;
-			}
+		if (config->is_open_drain) {
+			/* The MCP23x09/x18 default to clearing the interrupt on a GPIO
+			 * read; this driver acknowledges by reading INTCAP.
+			 */
+			iocon |= REG_IOCON_INTCC;
+		}
+
+		err = write_iocon(dev, iocon);
+		if (err != 0) {
+			LOG_ERR("Failed to configure IOCON: %d", err);
+			return -EIO;
 		}
 
 		if (!gpio_is_ready_dt(&config->gpio_int)) {

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -546,7 +546,8 @@ static void mcp23xxx_work_handler(struct k_work *work)
 	 * during a level interrupt. Submitting instead of looping lets other work
 	 * items run in between.
 	 */
-	if (gpio_pin_get_dt(&config->gpio_int) > 0) {
+	if (gpio_pin_get_dt(&config->gpio_int) > 0 ||
+	    (config->gpio_intb.port && gpio_pin_get_dt(&config->gpio_intb) > 0)) {
 		k_work_submit(work);
 	}
 }
@@ -558,6 +559,50 @@ static void mcp23xxx_int_gpio_handler(const struct device *port, struct gpio_cal
 		CONTAINER_OF(cb, struct mcp23xxx_drv_data, int_gpio_cb);
 
 	k_work_submit(&drv_data->work);
+}
+
+static void mcp23xxx_intb_gpio_handler(const struct device *port, struct gpio_callback *cb,
+				       gpio_port_pins_t pins)
+{
+	struct mcp23xxx_drv_data *drv_data =
+		CONTAINER_OF(cb, struct mcp23xxx_drv_data, intb_gpio_cb);
+
+	k_work_submit(&drv_data->work);
+}
+
+/**
+ * @brief Connect one INT line to the given callback.
+ */
+static int setup_int_line(const struct gpio_dt_spec *spec, struct gpio_callback *cb,
+			  gpio_callback_handler_t handler)
+{
+	int err;
+
+	if (!gpio_is_ready_dt(spec)) {
+		LOG_ERR("INT port is not ready");
+		return -ENODEV;
+	}
+
+	err = gpio_pin_configure_dt(spec, GPIO_INPUT);
+	if (err != 0) {
+		LOG_ERR("Failed to configure INT line: %d", err);
+		return -EIO;
+	}
+
+	gpio_init_callback(cb, handler, BIT(spec->pin));
+	err = gpio_add_callback(spec->port, cb);
+	if (err != 0) {
+		LOG_ERR("Failed to add INT callback: %d", err);
+		return -EIO;
+	}
+
+	err = gpio_pin_interrupt_configure_dt(spec, GPIO_INT_EDGE_TO_ACTIVE);
+	if (err != 0) {
+		LOG_ERR("Failed to configure INT interrupt: %d", err);
+		return -EIO;
+	}
+
+	return 0;
 }
 
 DEVICE_API(gpio, gpio_mcp23xxx_api_table) = {
@@ -616,7 +661,17 @@ int gpio_mcp23xxx_init(const struct device *dev)
 	if (config->gpio_int.port) {
 		uint8_t iocon = 0;
 
-		if (config->ngpios == 16) {
+		if (config->gpio_intb.port) {
+			if (config->ngpios != 16) {
+				LOG_ERR("Only the 16 pin parts have two INT lines");
+				return -EINVAL;
+			}
+			if ((config->gpio_int.dt_flags & GPIO_ACTIVE_LOW) !=
+			    (config->gpio_intb.dt_flags & GPIO_ACTIVE_LOW)) {
+				LOG_ERR("INTA and INTB must have the same polarity");
+				return -EINVAL;
+			}
+		} else if (config->ngpios == 16) {
 			/* send both ports' interrupts through one IRQ pin */
 			iocon |= REG_IOCON_MIRROR;
 		}
@@ -640,32 +695,21 @@ int gpio_mcp23xxx_init(const struct device *dev)
 			return -EIO;
 		}
 
-		if (!gpio_is_ready_dt(&config->gpio_int)) {
-			LOG_ERR("INT port is not ready");
-			return -ENODEV;
-		}
-
 		drv_data->dev = dev;
 		k_work_init(&drv_data->work, mcp23xxx_work_handler);
 
-		err = gpio_pin_configure_dt(&config->gpio_int, GPIO_INPUT);
+		err = setup_int_line(&config->gpio_int, &drv_data->int_gpio_cb,
+				     mcp23xxx_int_gpio_handler);
 		if (err != 0) {
-			LOG_ERR("Failed to configure INT line: %d", err);
-			return -EIO;
+			return err;
 		}
 
-		gpio_init_callback(&drv_data->int_gpio_cb, mcp23xxx_int_gpio_handler,
-				   BIT(config->gpio_int.pin));
-		err = gpio_add_callback(config->gpio_int.port, &drv_data->int_gpio_cb);
-		if (err != 0) {
-			LOG_ERR("Failed to add INT callback: %d", err);
-			return -EIO;
-		}
-
-		err = gpio_pin_interrupt_configure_dt(&config->gpio_int, GPIO_INT_EDGE_TO_ACTIVE);
-		if (err != 0) {
-			LOG_ERR("Failed to configure INT interrupt: %d", err);
-			return -EIO;
+		if (config->gpio_intb.port) {
+			err = setup_int_line(&config->gpio_intb, &drv_data->intb_gpio_cb,
+					     mcp23xxx_intb_gpio_handler);
+			if (err != 0) {
+				return err;
+			}
 		}
 	}
 

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -112,6 +112,68 @@ static int write_iocon(const struct device *dev, uint8_t value)
 }
 
 /**
+ * @brief Read the interrupt status registers in one bus transaction.
+ *
+ * INTF, INTCAP and GPIO are consecutive registers (with IOCON.BANK = 0), so the
+ * whole interrupt state can be captured atomically from the device's point of
+ * view. Reading INTCAP clears the pending interrupt, so this must always read
+ * INTCAP before GPIO: the datasheet warns that reading GPIO first while another
+ * interrupt is pending loses the captured value.
+ *
+ * @param dev The mcp23xxx device.
+ * @param intf Receives INTF.
+ * @param intcap Receives INTCAP.
+ * @param gpio If not NULL, receives GPIO as well.
+ *
+ * @return 0 if successful. Otherwise <0 will be returned.
+ */
+static int read_int_regs(const struct device *dev, uint16_t *intf, uint16_t *intcap, uint16_t *gpio)
+{
+	const struct mcp23xxx_config *config = dev->config;
+	size_t nports = (config->ngpios == 16U) ? 2 : 1;
+	size_t nregs = (gpio != NULL) ? 3 : 2;
+	uint8_t data[MCP23XXX_MAX_BURST] = {0};
+	int ret;
+
+	ret = config->read_fn(dev, REG_INTF * nports, data, nregs * nports);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (nports == 2) {
+		*intf = sys_get_le16(&data[0]);
+		*intcap = sys_get_le16(&data[2]);
+		if (gpio != NULL) {
+			*gpio = sys_get_le16(&data[4]);
+		}
+	} else {
+		*intf = data[0];
+		*intcap = data[1];
+		if (gpio != NULL) {
+			*gpio = data[2];
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Turn raw INTF/INTCAP contents into the set of pins whose interrupt fired.
+ *
+ * The mcp23xxx only knows "any change" and "differs from DEFVAL" interrupts,
+ * so single-edge interrupts are filtered here using the captured pin state.
+ * Must be called with the driver lock held.
+ */
+static uint16_t filter_int_pins(const struct device *dev, uint16_t intf, uint16_t intcap)
+{
+	struct mcp23xxx_drv_data *drv_data = dev->data;
+	uint16_t level_ints = drv_data->reg_cache.gpinten & drv_data->reg_cache.intcon;
+
+	return intf & (level_ints | (intcap & drv_data->rising_edge_ints) |
+		       (~intcap & drv_data->falling_edge_ints));
+}
+
+/**
  * @brief Setup the pin direction.
  *
  * @param dev The mcp23xxx device.
@@ -228,6 +290,7 @@ done:
 static int mcp23xxx_port_get_raw(const struct device *dev, uint32_t *value)
 {
 	struct mcp23xxx_drv_data *drv_data = dev->data;
+	const struct mcp23xxx_config *config = dev->config;
 	uint16_t buf;
 	int ret;
 
@@ -237,7 +300,24 @@ static int mcp23xxx_port_get_raw(const struct device *dev, uint32_t *value)
 
 	k_sem_take(&drv_data->lock, K_FOREVER);
 
-	ret = read_port_regs(dev, REG_GPIO, &buf);
+	if (config->gpio_int.port && drv_data->reg_cache.gpinten != 0) {
+		/* Reading GPIO clears any pending interrupt and discards INTCAP.
+		 * Capture both alongside the port value so the event is not lost
+		 * if the interrupt handler has not run yet, and let the handler
+		 * deliver it.
+		 */
+		uint16_t intf;
+		uint16_t intcap;
+
+		ret = read_int_regs(dev, &intf, &intcap, &buf);
+		if (ret == 0 && intf != 0) {
+			drv_data->pending_ints |= filter_int_pins(dev, intf, intcap);
+			k_work_submit(&drv_data->work);
+		}
+	} else {
+		ret = read_port_regs(dev, REG_GPIO, &buf);
+	}
+
 	if (ret == 0) {
 		*value = buf;
 	}
@@ -330,6 +410,7 @@ static int mcp23xxx_pin_interrupt_configure(const struct device *dev, gpio_pin_t
 	switch (mode) {
 	case GPIO_INT_MODE_DISABLED:
 		gpinten &= ~BIT(pin);
+		drv_data->pending_ints &= ~BIT(pin);
 		break;
 
 	case GPIO_INT_MODE_LEVEL:
@@ -428,53 +509,34 @@ static void mcp23xxx_work_handler(struct k_work *work)
 {
 	struct mcp23xxx_drv_data *drv_data = CONTAINER_OF(work, struct mcp23xxx_drv_data, work);
 	const struct device *dev = drv_data->dev;
-
+	uint16_t intf;
+	uint16_t intcap;
+	uint16_t pins;
 	int ret;
 
 	k_sem_take(&drv_data->lock, K_FOREVER);
 
-	uint16_t intf;
-
-	ret = read_port_regs(dev, REG_INTF, &intf);
+	/* Reading INTCAP acknowledges the interrupt */
+	ret = read_int_regs(dev, &intf, &intcap, NULL);
 	if (ret != 0) {
-		LOG_ERR("Failed to read INTF");
-		goto fail;
+		LOG_ERR("Failed to read INTF/INTCAP (%d)", ret);
+		k_sem_give(&drv_data->lock);
+		return;
 	}
 
-	if (!intf) {
-		/* Probable causes:
-		 * - REG_GPIO was read from somewhere else before the interrupt handler had a chance
-		 *   to run
-		 * - Even though the datasheet says differently, reading INTCAP while a level
-		 *   interrupt is active briefly (~2ns) causes the interrupt line to go high and
-		 *   low again. This causes a second ISR to be scheduled, which then won't
-		 *   find any active interrupts if the callback has disabled the level interrupt.
+	pins = drv_data->pending_ints | filter_int_pins(dev, intf, intcap);
+	drv_data->pending_ints = 0;
+
+	k_sem_give(&drv_data->lock);
+
+	if (pins != 0) {
+		gpio_fire_callbacks(&drv_data->callbacks, dev, pins);
+	} else {
+		/* Not an error: a level interrupt that the callback disabled, or an
+		 * edge interrupt filtered out for the other edge, ends up here.
 		 */
-		LOG_ERR("Spurious interrupt");
-		goto fail;
+		LOG_DBG("No interrupt pending");
 	}
-
-	uint16_t intcap;
-
-	/* Read INTCAP to acknowledge the interrupt */
-	ret = read_port_regs(dev, REG_INTCAP, &intcap);
-	if (ret != 0) {
-		LOG_ERR("Failed to read INTCAP");
-		goto fail;
-	}
-
-	/* mcp23xxx does not support single-edge interrupts in hardware, filter them out manually */
-	uint16_t level_ints = drv_data->reg_cache.gpinten & drv_data->reg_cache.intcon;
-
-	intf &= level_ints | (intcap & drv_data->rising_edge_ints) |
-		(~intcap & drv_data->falling_edge_ints);
-
-	k_sem_give(&drv_data->lock);
-	gpio_fire_callbacks(&drv_data->callbacks, dev, intf);
-	return;
-
-fail:
-	k_sem_give(&drv_data->lock);
 }
 
 static void mcp23xxx_int_gpio_handler(const struct device *port, struct gpio_callback *cb,

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -509,6 +509,7 @@ static void mcp23xxx_work_handler(struct k_work *work)
 {
 	struct mcp23xxx_drv_data *drv_data = CONTAINER_OF(work, struct mcp23xxx_drv_data, work);
 	const struct device *dev = drv_data->dev;
+	const struct mcp23xxx_config *config = dev->config;
 	uint16_t intf;
 	uint16_t intcap;
 	uint16_t pins;
@@ -536,6 +537,17 @@ static void mcp23xxx_work_handler(struct k_work *work)
 		 * edge interrupt filtered out for the other edge, ends up here.
 		 */
 		LOG_DBG("No interrupt pending");
+	}
+
+	/* The host side interrupt is edge triggered, but a DEFVAL compare (level)
+	 * interrupt keeps INT asserted for as long as the mismatch exists, so no
+	 * new edge is ever produced. Re-run while the line is still active rather
+	 * than relying on the brief INT pulse the chip emits when INTCAP is read
+	 * during a level interrupt. Submitting instead of looping lets other work
+	 * items run in between.
+	 */
+	if (gpio_pin_get_dt(&config->gpio_int) > 0) {
+		k_work_submit(work);
 	}
 }
 

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -458,6 +458,26 @@ static int mcp23xxx_pin_interrupt_configure(const struct device *dev, gpio_pin_t
 		break;
 	}
 
+	if ((gpinten & ~drv_data->reg_cache.gpinten) != 0) {
+		/* Interrupt-on-change compares against the pin value seen at the
+		 * last GPIO or INTCAP read, which may be long stale. Refresh it so
+		 * that enabling does not fire for a change that predates the
+		 * enable, keeping any interrupt the read consumes for the handler.
+		 */
+		uint16_t intf;
+		uint16_t intcap;
+		uint16_t gpio;
+
+		ret = read_int_regs(dev, &intf, &intcap, &gpio);
+		if (ret != 0) {
+			goto done;
+		}
+		if (intf != 0) {
+			drv_data->pending_ints |= filter_int_pins(dev, intf, intcap);
+			k_work_submit(&drv_data->work);
+		}
+	}
+
 	ret = write_port_regs(dev, REG_GPINTEN, gpinten);
 	if (ret != 0) {
 		goto done;

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -628,6 +628,12 @@ int gpio_mcp23xxx_init(const struct device *dev)
 			iocon |= REG_IOCON_INTCC;
 		}
 
+		if (config->int_open_drain) {
+			iocon |= REG_IOCON_ODR;
+		} else if ((config->gpio_int.dt_flags & GPIO_ACTIVE_LOW) == 0) {
+			iocon |= REG_IOCON_INTPOL;
+		}
+
 		err = write_iocon(dev, iocon);
 		if (err != 0) {
 			LOG_ERR("Failed to configure IOCON: %d", err);

--- a/drivers/gpio/gpio_mcp23xxx.c
+++ b/drivers/gpio/gpio_mcp23xxx.c
@@ -40,12 +40,21 @@ LOG_MODULE_REGISTER(gpio_mcp23xxx);
 static int read_port_regs(const struct device *dev, uint8_t reg, uint16_t *buf)
 {
 	const struct mcp23xxx_config *config = dev->config;
+	uint8_t data[2] = {0};
+	size_t len = 1;
+	int ret;
 
 	if (config->ngpios == 16U) {
 		reg *= 2;
+		len = 2;
 	}
 
-	return config->read_fn(dev, reg, buf);
+	ret = config->read_fn(dev, reg, data, len);
+	if (ret == 0) {
+		*buf = sys_get_le16(data);
+	}
+
+	return ret;
 }
 
 /**
@@ -63,12 +72,17 @@ static int read_port_regs(const struct device *dev, uint8_t reg, uint16_t *buf)
 static int write_port_regs(const struct device *dev, uint8_t reg, uint16_t value)
 {
 	const struct mcp23xxx_config *config = dev->config;
+	uint8_t data[2];
+	size_t len = 1;
 
 	if (config->ngpios == 16U) {
 		reg *= 2;
+		len = 2;
 	}
 
-	return config->write_fn(dev, reg, value);
+	sys_put_le16(value, data);
+
+	return config->write_fn(dev, reg, data, len);
 }
 
 /**

--- a/drivers/gpio/gpio_mcp23xxx.h
+++ b/drivers/gpio/gpio_mcp23xxx.h
@@ -66,6 +66,11 @@ typedef int (*mcp23xxx_read_regs)(const struct device *dev, uint8_t reg, uint8_t
 typedef int (*mcp23xxx_write_regs)(const struct device *dev, uint8_t reg, const uint8_t *buf,
 				   size_t len);
 typedef int (*mcp23xxx_bus_is_ready)(const struct device *dev);
+
+/* Optional second int-gpios entry (INTB) of a driver instance */
+#define MCP23XXX_INTB_DT_SPEC_INST_GET(inst)                                                       \
+	GPIO_DT_SPEC_INST_GET_BY_IDX_OR(inst, int_gpios, 1, {0})
+
 /** Configuration data */
 struct mcp23xxx_config {
 	/* gpio_driver_config needs to be first */
@@ -81,7 +86,10 @@ struct mcp23xxx_config {
 #endif /* CONFIG_GPIO_MCP23SXX */
 	} bus;
 
+	/* INTA, or the single mirrored INT line */
 	struct gpio_dt_spec gpio_int;
+	/* INTB, only set when the two ports use separate lines */
+	struct gpio_dt_spec gpio_intb;
 	struct gpio_dt_spec gpio_reset;
 
 	uint8_t ngpios;
@@ -101,6 +109,7 @@ struct mcp23xxx_drv_data {
 	sys_slist_t callbacks;
 	const struct device *dev;
 	struct gpio_callback int_gpio_cb;
+	struct gpio_callback intb_gpio_cb;
 	struct k_work work;
 
 	uint16_t rising_edge_ints;

--- a/drivers/gpio/gpio_mcp23xxx.h
+++ b/drivers/gpio/gpio_mcp23xxx.h
@@ -96,6 +96,8 @@ struct mcp23xxx_drv_data {
 
 	uint16_t rising_edge_ints;
 	uint16_t falling_edge_ints;
+	/* Interrupts consumed by a port read, still to be delivered by the work handler */
+	uint16_t pending_ints;
 
 	struct {
 		uint16_t iodir;

--- a/drivers/gpio/gpio_mcp23xxx.h
+++ b/drivers/gpio/gpio_mcp23xxx.h
@@ -34,7 +34,15 @@
 #define REG_GPIO 0x09
 #define REG_OLAT 0x0A
 
+#define REG_IOCON_BANK   BIT(7)
 #define REG_IOCON_MIRROR BIT(6)
+#define REG_IOCON_SEQOP  BIT(5)
+#define REG_IOCON_DISSLW BIT(4)
+#define REG_IOCON_HAEN   BIT(3)
+#define REG_IOCON_ODR    BIT(2)
+#define REG_IOCON_INTPOL BIT(1)
+/* MCP23x09 and MCP23x18 only: interrupt cleared by reading INTCAP (1) or GPIO (0) */
+#define REG_IOCON_INTCC  BIT(0)
 
 #define MCP23SXX_ADDR 0x40
 #define MCP23SXX_READBIT 0x01

--- a/drivers/gpio/gpio_mcp23xxx.h
+++ b/drivers/gpio/gpio_mcp23xxx.h
@@ -86,6 +86,7 @@ struct mcp23xxx_config {
 
 	uint8_t ngpios;
 	bool is_open_drain;
+	bool int_open_drain;
 	mcp23xxx_read_regs read_fn;
 	mcp23xxx_write_regs write_fn;
 	mcp23xxx_bus_is_ready bus_fn;

--- a/drivers/gpio/gpio_mcp23xxx.h
+++ b/drivers/gpio/gpio_mcp23xxx.h
@@ -39,8 +39,24 @@
 #define MCP23SXX_ADDR 0x40
 #define MCP23SXX_READBIT 0x01
 
-typedef int (*mcp23xxx_read_port_regs)(const struct device *dev, uint8_t reg, uint16_t *buf);
-typedef int (*mcp23xxx_write_port_regs)(const struct device *dev, uint8_t reg, uint16_t value);
+/* Largest register burst the core driver issues, see mcp23xxx_read_regs. */
+#define MCP23XXX_MAX_BURST 6
+
+/**
+ * @brief Read @p len consecutive registers starting at @p reg.
+ *
+ * @p reg is the raw (IOCON.BANK = 0) register address, @p len is at most
+ * MCP23XXX_MAX_BURST.
+ */
+typedef int (*mcp23xxx_read_regs)(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len);
+/**
+ * @brief Write @p len consecutive registers starting at @p reg.
+ *
+ * @p reg is the raw (IOCON.BANK = 0) register address, @p len is at most
+ * MCP23XXX_MAX_BURST.
+ */
+typedef int (*mcp23xxx_write_regs)(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				   size_t len);
 typedef int (*mcp23xxx_bus_is_ready)(const struct device *dev);
 /** Configuration data */
 struct mcp23xxx_config {
@@ -62,8 +78,8 @@ struct mcp23xxx_config {
 
 	uint8_t ngpios;
 	bool is_open_drain;
-	mcp23xxx_read_port_regs read_fn;
-	mcp23xxx_write_port_regs write_fn;
+	mcp23xxx_read_regs read_fn;
+	mcp23xxx_write_regs write_fn;
 	mcp23xxx_bus_is_ready bus_fn;
 };
 

--- a/dts/bindings/gpio/microchip,mcp23xxx.yaml
+++ b/dts/bindings/gpio/microchip,mcp23xxx.yaml
@@ -15,7 +15,19 @@ properties:
   int-gpios:
     type: phandle-array
     description: |
-        GPIO connected to the controller INT pin. This pin is active-low.
+        GPIO connected to the controller INT pin.
+
+        The INT pin is push-pull by default and its polarity follows the
+        GPIO_ACTIVE_LOW / GPIO_ACTIVE_HIGH flag given here (IOCON.INTPOL).
+        Set int-open-drain to make it open-drain active-low instead.
+
+  int-open-drain:
+    type: boolean
+    description: |
+        Configure the INT pin as an open-drain output (IOCON.ODR). The pin is
+        then active-low regardless of the flags in int-gpios, and needs an
+        external pull-up (or GPIO_PULL_UP in int-gpios if the host provides
+        one). Use this to share one interrupt line between several expanders.
 
   reset-gpios:
     type: phandle-array

--- a/dts/bindings/gpio/microchip,mcp23xxx.yaml
+++ b/dts/bindings/gpio/microchip,mcp23xxx.yaml
@@ -15,11 +15,18 @@ properties:
   int-gpios:
     type: phandle-array
     description: |
-        GPIO connected to the controller INT pin.
+        GPIOs connected to the controller INT pin(s).
 
-        The INT pin is push-pull by default and its polarity follows the
-        GPIO_ACTIVE_LOW / GPIO_ACTIVE_HIGH flag given here (IOCON.INTPOL).
-        Set int-open-drain to make it open-drain active-low instead.
+        With a single entry, the 16 pin parts mirror the interrupts of both
+        ports onto that line (IOCON.MIRROR) and only one of INTA/INTB needs
+        to be wired. With two entries, the first is INTA (port A, pins 0-7)
+        and the second INTB (port B, pins 8-15), and the ports interrupt
+        independently. Two entries are only valid on the 16 pin parts.
+
+        The INT pins are push-pull by default and their polarity follows the
+        GPIO_ACTIVE_LOW / GPIO_ACTIVE_HIGH flag given here (IOCON.INTPOL);
+        both entries must use the same polarity. Set int-open-drain to make
+        them open-drain active-low instead.
 
   int-open-drain:
     type: boolean

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -177,6 +177,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
+				int-gpios = <&test_gpio 0 0>, <&test_gpio 1 0>;
 			};
 
 			test_i2c_fxl6408: fxl6408@8 {
@@ -561,6 +562,8 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <16>;
+				int-gpios = <&test_gpio 0 0>;
+				int-open-drain;
 			};
 
 			test_spi_mcp23sxx: mcp23s18@1 {


### PR DESCRIPTION
The MCP23xxx driver only ever wrote one IOCON bit (MIRROR) and otherwise treated the chip as a generic expander with a single active-low interrupt line. Reading the MCP23017 and MCP23018 datasheets against the driver turned up several gaps and two real bugs. This series closes them, one per commit:

- **Byte-oriented bus accessors** (refactor, no functional change) so the core can burst over consecutive registers.
- **Port reads no longer lose interrupts.** Reading GPIO clears the pending interrupt and discards INTCAP (datasheet 3.6.4). If an application read the port before the work handler ran, the event was gone and an error was logged. Port reads now burst INTF+INTCAP+GPIO in one transaction and stash the interrupt for the handler. The handler also reads INTF+INTCAP in one burst instead of two.
- **INT line re-checked after servicing.** DEFVAL-compare (level) interrupts keep INT asserted as long as the mismatch exists (datasheet 3.6.5), so an edge-triggered host never sees another edge. The old code relied on a ~2 ns pulse the chip emits when INTCAP is read, as its own comment admitted.
- **MCP23x09/x18 interrupts now clear.** Those parts have an INTCC bit that defaults to "clear on GPIO read", but the driver acknowledges by reading INTCAP, so INT never deasserted after the first event.
- **INT polarity and drive are configurable.** IOCON.INTPOL follows the `GPIO_ACTIVE_*` flag on `int-gpios`; a new `int-open-drain` boolean sets IOCON.ODR for boards sharing one interrupt line between expanders.
- **Separate INTA and INTB.** `int-gpios` accepts a second entry; with two entries MIRROR is left clear and each port's line gets its own host callback. A single entry keeps the mirrored behaviour, so existing device trees are unaffected.
- **No spurious callback on enable.** Found on hardware: interrupt-on-change compares against the pin value at the last GPIO/INTCAP read, so enabling a pin that changed since then fired immediately. The reference is now refreshed right before GPINTEN is set.

The build_all GPIO overlay gains both binding forms so the new paths are compiled. Each commit builds on its own on `native_sim/native/64` and `qemu_cortex_m3`.

**Hardware testing** (MCP23017 breakouts on an ESP32, I2C at 400 kHz, GPA0 jumpered to GPB0 so the output drives the input on the other port):

| Case | Mirrored, one INT line | Two lines (INTA, INTB) |
|---|---|---|
| Edge both / rising / falling, 200 toggles | 200 / 100 / 100 exact | 200 / 100 / 100 exact, both directions |
| Edge both while another thread hammers `gpio_port_get_raw` | 200 exact | 200 exact |
| Level low held | re-fires continuously (~480 per 100 ms), once when disabled from the callback | same |
| Level low armed while high, then driven low | 0 before, fires after | same |
| Level high, disabled from callback | exactly 1 | exactly 1 |
| Host-side edge counters on INTA/INTB | n/a | port B input: 0 on INTA, 200 on INTB; port A input: 200 on INTA, 0 on INTB |

Tested on two separate MCP23017 boards in mirrored mode and one in two-line mode. Not yet tested: `int-open-drain`, and the INTCC change on an MCP23x09/x18, so review from anyone with one of those on hand would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJ75m21oo6fh2XkUDnQByP