### PR TITLE
drivers: i3c: Fix return error for detaching an already detached device

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -961,7 +961,7 @@ int i3c_bus_rstdaa_all(const struct device *dev)
 		LOG_DBG("%s: Reset dynamic address for device %s", dev->name,
 			desc->dev->name);
 		dret = i3c_detach_i3c_device(desc);
-		if (dret != 0) {
+		if ((dret != 0) && (dret != -EALREADY)) {
 			LOG_ERR("%s: failed to detach %s (%d)", dev->name,
 				desc->dev->name, dret);
 		}

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1928,8 +1928,7 @@ static int dw_i3c_detach_device(const struct device *dev, struct i3c_device_desc
 	struct dw_i3c_i2c_dev_data *dw_i3c_device_data = desc->controller_priv;
 
 	if (dw_i3c_device_data == NULL) {
-		LOG_ERR("%s: %s: device not attached", dev->name, desc->dev->name);
-		return -EINVAL;
+		return -EALREADY;
 	}
 
 	LOG_DBG("%s: Detaching %s", dev->name, desc->dev->name);


### PR DESCRIPTION
Fix detach to return EALREADY, not EINVAL, when detaching a device that isn't attached - per its own documentation