### PR TITLE
posix: mutex: reset mutex type on pool slot reuse

### DIFF
--- a/subsys/portability/posix/options/mutex.c
+++ b/subsys/portability/posix/options/mutex.c
@@ -105,6 +105,7 @@ struct k_mutex *to_posix_mutex(pthread_mutex_t *mu)
 
 		/* Record the associated posix_mutex in mu and mark as initialized */
 		*mu = mark_pthread_obj_initialized(bit);
+		posix_mutex_type[bit] = def_attr.type;
 		m = &posix_mutex_pool[bit];
 	}
 
@@ -315,6 +316,7 @@ int pthread_mutex_destroy(pthread_mutex_t *mu)
 	__ASSERT_NO_MSG(err == 0);
 
 	bit = to_posix_mutex_idx(*mu);
+	posix_mutex_type[bit] = def_attr.type;
 	err = sys_bitarray_free(&posix_mutex_bitarray, 1, bit);
 	__ASSERT_NO_MSG(err == 0);
 

--- a/tests/subsys/portability/posix/threads_base/src/mutex.c
+++ b/tests/subsys/portability/posix/threads_base/src/mutex.c
@@ -260,6 +260,44 @@ ZTEST(mutex, test_mutex_static_initializer)
 	zassert_ok(pthread_mutex_destroy(&m));
 }
 
+/**
+ * @brief Verify a statically-initialized mutex reuses a slot with default type
+ *
+ * @details Destroying a recursive mutex must reset the pool slot's type. A
+ *          subsequently auto-initialized static mutex reusing that slot must
+ *          behave as PTHREAD_MUTEX_DEFAULT (non-recursive).
+ */
+ZTEST(mutex, test_mutex_static_initializer_after_destroy)
+{
+	static pthread_mutex_t m_static = PTHREAD_MUTEX_INITIALIZER;
+	pthread_mutexattr_t attr;
+	pthread_mutex_t m_rec;
+
+	zassert_ok(pthread_mutexattr_init(&attr));
+	zassert_ok(pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+	zassert_ok(pthread_mutex_init(&m_rec, &attr));
+	zassert_ok(pthread_mutexattr_destroy(&attr));
+
+	/* Lock twice and unlock twice to verify recursive behavior */
+	zassert_ok(pthread_mutex_lock(&m_rec));
+	zassert_ok(pthread_mutex_lock(&m_rec));
+	zassert_ok(pthread_mutex_unlock(&m_rec));
+	zassert_ok(pthread_mutex_unlock(&m_rec));
+
+	/* Destroy recursive mutex to return slot to pool */
+	zassert_ok(pthread_mutex_destroy(&m_rec));
+
+	/* Lock statically-initialized mutex, which reclaims the pool slot */
+	zassert_ok(pthread_mutex_lock(&m_static));
+
+	/* Relocking from the same thread must return EBUSY, not succeed */
+	zassert_equal(EBUSY, pthread_mutex_trylock(&m_static),
+		      "static mutex inherited recursive type from destroyed slot");
+
+	zassert_ok(pthread_mutex_unlock(&m_static));
+	zassert_ok(pthread_mutex_destroy(&m_static));
+}
+
 static void before(void *arg)
 {
 	ARG_UNUSED(arg);


### PR DESCRIPTION
When a mutex is initialized using `pthread_mutex_init()` with a non-default type (such as `PTHREAD_MUTEX_RECURSIVE` or `PTHREAD_MUTEX_ERRORCHECK`), its type attribute is stored in `posix_mutex_type[bit]`.

When `pthread_mutex_destroy()` frees that slot back to `posix_mutex_bitarray`, `posix_mutex_pool[bit]` is reinitialized with `k_mutex_init()`, but `posix_mutex_type[bit]` is left unchanged. In addition, when a static mutex (`PTHREAD_MUTEX_INITIALIZER`) subsequently allocates a slot in `to_posix_mutex()`, `posix_mutex_type[bit]` is never initialized.

Consequently, a `PTHREAD_MUTEX_INITIALIZER` mutex that reclaims a slot previously held by a recursive or error-check mutex silently inherits that type instead of behaving as `PTHREAD_MUTEX_DEFAULT` (non-recursive). This allows recursive re-locking by the same thread rather than blocking or returning `EBUSY` on `pthread_mutex_trylock()`, violating IEEE Std 1003.1-2017.

Reset `posix_mutex_type[bit]` to `def_attr.type` upon lazy allocation in `to_posix_mutex()` and when releasing the slot in `pthread_mutex_destroy()`. Add a regression test in `threads_base` to ensure static mutexes retain default non-recursive attributes after slot recycling.

Fixes #118893
