### PR TITLE
tests: sbom: do not depend on the REUSE copyright symbol spelling

### DIFF
--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -15,6 +15,7 @@ and license information for a minimal Zephyr application.
 
 import hashlib
 import os
+import re
 
 import pytest
 from spdx_tools.spdx.model import ExternalPackageRefCategory
@@ -54,7 +55,7 @@ FILE_REUSE_TOML_C = "./src/no_header.c"
 # Common license and copyright strings as they appear in the SBOM.
 LICENSE_APACHE = "Apache-2.0"
 COPYRIGHT_ZEPHYR = "Copyright The Zephyr Project Contributors"
-COPYRIGHT_LINUX_FOUNDATION = "Copyright (C) 2026 The Linux Foundation"
+COPYRIGHT_LINUX_FOUNDATION = "Copyright (c) 2026 The Linux Foundation"
 
 # Fake vendor blobs provided by the used module: one linked as an imported
 # library, one via -lNAME/-L linker flags and one via an -l:FILENAME flag.
@@ -68,13 +69,23 @@ BLOB_CONTENT = b"!<arch>\n"
 BLOB_VERSION = "1.2.3"
 BLOB_URL_PREFIX = "https://example.com/blobs/"
 LICENSE_BLOBS = "MIT"
-# REUSE canonicalizes copyright notices, so the "(c)" the module's REUSE.toml
-# declares is surfaced as "(C)" here.
-COPYRIGHT_BLOBS = "Copyright (C) 2026 Fake Vendor"
+COPYRIGHT_BLOBS = "Copyright (c) 2026 Fake Vendor"
 
 # answer.c declares its copyright with the SPDX tag, and the scanner stores each
 # notice canonically between newlines, so this is the exact value in the SBOM.
 EXPECTED_USED_MODULE_COPYRIGHT = f"\nSPDX-FileCopyrightText: {COPYRIGHT_ZEPHYR}\n"
+
+
+def normalize_copyright(text):
+    """
+    Fold the copyright symbol to a single spelling.
+
+    REUSE re-renders a notice from a canonical prefix rather than echoing the
+    one the source declares, and which of "(c)" or "(C)" it picks varies
+    between library versions, so normalize both sides before comparing.
+    """
+
+    return re.sub(r"\(c\)", "(C)", str(text), flags=re.IGNORECASE)
 
 
 def find_file_by_name(doc, name):
@@ -381,10 +392,12 @@ class TestAppDocument:
 
         assert main_c_spdx.copyright_text, "app.spdx: main.c has no copyright_text"
 
-        copyright_text = str(main_c_spdx.copyright_text)
+        copyright_text = normalize_copyright(main_c_spdx.copyright_text)
         expected = [COPYRIGHT_ZEPHYR, COPYRIGHT_LINUX_FOUNDATION]
         for s in expected:
-            assert s in copyright_text, f"main.c copyright missing '{s}', got '{copyright_text}'"
+            assert normalize_copyright(s) in copyright_text, (
+                f"main.c copyright missing '{s}', got '{main_c_spdx.copyright_text}'"
+            )
 
 
 class TestZephyrDocument:
@@ -1149,7 +1162,8 @@ class TestBlobs:
 
     def test_blob_copyright_from_reuse_toml(self, blob_file):
         """Binary blobs cannot carry SPDX headers; REUSE.toml supplies their copyright."""
-        assert COPYRIGHT_BLOBS in str(blob_file.copyright_text), (
+        copyright_text = normalize_copyright(blob_file.copyright_text)
+        assert normalize_copyright(COPYRIGHT_BLOBS) in copyright_text, (
             f"zephyr.spdx: {blob_file.name} copyright should come from REUSE.toml "
             f"('{COPYRIGHT_BLOBS}'), got '{blob_file.copyright_text}'"
         )


### PR DESCRIPTION
The SBOM content tests compared copyright notices against constants that
hardcoded "Copyright (C)", while the fixtures declare "Copyright (c)" in
src/main.c and used_module/REUSE.toml. That only worked because REUSE
re-renders a notice from a canonical prefix instead of echoing the
source: released reuse 6.x has no lowercase member in CopyrightPrefix,
so it close-matched "Copyright (c)" to "Copyright (C)".

The revision pinned in scripts/requirements-compliance.txt adds the
lowercase members, so it preserves what the source declares. Both declare
version 6.2.0, so pip leaves an already-installed copy alone and the
container image decides which one runs; after commit e5d4c2cd3330
("ci: workflows: use updated docker ci-repo-cache:v0.29.4.20260912") the
notices came out lowercase and test_main_c_copyright_correct and
test_blob_copyright_from_reuse_toml failed on an unchanged tree.

Spell the constants the way the fixtures declare them and fold the symbol
on both sides of the comparison, so the tests pass under either rendering
and no longer depend on which reuse is installed. Verified the helper
against the notices from both; the twister scenario itself was not run
locally.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
