### PR TITLE
i3c: fix I3C_DEVICE_ID() expansion for arguments not named pid

### DIFF
--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -988,12 +988,9 @@ struct i3c_device_id {
  * This helper macro expands to a static initializer for a i3c_device_id
  * by populating the PID (Provisioned ID) field.
  *
- * @param pid Provisioned ID.
+ * @param pid_val Provisioned ID.
  */
-#define I3C_DEVICE_ID(pid)						\
-	{								\
-		.pid = pid						\
-	}
+#define I3C_DEVICE_ID(pid_val) {.pid = pid_val}
 
 /**
  * @brief Structure describing a I3C target device.


### PR DESCRIPTION
Renaming the I3C_DEVICE_ID parameter to pid_val.  Using the pid name as both the struct member and the assigned value meant any variable passed in that's not also named 'pid' would fail to build