### PR TITLE
drivers: adc: add a generic ADC_DMA transfer-mode request

### DIFF
--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -67,6 +67,18 @@ config ADC_ASYNC
 	help
 	  This option enables the asynchronous API calls.
 
+config ADC_DMA
+	bool "Request DMA-driven ADC transfers"
+	help
+	  Request the DMA mode of the ADC driver. Each driver with a DMA mode
+	  enables its own option for it in response, where the devicetree
+	  wires the controller to a DMA channel; drivers without one ignore
+	  the request.
+
+	  This only requests DMA and cannot disable it: a driver using DMA by
+	  default keeps doing so when this is left disabled. To force a driver
+	  out of its DMA mode, clear its own option instead.
+
 config ADC_INIT_PRIORITY
 	int "ADC init priority"
 	default KERNEL_INIT_PRIORITY_DEVICE

--- a/drivers/adc/Kconfig.cc23x0
+++ b/drivers/adc/Kconfig.cc23x0
@@ -11,6 +11,7 @@ config ADC_CC23X0
 
 config ADC_CC23X0_DMA_DRIVEN
 	bool "DMA support for TI CC23X0 ADC devices"
+	default y if ADC_DMA
 	depends on ADC_CC23X0
 	select DMA
 	help

--- a/drivers/adc/Kconfig.esp32
+++ b/drivers/adc/Kconfig.esp32
@@ -13,6 +13,7 @@ if ADC_ESP32
 
 config ADC_ESP32_DMA
 	bool "ESP32 ADC DMA Support"
+	default y if ADC_DMA
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ESPRESSIF_ESP32_ADC),dmas) || \
 		SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2
 	select DMA if DT_HAS_ESPRESSIF_ESP32_GDMA_ENABLED

--- a/drivers/adc/Kconfig.esp32
+++ b/drivers/adc/Kconfig.esp32
@@ -13,9 +13,13 @@ if ADC_ESP32
 
 config ADC_ESP32_DMA
 	bool "ESP32 ADC DMA Support"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ESPRESSIF_ESP32_ADC),dmas) || \
+		SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2
 	select DMA if DT_HAS_ESPRESSIF_ESP32_GDMA_ENABLED
 	help
-	  Enable the ADC DMA mode
+	  Enable the ADC DMA mode. The ESP32 and ESP32-S2 ADCs have a DMA of
+	  their own; the others take the GDMA channel the devicetree wires to
+	  the controller.
 
 config ADC_ESP32_CONVERSION_TIMEOUT_US
 	int "Oneshot conversion completion timeout in microseconds"

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -87,9 +87,11 @@ endchoice
 
 config ADC_MCUX_ADC16_ENABLE_EDMA
 	bool "EDMA for adc driver"
-	depends on DMA_MCUX_EDMA
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_KINETIS_ADC16),dmas)
+	select DMA
 	help
-	  Enable the MCUX ADC16 driver.
+	  Transfer the samples through the EDMA channel the devicetree wires
+	  to the controller.
 
 if ADC_MCUX_ADC16_ENABLE_EDMA
 

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -87,6 +87,7 @@ endchoice
 
 config ADC_MCUX_ADC16_ENABLE_EDMA
 	bool "EDMA for adc driver"
+	default y if ADC_DMA
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_KINETIS_ADC16),dmas)
 	select DMA
 	help
@@ -126,6 +127,7 @@ config LPADC_CHANNEL_COUNT
 
 config ADC_MCUX_LPADC_DMA_DRIVEN
 	bool "Use DMA to transfer data"
+	default y if ADC_DMA
 	select DMA
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPC_LPADC),dmas) && \
 		   $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_LPC_LPADC),dma-names)

--- a/drivers/adc/Kconfig.silabs
+++ b/drivers/adc/Kconfig.silabs
@@ -25,6 +25,7 @@ if ADC_SILABS_IADC
 
 config ADC_SILABS_IADC_DMA
 	bool "Silabs IADC async DMA support"
+	default y if ADC_DMA
 	select DMA
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_SILABS_IADC),dmas)
 	help

--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -33,6 +33,7 @@ if ADC_STM32 || ADC_STM32WB0
 
 config ADC_STM32_DMA
 	bool "STM32 MCU ADC DMA Support"
+	default y if ADC_DMA
 	select DMA
 	help
 	  Enable the ADC DMA mode for ADC instances


### PR DESCRIPTION
Selecting DMA-driven ADC sampling means knowing the driver: six options
across vendors (ADC_STM32_DMA, ADC_MCUX_ADC16_ENABLE_EDMA,
ADC_MCUX_LPADC_DMA_DRIVEN, ADC_ESP32_DMA, ADC_SILABS_IADC_DMA,
ADC_CC23X0_DMA_DRIVEN) say the same thing, so an application or a test
wanting DMA carries a per-vendor table of them.

Add ADC_DMA to state the intent once. Each driver option gains a default
following it, so enabling the request turns on the right option where the
driver's own conditions hold, and a driver without a DMA mode ignores it. The
request is one-way: it only ever turns an option on, so leaving it disabled
changes no existing configuration, and a driver using DMA by default keeps
doing so.
