### PR TITLE
kernel: mark the message queue receive fast path likely

### DIFF
--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -310,7 +310,7 @@ int z_impl_k_msgq_get(struct k_msgq *msgq, void *data, k_timeout_t timeout)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_msgq, get, msgq, timeout);
 
-	if (msgq->used_msgs > 0U) {
+	if (likely(msgq->used_msgs > 0U)) {
 		/* take first available message from queue */
 		(void)memcpy((char *)data, msgq->read_ptr, msgq->msg_size);
 		msgq->read_ptr += msgq->msg_size;


### PR DESCRIPTION
`k_msgq_get()` falls straight through to the empty case and leaves the transfer behind a taken branch, though the transfer is both the common case and the only one that copies anything.

A transfer costs five cycles less and a get on an empty queue two more, on a path that returns without copying and that a caller hitting it routinely would normally be blocking on rather than polling anyway.

thread_metric message processing:

| target | base | likely() | delta |
|---|---|---|---|
| x86 | 133267 | 133267 | +0.00% |
| Xtensa DC233C | 84595 | 84595 | +0.00% |
| ARM Cortex-M3 | 96465 | 97083 | +0.64% |
| ARM Cortex-A53 | 497986 | 501946 | +0.80% |
| RISC-V 32 | 80998 | 81839 | +1.04% |
| ARM Cortex-M4 | 410042 | 418985 | +2.18% |

The first five are QEMU under icount; the Cortex-M4 figure is an MXChip AZ3166 at 96 MHz, where flash wait states make a taken branch dearer. It is a gain on ARM and RISC-V, neutral on x86 and Xtensa, and a regression on none. Text shrinks by 4 bytes and there is no impact on RAM.

`k_msgq_put()` has an equivalent test that is deliberately left alone: annotating it makes GCC spill an extra callee-saved register, turning the 16-bit `push`/`pop` into 32-bit `stmdb.w`/`ldmia.w` and costing two cycles on every call, which is more than the layout saves. `k_msgq_peek()` is likewise untouched.

`tests/kernel/msgq` passes on qemu_cortex_m3 and native_sim.