### PR TITLE
tests: sched: preempt: remove duplicate manager_thread declaration

### DIFF
--- a/tests/kernel/sched/preempt/src/main.c
+++ b/tests/kernel/sched/preempt/src/main.c
@@ -59,8 +59,6 @@ struct k_thread worker_threads[NUM_THREADS];
 
 K_THREAD_STACK_ARRAY_DEFINE(worker_stacks, NUM_THREADS, STACK_SIZE);
 
-struct k_thread manager_thread;
-
 struct k_sem worker_sems[NUM_THREADS];
 
 /* Command to worker: who to wake up */


### PR DESCRIPTION
The `manager_thread` object is declared twice in the preemption scheduler test. The second declaration is redundant and can be removed.

### Validation

Tested on `native_sim` using the host toolchain.

Before the change:

* `suite_preempt`: PASS
* `test_preempt`: PASS

After removing the duplicate declaration:

* `suite_preempt`: PASS
* `test_preempt`: PASS

The test behavior and results are unchanged.
