### PR TITLE
logging: fix lost wakeup when attaching the first backend

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -107,7 +107,7 @@ K_SEM_DEFINE(log_process_thread_sem, 0, 1);
 
 static atomic_t initialized;
 static bool panic_mode;
-static bool backend_attached;
+static atomic_t backend_attached;
 static atomic_t buffered_cnt;
 static atomic_t dropped_cnt;
 static k_tid_t proc_tid;
@@ -547,14 +547,16 @@ void unordered_notify(void)
 
 void z_log_notify_backend_enabled(void)
 {
+	atomic_val_t was_attached = atomic_set(&backend_attached, 1);
+
 	/* Wakeup logger thread after attaching first backend. It might be
-	 * blocked with log messages pending.
+	 * blocked with log messages pending. Flag is set before giving the
+	 * semaphore so that the woken up thread sees the backend as attached
+	 * and does not skip processing and go back to sleep.
 	 */
-	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD) && !backend_attached) {
+	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD) && was_attached == 0) {
 		k_sem_give(&log_process_thread_sem);
 	}
-
-	backend_attached = true;
 }
 
 static inline bool z_log_unordered_pending(void)
@@ -571,7 +573,7 @@ bool z_impl_log_process(void)
 	k_timeout_t backoff = K_NO_WAIT;
 	union log_msg_generic *msg;
 
-	if (!backend_attached) {
+	if (atomic_get(&backend_attached) == 0) {
 		return false;
 	}
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -40,10 +40,15 @@ void z_shell_log_backend_enable(const struct shell_log_backend *backend,
 
 	if (err == 0) {
 		fifo_reset(backend);
-		log_backend_enable(backend->backend, ctx, init_log_level);
 		log_output_ctx_set(backend->log_output, ctx);
 		backend->control_block->dropped_cnt = 0;
+		/* Set the state before activating the backend. When the backend
+		 * is activated the logging thread may immediately dispatch
+		 * buffered messages which would be dropped if the backend was
+		 * not yet in the enabled state.
+		 */
 		backend->control_block->state = SHELL_LOG_BACKEND_ENABLED;
+		log_backend_enable(backend->backend, ctx, init_log_level);
 	}
 }
 


### PR DESCRIPTION
The log processing thread does not poll periodically: when no autostart backend is pending activation it parks on log_process_thread_sem with K_FOREVER, and the first flush of the boot messages depends on the single wake token given by z_log_notify_backend_enabled().

The token is given before backend_attached is set, and that flag is a plain bool the woken thread reads without synchronization. On SMP the log thread runs on another core and can observe a stale backend_attached == false, return from log_process() without claiming any message, and park again. The semaphore limit is 1, so the token is gone. Messages buffered before the log thread first ran never armed the one-shot trigger timer, and as long as their count stays below CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD nothing wakes the thread again.

The shell log backend opens a second window: it sets its state to SHELL_LOG_BACKEND_ENABLED only after log_backend_enable() returns, so a log thread dispatched in between finds the backend active but still in the SHELL_LOG_BACKEND_UNINIT state and process() silently discards the claimed messages.

Fix both windows:

- make backend_attached an atomic_t and set it before giving the semaphore, so the woken thread always observes the backend as attached;

- set the shell backend state, output context and dropped count before activating the backend, so messages dispatched right after activation are processed instead of dropped.

The two changes are interdependent: closing only the first window makes the woken thread hit the second.

Verified on a quad-core rk3588 board, where the race is reachable at every boot with the shell as the only non-autostart log backend: without the fix, boot logs appeared late or not at all; with it, 100 consecutive boots flushed all boot logs before the first prompt. The logging test suite passes on native_sim; builds were verified in deferred and immediate modes.

Fixes #118927

Assisted-by: Claude:glm-5.3