### PR TITLE
twister: make a QEMU that cannot start visible and fail fast

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -1050,9 +1050,14 @@ class QEMUHandler(QEMUHandlerBase):
 
         self.pid_fn = os.path.join(instance.build_dir, "qemu.pid")
 
+        # The run command's stdout is the generator's own output (the failed
+        # command line when it fails), its stderr is what QEMU itself
+        # reports: a binary that cannot be executed, a bad option, missing
+        # firmware. The latter goes to the file the failure reports already
+        # read, so it reaches the inline log and twister.json.
         self.stdout_fn = os.path.join(instance.build_dir, "qemu.stdout")
 
-        self.stderr_fn = os.path.join(instance.build_dir, "qemu.stderr")
+        self.stderr_fn = os.path.join(instance.build_dir, "handler_stderr.log")
 
         if instance.testsuite.ignore_qemu_crash:
             self.ignore_crash = True

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -1220,6 +1220,44 @@ class QEMUHandler(QEMUHandlerBase):
         self.fifo_fn = os.path.join(self.instance.build_dir, "qemu-fifo")
         super()._set_qemu_filenames(sysbuild_build_dir)
 
+    # Seconds given to the monitor thread to drain the pipe after QEMU
+    # exited before it is assumed to be blocked on a fifo open.
+    EXIT_GRACE_PERIOD = 1.0
+
+    def _release_thread(self, timeout=5.0):
+        """Unblock the monitor thread after QEMU exited without connecting.
+
+        The thread opens the fifos as QEMU's counterpart, and each of those
+        opens blocks until QEMU opens the other end. When QEMU never
+        starts, for instance because the run command could not execute it,
+        the thread sits in open() for the whole test timeout. Connect to
+        the fifos in QEMU's place and disconnect again: the thread's
+        opens return, it reads EOF and finishes.
+
+        Returns True when the thread was connected to, False when it did
+        not open its end within the timeout or was gone already.
+        """
+        fifo_in, fifo_out = self._thread_get_fifo_names(self.fifo_fn)
+        in_fd = None
+        out_fd = None
+        deadline = time.time() + timeout
+        while out_fd is None and self.thread.is_alive() and time.time() < deadline:
+            try:
+                if in_fd is None:
+                    in_fd = os.open(fifo_in, os.O_RDONLY | os.O_NONBLOCK)
+                out_fd = os.open(fifo_out, os.O_WRONLY | os.O_NONBLOCK)
+            except OSError:
+                # ENOENT: the thread has not created the fifos yet, or has
+                # finished and removed them. ENXIO: it has not opened its
+                # reading end of fifo_out yet.
+                time.sleep(0.05)
+
+        if in_fd is not None:
+            os.close(in_fd)
+        if out_fd is not None:
+            os.close(out_fd)
+        return out_fd is not None
+
     def handle(self, harness):
         robot_test = getattr(harness, "is_robot_test", False) is True
 
@@ -1267,6 +1305,7 @@ class QEMUHandler(QEMUHandlerBase):
 
         failure_type = self.FailureType.NONE
         qemu_pid = None
+        never_started = False
 
         # As in BinaryHandler._handle: no terminal stdin for QEMU while the
         # --console-monitor UI owns the terminal.
@@ -1300,12 +1339,32 @@ class QEMUHandler(QEMUHandlerBase):
                         qemu_pid = int(pid_file.read())
                 logger.debug(f"No timeout, return code from QEMU ({qemu_pid}): {proc.returncode}")
                 self.returncode = proc.returncode
+                never_started = qemu_pid is None and proc.returncode != 0
+
+                # QEMU is gone, so the thread has at most buffered output
+                # left to read. If it is still around after that, it is
+                # blocked opening a fifo QEMU never connected to, which is
+                # what a run command that could not start QEMU leaves
+                # behind. Connect in QEMU's place so the thread finishes
+                # now instead of when the test timeout expires.
+                self.thread.join(self.EXIT_GRACE_PERIOD)
+                if self.thread.is_alive():
+                    logger.debug(
+                        f"QEMU exited with {proc.returncode} without connecting: "
+                        f"releasing the monitor thread"
+                    )
+                    self._release_thread()
             # Need to wait for harness to finish processing
             # output from QEMU. Otherwise it might miss some
             # messages.
             self.thread.join(max(thread_max_time - time.time(), 0))
             if self.thread.is_alive():
                 logger.debug("Timed out while monitoring QEMU output")
+            if never_started:
+                # QEMU never wrote its pid file, so the thread saw EOF on
+                # a pipe nothing ever wrote to. The exit code names the
+                # failure, not that EOF.
+                self.instance.reason = None
 
             if os.path.exists(self.pid_fn):
                 try:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -403,8 +403,9 @@ class JsonReport:
                 suite["status"] = TwisterStatus.NOTRUN
                 suite["reason"] = instance.reason
             else:
+                # Not run yet, as in a test plan saved before running:
+                # there is no reason to give.
                 suite["status"] = TwisterStatus.NONE
-                suite["reason"] = 'Unknown Instance status'
 
             if instance.status != TwisterStatus.NONE:
                 suite["execution_time"] =  f"{float(handler_time):.2f}"

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1660,6 +1660,10 @@ class ProjectBuilder(FilterBuilder):
         if instance.handler.ready:
             logger.debug(f"Reset instance status from '{instance.status}' to None before run.")
             instance.status = TwisterStatus.NONE
+            # The handler only fills in a reason of its own, such as the exit
+            # code, when none is set: drop whatever a loaded test plan or an
+            # earlier retry iteration left behind.
+            instance.reason = None
 
             if(self.options.seed is not None and instance.platform.name.startswith("native_")):
                 self.parse_generated()

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -724,6 +724,12 @@ class ProjectBuilder(FilterBuilder):
             self.log_info(f"{script_log}", inline_logs, log_only_failed=True)
         elif os.path.exists(h_log) and os.path.getsize(h_log) > 0:
             self.log_info(f"{h_log}", inline_logs)
+            # What the process wrote to stderr (a loader or sanitizer
+            # message, QEMU refusing to start) explains a console log
+            # that stops short; show it with the console output like the
+            # JSON report does.
+            if os.path.exists(he_log) and os.path.getsize(he_log) > 0:
+                self.log_info(f"{he_log}", inline_logs)
         elif os.path.exists(he_log) and os.path.getsize(he_log) > 0:
             self.log_info(f"{he_log}", inline_logs)
         elif os.path.exists(d_log) and os.path.getsize(d_log) > 0:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -822,6 +822,12 @@ class TestPlan:
                     elif status == TwisterStatus.NOTRUN and instance.run and self.options.test_only:
                         instance.status = TwisterStatus.NONE
                         instance.reason = None
+                    elif status == TwisterStatus.NONE:
+                        # Not run yet: whatever reason the plan carries
+                        # (older twister versions wrote a placeholder)
+                        # must not survive into this run's results.
+                        instance.status = status
+                        instance.reason = None
                     else:
                         instance.status = status
                         instance.reason = reason

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -12,6 +12,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from contextlib import nullcontext
 from importlib import reload
 from subprocess import CalledProcessError, TimeoutExpired
@@ -1739,17 +1740,28 @@ def test_qemuhandler_thread(
 
 
 TESTDATA_26 = [
-    (True, False, TwisterStatus.NONE, True,
+    (True, False, TwisterStatus.NONE, True, True, 'stale',
      ['No timeout, return code from QEMU (1): 1',
       'return code from QEMU (1): 1']),
-    (False, True, TwisterStatus.PASS, True, ['return code from QEMU (1): 0']),
-    (False, True, TwisterStatus.FAIL, False, ['return code from QEMU (None): 1']),
+    (False, True, TwisterStatus.PASS, True, False, 'stale',
+     ['return code from QEMU (1): 0']),
+    (False, True, TwisterStatus.FAIL, False, False, 'harness reason',
+     ['return code from QEMU (None): 1']),
+    # The run command exited without QEMU ever writing its pid file: the
+    # monitor thread is released and the exit code, not the stale reason,
+    # names the failure.
+    (False, False, TwisterStatus.NONE, False, True, 'Exited with 1',
+     ['No timeout, return code from QEMU (None): 1',
+      'QEMU exited with 1 without connecting: releasing the monitor thread',
+      'return code from QEMU (None): 1']),
 ]
 
 @pytest.mark.parametrize(
-    'isatty, do_timeout, harness_status, exists_pid_fn, expected_logs',
+    'isatty, do_timeout, harness_status, exists_pid_fn,'
+    ' expect_release, expected_reason, expected_logs',
     TESTDATA_26,
-    ids=['no timeout, isatty', 'timeout passed', 'timeout, no pid_fn']
+    ids=['no timeout, isatty', 'timeout passed', 'timeout, no pid_fn',
+         'exited before start']
 )
 def test_qemuhandler_handle(
     mocked_instance,
@@ -1759,6 +1771,8 @@ def test_qemuhandler_handle(
     do_timeout,
     harness_status,
     exists_pid_fn,
+    expect_release,
+    expected_reason,
     expected_logs
 ):
     def mock_wait(*args, **kwargs):
@@ -1791,7 +1805,7 @@ def test_qemuhandler_handle(
         handler.pid_fn = os.path.join(sysbuild_build_dir, 'qemu.pid')
         handler.log_fn = os.path.join('dummy', 'log')
 
-    harness = mock.Mock(status=harness_status, fault=False)
+    harness = mock.Mock(status=harness_status, fault=False, reason='harness reason')
     handler_options_west_flash = []
 
     domain_build_dir = os.path.join('sysbuild', 'dummydir')
@@ -1810,6 +1824,9 @@ def test_qemuhandler_handle(
     handler._set_qemu_filenames = mock.Mock(side_effect=mock_filenames)
     handler.get_default_domain_build_dir = mock.Mock(return_value=domain_build_dir)
     handler.terminate = mock.Mock()
+    handler._release_thread = mock.Mock(return_value=True)
+    # A reason left over from a previous iteration or a loaded test plan.
+    handler.instance.reason = 'stale'
 
     unlink_mock = mock.Mock()
 
@@ -1822,6 +1839,50 @@ def test_qemuhandler_handle(
         handler.handle(harness)
 
     assert all([expected_log in caplog.text for expected_log in expected_logs])
+    assert handler._release_thread.called == expect_release
+    assert handler.instance.reason == expected_reason
+
+
+def test_qemuhandler_release_thread(mocked_instance, tmp_path):
+    """The monitor thread blocks opening the fifos until QEMU connects.
+
+    When QEMU never does, _release_thread() connects in its place and the
+    thread finishes with the EOF it then reads, instead of sitting in
+    open() until the test timeout.
+    """
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
+    handler.fifo_fn = str(tmp_path / 'qemu-fifo')
+    handler.pid_fn = str(tmp_path / 'qemu.pid')
+    handler.log_fn = str(tmp_path / 'handler.log')
+    harness = mock.Mock(status=TwisterStatus.NONE, fault=False)
+
+    handler.thread = threading.Thread(
+        target=QEMUHandler._thread,
+        args=(handler, 60, str(tmp_path), handler.log_fn, handler.fifo_fn,
+              handler.pid_fn, harness, False),
+        daemon=True,
+    )
+    handler.thread.start()
+
+    with mock.patch(
+        'twisterlib.handlers.QEMUHandler._thread_update_instance_info'
+    ) as update_mock:
+        assert handler._release_thread(timeout=5) is True
+        handler.thread.join(5)
+
+    assert not handler.thread.is_alive()
+    update_mock.assert_called_once_with(handler, TwisterStatus.FAIL, 'unexpected eof')
+    assert not os.path.exists(handler.fifo_fn + '.in')
+    assert not os.path.exists(handler.fifo_fn + '.out')
+
+
+def test_qemuhandler_release_thread_gone(mocked_instance, tmp_path):
+    """Nothing to release once the thread has finished and removed the fifos."""
+    handler = QEMUHandler(mocked_instance, 'build', mock.Mock(timeout_multiplier=1))
+    handler.fifo_fn = str(tmp_path / 'qemu-fifo')
+    handler.thread = mock.Mock(is_alive=mock.Mock(return_value=False))
+
+    assert handler._release_thread(timeout=5) is False
 
 
 def test_qemuhandler_get_fifo(mocked_instance):

--- a/scripts/tests/twister/test_reports.py
+++ b/scripts/tests/twister/test_reports.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import pytest
 from twisterlib.reports import JsonReport, ReportingJSONEncoder, ReportStatus
+from twisterlib.statuses import TwisterStatus
 
 
 def test_report_status_is_its_value():
@@ -209,3 +210,39 @@ TESTDATA_DETAILED_REASON = [
 def test_get_detailed_reason(reason, lines, expected):
     report = JsonReport(mock.Mock(), {})
     assert report.get_detailed_reason(reason, '\n'.join(lines)) == expected
+
+
+def test_json_report_gives_no_reason_for_a_suite_not_run(tmp_path):
+    """A suite with no status yet, as in a saved test plan, gets no reason.
+
+    A reason there would be loaded back with the plan and shown for the
+    run instead of what actually happened.
+    """
+    env = mock.Mock(toolchain='zephyr', commit_date='today', run_date='today')
+    env.options.report_all_options = False
+    env.non_default_options = mock.Mock(return_value={})
+    instance = mock.Mock(
+        status=TwisterStatus.NONE,
+        reason=None,
+        run_id=None,
+        run=True,
+        metrics={},
+        retries=0,
+        toolchain='zephyr',
+        hardware_id=None,
+        build_dir=str(tmp_path),
+        build_time=0,
+        testcases=[],
+        recording=None,
+    )
+    instance.testsuite.name = 'suite'
+    instance.testsuite.source_dir_rel = 'tests/suite'
+    instance.platform.name = 'plat'
+    instance.platform.arch = 'arch'
+    report = tmp_path / 'testplan.json'
+
+    JsonReport(env, {'plat/suite': instance}).create(report)
+
+    suite = json.loads(report.read_text())['testsuites'][0]
+    assert suite['status'] == TwisterStatus.NONE
+    assert 'reason' not in suite

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -797,21 +797,26 @@ def test_projectbuilder_log_info(
 
 
 TESTDATA_5 = [
-    (True, False, False, "Valgrind error", 0, 0, 'build_dir/valgrind.log'),
-    (True, False, False, "Error", 0, 0, 'build_dir/build.log'),
-    (False, True, False, None, 1024, 0, 'build_dir/handler.log'),
-    (False, True, False, None, 0, 0, 'build_dir/build.log'),
-    (False, False, True, None, 0, 1024, 'build_dir/device.log'),
-    (False, False, True, None, 0, 0, 'build_dir/build.log'),
-    (False, False, False, None, 0, 0, 'build_dir/build.log'),
+    (True, False, False, "Valgrind error", 0, 0, 0, ['build_dir/valgrind.log']),
+    (True, False, False, "Error", 0, 0, 0, ['build_dir/build.log']),
+    (False, True, False, None, 1024, 0, 0, ['build_dir/handler.log']),
+    (False, True, False, None, 1024, 512, 0,
+     ['build_dir/handler.log', 'build_dir/handler_stderr.log']),
+    (False, True, False, None, 0, 512, 0, ['build_dir/handler_stderr.log']),
+    (False, True, False, None, 0, 0, 0, ['build_dir/build.log']),
+    (False, False, True, None, 0, 0, 1024, ['build_dir/device.log']),
+    (False, False, True, None, 0, 0, 0, ['build_dir/build.log']),
+    (False, False, False, None, 0, 0, 0, ['build_dir/build.log']),
 ]
 
 @pytest.mark.parametrize(
     'valgrind_log_exists, handler_log_exists, device_log_exists,' \
-    ' instance_reason, handler_log_getsize, device_log_getsize, expected_log',
+    ' instance_reason, handler_log_getsize, handler_stderr_log_getsize,' \
+    ' device_log_getsize, expected_logs',
     TESTDATA_5,
     ids=['valgrind log', 'valgrind log unused',
-         'handler log', 'handler log unused',
+         'handler log', 'handler log with stderr', 'stderr only',
+         'handler log unused',
          'device log', 'device log unused',
          'no logs']
 )
@@ -823,12 +828,15 @@ def test_projectbuilder_log_info_file(
     device_log_exists,
     instance_reason,
     handler_log_getsize,
+    handler_stderr_log_getsize,
     device_log_getsize,
-    expected_log
+    expected_logs
 ):
     def mock_exists(filename, *args, **kwargs):
         if filename == 'build_dir/handler.log':
             return handler_log_exists
+        if filename == 'build_dir/handler_stderr.log':
+            return handler_stderr_log_getsize > 0
         if filename == 'build_dir/valgrind.log':
             return valgrind_log_exists
         if filename == 'build_dir/device.log':
@@ -838,6 +846,8 @@ def test_projectbuilder_log_info_file(
     def mock_getsize(filename, *args, **kwargs):
         if filename == 'build_dir/handler.log':
             return handler_log_getsize
+        if filename == 'build_dir/handler_stderr.log':
+            return handler_stderr_log_getsize
         if filename == 'build_dir/device.log':
             return device_log_getsize
         return 0
@@ -856,7 +866,9 @@ def test_projectbuilder_log_info_file(
          mock.patch('twisterlib.runner.ProjectBuilder.log_info', log_info_mock):
         pb.log_info_file(None)
 
-    log_info_mock.assert_called_with(expected_log, mock.ANY)
+    assert log_info_mock.call_args_list == [
+        mock.call(expected_log, mock.ANY) for expected_log in expected_logs
+    ]
 
 
 TESTDATA_6 = [

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2603,6 +2603,8 @@ def test_projectbuilder_run(
     instance_mock.platform.arch = platform_arch
     instance_mock.testsuite.harness = harness
     instance_mock.sidecar = None
+    # A reason left over from a loaded test plan or a previous iteration.
+    instance_mock.reason = 'stale'
     env_mock = mock.Mock()
 
     pb = ProjectBuilder(instance_mock, env_mock, mocked_jobserver)
@@ -2614,6 +2616,12 @@ def test_projectbuilder_run(
     with mock.patch('twisterlib.runner.HarnessImporter.get_harness',
                     mock_harness):
         pb.run()
+
+    if ready:
+        assert instance_mock.status == TwisterStatus.NONE
+        assert instance_mock.reason is None
+    else:
+        assert instance_mock.reason == 'stale'
 
     if expect_parse_generated:
         pb.parse_generated.assert_called_once()

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -1705,9 +1705,11 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     ts1 = mock.Mock(testcases=[ts1tc1])
     ts1.name = 'TestSuite 1'
     ts1.toolchain = 'zephyr'
+    ts1.required_applications = []
     ts2 = mock.Mock(testcases=[])
     ts2.name = 'TestSuite 2'
     ts2.toolchain = 'zephyr'
+    ts2.required_applications = []
     ts3tc1 = mock.Mock()
     ts3tc1.name = 'TS3.tc1'
     ts3tc2 = mock.Mock()
@@ -1715,14 +1717,17 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     ts3 = mock.Mock(testcases=[ts3tc1, ts3tc2])
     ts3.name = 'TestSuite 3'
     ts3.toolchain = 'zephyr'
+    ts3.required_applications = []
     ts4tc1 = mock.Mock()
     ts4tc1.name = 'TS4.tc1'
     ts4 = mock.Mock(testcases=[ts4tc1])
     ts4.name = 'TestSuite 4'
     ts4.toolchain = 'zephyr'
+    ts4.required_applications = []
     ts5 = mock.Mock(testcases=[])
     ts5.name = 'TestSuite 5'
     ts5.toolchain = 'zephyr'
+    ts5.required_applications = []
 
     env = mock_twister_env()
     env.outdir = os.path.join('out', 'dir')
@@ -1766,7 +1771,9 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
         {
             "name": "TestSuite 2",
             "platform": "Platform 1",
-            "toolchain": "zephyr"
+            "toolchain": "zephyr",
+            "status": null,
+            "reason": "Unknown Instance status"
         },
         {
             "name": "TestSuite 3",
@@ -1863,6 +1870,8 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
                 'available_ram': 0,
                 'available_rom': 0
             },
+            'status': TwisterStatus.NONE,
+            'reason': None,
             'retries': 0,
             'toolchain': 'zephyr',
             'testcases': []
@@ -1916,6 +1925,9 @@ def test_testplan_load_from_file(caplog, device_testing, expected_tfilter):
     for n, i in testplan.instances.items():
         assert expected_instances[n]['metrics'] == i.metrics
         assert expected_instances[n]['retries'] == i.retries
+        if 'status' in expected_instances[n]:
+            assert expected_instances[n]['status'] == i.status
+            assert expected_instances[n]['reason'] == i.reason
         for t in i.testcases:
             assert expected_instances[n]['testcases'][str(t)]['status'] == t.status
             assert expected_instances[n]['testcases'][str(t)]['reason'] == t.reason


### PR DESCRIPTION
When the `run` target cannot start QEMU at all (binary not found, missing
shared library, rejected option), twister reports the test only after the full
test timeout, with the reason "Unknown Instance status" and `build.log` as the
failing log, which shows a build that succeeded. Nothing points at the actual
error. This is what the qemu_hexagon runs in CI looked like when
`qemu-system-hexagon` failed to load `libslirp.so.0`: four minutes per test,
then a passing build log printed as the failure (see
https://github.com/zephyrproject-rtos/zephyr/actions/runs/34694253211/job/103555265833).
