### PR TITLE
drivers: ethernet: dwc_mac: 1000: set the programmable burst length

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -635,9 +635,14 @@ int dwmac_probe(const struct device *dev)
 	memset(p->tx_descs, 0, NB_TX_DESCS * sizeof(struct dwmac_dma_desc));
 	memset(p->rx_descs, 0, NB_RX_DESCS * sizeof(struct dwmac_dma_desc));
 
+	reg_val = DWMAC_REG_READ(DWMAC_DMABMR) & ~DWMAC_DMABMR_PBL;
+	reg_val |= FIELD_PREP(DWMAC_DMABMR_PBL, 32);
+
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)) {
-		DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_EDFE);
+		reg_val |= DWMAC_DMABMR_EDFE;
 	}
+
+	DWMAC_REG_WRITE(DWMAC_DMABMR, reg_val);
 
 	DWMAC_REG_WRITE(DWMAC_DMATDLAR, TXDESC_PHYS_L(0));
 	DWMAC_REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -1466,7 +1466,17 @@ extern const struct ethernet_api dwmac_api;
 
 /* DMA bus mode bits */
 #define DWMAC_DMABMR_SR    BIT(0)
+#define DWMAC_DMABMR_DA    BIT(1)
+#define DWMAC_DMABMR_DSL   GENMASK(6, 2)
 #define DWMAC_DMABMR_EDFE  BIT(7)
+#define DWMAC_DMABMR_PBL   GENMASK(13, 8)
+#define DWMAC_DMABMR_PR    GENMASK(15, 14)
+#define DWMAC_DMABMR_FB    BIT(16)
+#define DWMAC_DMABMR_RPBL  GENMASK(22, 17)
+#define DWMAC_DMABMR_USP   BIT(23)
+#define DWMAC_DMABMR_PBLx8 BIT(24)
+#define DWMAC_DMABMR_AAL   BIT(25)
+#define DWMAC_DMABMR_MB    BIT(26)
 
 /* DMA interrupt enable bits */
 #define DWMAC_DMAIER_TIE   BIT(0)

--- a/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
@@ -31,7 +31,7 @@ BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii) ||
 		     DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii),
 	     "Unsupported PHY interface type. Only RMII and MII are supported.");
 
-/* The DMA bus master interface is 32-bit on this IP */
+/* The DMA bus master interface is a 32-bit AHB interface on this IP */
 #define DATA_BUS_WIDTH 32
 
 DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
@@ -119,6 +119,8 @@ int dwmac_platform_init(const struct device *dev)
 	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 	struct dwmac_priv *p = dev->data;
 	int ret;
+
+	DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_DMABMR_AAL | DWMAC_DMABMR_FB);
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 #include "eth_dwmac_priv.h"
 #include "eth_stm32_dwc.h"
 
-/* The DMA bus master interface is 32-bit on this IP */
+/* The DMA bus master interface is a 32-bit AHB interface on this IP */
 #define DATA_BUS_WIDTH 32
 
 DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
@@ -123,6 +123,8 @@ int dwmac_platform_init(const struct device *dev)
 {
 	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 	struct dwmac_priv *p = dev->data;
+
+	DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_DMABMR_AAL | DWMAC_DMABMR_FB);
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;

--- a/drivers/ethernet/dwc_mac/eth_xmc_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_xmc_dwc_ether_1000.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 
 #include "eth_dwmac_priv.h"
 
-/* The DMA bus master interface is 32-bit on this IP */
+/* The DMA bus master interface is a 32-bit AHB interface on this IP */
 #define DATA_BUS_WIDTH 32
 
 DWMAC_ASSERT_BUFFER_ALIGNMENT(DATA_BUS_WIDTH);
@@ -88,6 +88,8 @@ int dwmac_platform_init(const struct device *dev)
 	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 	struct dwmac_priv *p = dev->data;
 	int ret;
+
+	DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_DMABMR_AAL | DWMAC_DMABMR_FB);
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;


### PR DESCRIPTION
The DMA bus mode register was only ever written for the software reset and the descriptor size, which left the programmable burst length at its reset value of one beat, so the DMA moved a single beat per bus transaction. Set it to 32 beats, which is what the vendor drivers of every platform this core supports use. Configure the individual glue layers to utilize fixed length bursts with address aligned beats.

This matches the configuration that is also used with the QoS core.