### PR TITLE
doc: kernel: fix typos

### DIFF
--- a/doc/kernel/object_cores/index.rst
+++ b/doc/kernel/object_cores/index.rst
@@ -15,13 +15,13 @@ Object Core Concepts
 
 Each instance of an object embeds an object core field named ``obj_core``.
 Objects of the same type are linked together via their respective object
-cores to form a singly linked list. Each object core also links to the their
+cores to form a singly linked list. Each object core also links to their
 respective object type. Each object type contains a singly linked list
 linking together all the object cores of that type. Object types are also
 linked together via a singly linked list. Together, this can allow debugging
 tools to traverse all the objects in the system.
 
-Object cores have been integrated into following kernel objects:
+Object cores have been integrated into the following kernel objects:
 
 * :ref:`Condition Variables <condvar>`
 * :ref:`Events <events>`

--- a/doc/kernel/timeutil.rst
+++ b/doc/kernel/timeutil.rst
@@ -6,8 +6,8 @@ Time Utilities
 Overview
 ********
 
-:ref:`kernel_timing_uptime` in Zephyr is based on the a tick counter.  With
-the default :kconfig:option:`CONFIG_TICKLESS_KERNEL` this counter advances at a
+:ref:`kernel_timing_uptime` in Zephyr is based on a tick counter.  With
+the default :kconfig:option:`CONFIG_TICKLESS_KERNEL`, this counter advances at a
 nominally constant rate from zero at the instant the system started. The POSIX
 equivalent to this counter is something like ``CLOCK_MONOTONIC`` or, in Linux,
 ``CLOCK_MONOTONIC_RAW``.  :c:func:`k_uptime_get()` provides a millisecond
@@ -88,13 +88,13 @@ Time Scale Synchronization
 
 There are several factors that affect synchronizing time scales:
 
-* The rate of discrete instant representation change.  For example Zephyr
+* The rate of discrete instant representation change.  For example, Zephyr
   uptime is tracked in ticks which advance at events that nominally occur at
   :kconfig:option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` Hertz, while an external time
   source may provide data in whole or fractional seconds (e.g. microseconds).
 * The absolute offset required to align the two scales at a single instant.
 * The relative error between observable instants in each scale, required to
-  align multiple instants consistently.  For example a reference clock that's
+  align multiple instants consistently.  For example, a reference clock that's
   conditioned by a 1-pulse-per-second GPS signal will be much more accurate
   than a Zephyr system clock driven by a RC oscillator with a +/- 250 ppm
   error.


### PR DESCRIPTION
While reading the documentation, I cleaned up these typos.