### PR TITLE
kernel: tail call the memory slab slow paths

### DIFF
--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -217,28 +217,42 @@ static bool slab_ptr_is_good(struct k_mem_slab *slab, const void *ptr)
 	       ((offset % slab->info.block_size) == 0);
 }
 
-int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
+/* Caller holds the lock and has checked the free list is not empty. */
+static ALWAYS_INLINE void slab_take_block(struct k_mem_slab *slab, void **mem)
+{
+	*mem = slab->free_list;
+	slab->free_list = *(char **)(slab->free_list);
+	slab->info.num_used++;
+	__ASSERT((slab->free_list == NULL &&
+		  slab->info.num_used == slab->info.num_blocks) ||
+		 slab_ptr_is_good(slab, slab->free_list),
+		 "slab corruption detected");
+
+#ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
+	slab->info.max_used = max(slab->info.num_used, slab->info.max_used);
+#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
+}
+
+/* Put a block back on the free list. The caller holds the lock. */
+static ALWAYS_INLINE void slab_put_block(struct k_mem_slab *slab, void *mem)
+{
+	*(char **) mem = slab->free_list;
+	slab->free_list = (char *) mem;
+	slab->info.num_used--;
+}
+
+/* Only ever tail called, so the fast path needs no frame. The caller drops the
+ * lock first, hence the re-check here.
+ */
+static int __noinline slab_alloc_slow(struct k_mem_slab *slab, void **mem,
+				      k_timeout_t timeout)
 {
 	k_spinlock_key_t key = k_spin_lock(&slab->lock);
 	int result;
 
-	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, alloc, slab, timeout);
-
 	if (slab->free_list != NULL) {
 		/* take a free block */
-		*mem = slab->free_list;
-		slab->free_list = *(char **)(slab->free_list);
-		slab->info.num_used++;
-		__ASSERT((slab->free_list == NULL &&
-			  slab->info.num_used == slab->info.num_blocks) ||
-			 slab_ptr_is_good(slab, slab->free_list),
-			 "slab corruption detected");
-
-#ifdef CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION
-		slab->info.max_used = max(slab->info.num_used,
-					  slab->info.max_used);
-#endif /* CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION */
-
+		slab_take_block(slab, mem);
 		result = 0;
 	} else if (K_TIMEOUT_EQ(timeout, K_NO_WAIT) ||
 		   !IS_ENABLED(CONFIG_MULTITHREADING)) {
@@ -266,6 +280,47 @@ int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
 	return result;
 }
 
+int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem, k_timeout_t timeout)
+{
+	k_spinlock_key_t key = k_spin_lock(&slab->lock);
+
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, alloc, slab, timeout);
+
+	if (unlikely(slab->free_list == NULL)) {
+		k_spin_unlock(&slab->lock, key);
+
+		return slab_alloc_slow(slab, mem, timeout);
+	}
+
+	/* take a free block */
+	slab_take_block(slab, mem);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, alloc, slab, timeout, 0);
+
+	k_spin_unlock(&slab->lock, key);
+
+	return 0;
+}
+
+/* Only ever tail called. The lock is handed over, not dropped, so the free list
+ * is still empty here.
+ */
+static void __noinline slab_free_slow(struct k_mem_slab *slab, void *mem,
+				      k_spinlock_key_t key)
+{
+	if (z_sched_wake(&slab->wait_q, 0, mem)) {
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
+		z_reschedule(&slab->lock, key);
+		return;
+	}
+
+	slab_put_block(slab, mem);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
+
+	k_spin_unlock(&slab->lock, key);
+}
+
 void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 {
 	if (!slab_ptr_is_good(slab, mem)) {
@@ -278,15 +333,11 @@ void k_mem_slab_free(struct k_mem_slab *slab, void *mem)
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_mem_slab, free, slab);
 	if (unlikely(slab->free_list == NULL) && IS_ENABLED(CONFIG_MULTITHREADING)) {
-		if (z_sched_wake(&slab->wait_q, 0, mem)) {
-			SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
-			z_reschedule(&slab->lock, key);
-			return;
-		}
+		slab_free_slow(slab, mem, key);
+		return;
 	}
-	*(char **) mem = slab->free_list;
-	slab->free_list = (char *) mem;
-	slab->info.num_used--;
+
+	slab_put_block(slab, mem);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mem_slab, free, slab);
 


### PR DESCRIPTION
`k_mem_slab_alloc()` and `k_mem_slab_free()` carried a stack frame for the blocking and waking cases even when a block was simply available. Those cases now live out of line and are reached by tail call, leaving the uncontended paths with no frame at all.

thread_metric memory allocation:

| target | base | tail-call | delta | Δtext |
|---|---|---|---|---|
| x86 | 300486 | 303376 | +0.96% | +0 |
| Xtensa DC233C | 258638 | 262948 | +1.67% | +100 |
| ARM Cortex-M3 | 222720 | 236640 | +6.25% | +112 |
| ARM Cortex-M4 | 756340 | 850046 | +12.40% | +104 |
| ARM Cortex-A53 | 889011 | 1051995 | +18.33% | +0 |
| RISC-V 32 | 199676 | 254425 | +27.42% | +54 |

The Cortex-M4 row is an MXChip AZ3166 at 96 MHz, the rest QEMU under icount. The gain tracks whether the ABI lets the frame go: it vanishes on RISC-V and Cortex-A53, while Xtensa's windowed `entry` and i386's frame pointer remain. Clang agrees, +8.96% on Cortex-M3.

**Text grows by at most 112 bytes and RAM is unchanged** — on x86 and Cortex-A53 not at all, because the entry points shrink by as much as the out-of-line helpers add. Call sites are untouched, so that cost is paid once however many callers a build has.

Needs `CONFIG_ASSERT=n`, the default outside tests; with asserts on the function is non-leaf anyway and alloc costs 4.8%.

`tests/kernel/mem_slab` passes on qemu_cortex_m3 and native_sim.