### PR TITLE
ci: workflows: use updated docker ci-repo-cache:v0.29.4.20260912

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -43,7 +43,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 120
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -21,7 +21,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 360
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -16,7 +16,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 300
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     permissions:
       contents: read

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     timeout-minutes: 60
     concurrency:

--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     timeout-minutes: 60
     env:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 120
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     defaults:
       run:

--- a/.github/workflows/gcc-analyzer.yml
+++ b/.github/workflows/gcc-analyzer.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     timeout-minutes: 720
     permissions:

--- a/.github/workflows/push_artifacts.yml
+++ b/.github/workflows/push_artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     timeout-minutes: 360
     env:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     timeout-minutes: 600
     permissions:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -29,7 +29,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 60
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
@@ -156,7 +156,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.4.20260912
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
The new version has two fixes since 0.29.3:

- add 32-bit libnl development packages
- install qemu-system-hexagon runtime dependencies

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
