### PR TITLE
tracing: Enhance sleep timeout reporting with signed ticks in tracing

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -81,13 +81,13 @@ void sys_trace_k_thread_priority_set(struct k_thread *thread)
 
 void sys_trace_k_thread_sleep_ticks_enter(k_timeout_t timeout)
 {
-	ctf_top_thread_sleep_ticks_enter(k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+	ctf_top_thread_sleep_ticks_enter(k_ticks_to_us_floor32((int32_t)timeout.ticks));
 }
 
 void sys_trace_k_thread_sleep_ticks_exit(k_timeout_t timeout, int ret)
 {
-	ctf_top_thread_sleep_ticks_exit(k_ticks_to_us_floor32((uint32_t)timeout.ticks),
-					(uint32_t)ret);
+	ctf_top_thread_sleep_ticks_exit(k_ticks_to_us_floor32((int32_t)timeout.ticks),
+					(int32_t)ret);
 }
 
 void sys_trace_k_thread_create(struct k_thread *thread, size_t stack_size, int prio)

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -81,13 +81,12 @@ void sys_trace_k_thread_priority_set(struct k_thread *thread)
 
 void sys_trace_k_thread_sleep_ticks_enter(k_timeout_t timeout)
 {
-	ctf_top_thread_sleep_ticks_enter(k_ticks_to_us_floor32((int32_t)timeout.ticks));
+	ctf_top_thread_sleep_ticks_enter((int32_t)timeout.ticks);
 }
 
 void sys_trace_k_thread_sleep_ticks_exit(k_timeout_t timeout, int ret)
 {
-	ctf_top_thread_sleep_ticks_exit(k_ticks_to_us_floor32((int32_t)timeout.ticks),
-					(int32_t)ret);
+	ctf_top_thread_sleep_ticks_exit((int32_t)timeout.ticks, (int32_t)ret);
 }
 
 void sys_trace_k_thread_create(struct k_thread *thread, size_t stack_size, int prio)

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -519,12 +519,12 @@ static inline void ctf_top_thread_priority_set(uint32_t thread_id, int8_t prio,
 	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_PRIORITY_SET), thread_id, name, prio);
 }
 
-static inline void ctf_top_thread_sleep_ticks_enter(uint32_t timeout)
+static inline void ctf_top_thread_sleep_ticks_enter(int32_t timeout)
 {
 	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SLEEP_TICKS_ENTER), timeout);
 }
 
-static inline void ctf_top_thread_sleep_ticks_exit(uint32_t timeout, int32_t ret)
+static inline void ctf_top_thread_sleep_ticks_exit(int32_t timeout, int32_t ret)
 {
 	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_THREAD_SLEEP_TICKS_EXIT), timeout, ret);
 }

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -3368,7 +3368,7 @@ event {
 	name = thread_sleep_ticks_enter;
 	id = 0x184;
 	fields := struct {
-		uint32_t timeout;
+		int32_t timeout;
 	};
 };
 
@@ -3376,7 +3376,7 @@ event {
 	name = thread_sleep_ticks_exit;
 	id = 0x185;
 	fields := struct {
-		uint32_t timeout;
+		int32_t timeout;
 		int32_t ret;
 	};
 };

--- a/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
+++ b/subsys/tracing/sysview/SYSVIEW_Zephyr.txt
@@ -8,6 +8,10 @@ NamedType Bool          0=false 1=true
 
 NamedType TimeOut       *="%u ticks" 0=TIMEOUT_NO_WAIT 4294967295=FOREVER
 
+# Sleep timeouts are signed. A negative value other than -1 is an absolute
+# deadline, encoded by Z_TICK_ABS() as -2 - deadline_ticks.
+NamedType SleepTicks    *="%d ticks" 0=K_NO_WAIT -1=K_FOREVER
+
 
 NamedType ErrCodePosix  *=%i 0=ESUCCESS  -1=EPERM        -2=ENOENT       -3=ESRCH         -4=EINTR            -5=EIO              -6=ENXIO       -7=E2BIG         -8=ENOEXEC       -9=EBADF       -10=ECHILD         -11=EAGAIN       -12=ENOMEM   -13=EACCES -14=EFAULT -15=ENOTEMPTY    -16=EBUSY   -17=EEXIST -18=EXDEV -19=ENODEV -20=ENOTDIR -21=EISDIR -22=EINVAL -23=ENFILE -24=EMFILE -25=ENOTTY -26=ENAMETOOLONG -27=EFBIG -28=ENOSPC -29=ESPIPE -30=EROFS -31=EMLINK -32=EPIPE -33=EDEADLK -34=ENOLCK -35=ENOTSUP -36=EMSGSIZE -72=ECANCELED -81=ERRMAX
 NamedType ErrCodeMath   *=%i 0=ESUCCESS -37=EDOM         -38=ERANGE
@@ -97,7 +101,7 @@ TaskState 0xBF 1=dummy, 2=Waiting, 4=New, 8=Terminated, 16=Suspended, 32=Termina
 93  timer->expiry_fn           timer=%I
 94  timer->stop_fn             timer=%I
 
-169 k_sleep_ticks              ticks=%u | Returns %u
+169 k_sleep_ticks              ticks=%SleepTicks | Returns %u
 
 98  k_thread_priority_set      thread=%t, priority=%u
 99  k_thread_wakeup

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -43,8 +43,13 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_thread_join_exit(thread, timeout, ret)                                    \
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_THREAD_JOIN, (int32_t)ret)
 
+/* Signed: K_FOREVER is -1 and an absolute timeout is a negative Z_TICK_ABS()
+ * encoding, so casting straight to unsigned loses which one this was. The
+ * wire format carries a raw 32-bit word either way, and the description file
+ * renders it signed. A deadline beyond 2^31 ticks still truncates.
+ */
 #define sys_port_trace_k_thread_sleep_ticks_enter(timeout)                                        \
-	SEGGER_SYSVIEW_RecordU32(TID_SLEEP_TICKS, (uint32_t)timeout.ticks)
+	SEGGER_SYSVIEW_RecordU32(TID_SLEEP_TICKS, (uint32_t)(int32_t)timeout.ticks)
 #define sys_port_trace_k_thread_sleep_ticks_exit(timeout, ret)                                     \
 	SEGGER_SYSVIEW_RecordEndCallU32(TID_SLEEP_TICKS, (int32_t)ret)
 


### PR DESCRIPTION
This pull request updates how thread sleep timeouts are represented and traced, switching from unsigned to signed integers to properly handle special values like `K_FOREVER` and absolute deadlines. The main changes ensure that negative timeout values are preserved and correctly interpreted across the trace infrastructure, including the CTF and SystemView tracing formats.

**Tracing infrastructure updates:**

* Changed the timeout parameter type from `uint32_t` to `int32_t` in `ctf_top_thread_sleep_ticks_enter` and `ctf_top_thread_sleep_ticks_exit` functions and their usage, ensuring signed values are passed through tracing events (`ctf_top.h`, `ctf_top.c`, `metadata`).
* Updated the SystemView trace macros to cast timeouts to signed 32-bit integers before tracing, preserving special negative values like `K_FOREVER` and absolute deadlines (`tracing_sysview.h`).

**Trace format and description updates:**

* Added a new `SleepTicks` named type to the SystemView description file, documenting that sleep timeouts are signed and explaining the encoding for absolute deadlines (`SYSVIEW_Zephyr.txt`).
* Updated the trace event for `k_sleep_ticks` to use the new `SleepTicks` type, ensuring correct display and interpretation of signed timeouts (`SYSVIEW_Zephyr.txt`).

These changes make the tracing of thread sleep timeouts more robust and accurate, especially when dealing with special timeout values.