### PR TITLE
drivers: i3c: dw: Misc DAT entry fixes

### DIFF
--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1901,6 +1901,7 @@ static int dw_i3c_attach_device(const struct device *dev, struct i3c_device_desc
 	if (desc->static_addr != 0U) {
 		dat |= DEV_ADDR_TABLE_STATIC_ADDR(desc->static_addr);
 	}
+	dat |= DEV_ADDR_TABLE_SIR_REJECT;
 
 	sys_write32(dat, config->regs + DEV_ADDR_TABLE_LOC(data->datstartaddr, pos));
 
@@ -2326,7 +2327,7 @@ static int dw_i3c_do_daa(const struct device *dev)
 		p = odd_parity(addr);
 		last_addr = addr;
 		addr |= (p << 7);
-		sys_write32(DEV_ADDR_TABLE_DYNAMIC_ADDR(addr),
+		sys_write32(DEV_ADDR_TABLE_DYNAMIC_ADDR(addr) | DEV_ADDR_TABLE_SIR_REJECT,
 			    config->regs + DEV_ADDR_TABLE_LOC(data->datstartaddr, pos));
 	}
 

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -472,7 +472,13 @@ static inline bool dw_i3c_is_current_controller(const struct device *dev)
 }
 
 #ifdef CONFIG_I3C_CONTROLLER
-static uint8_t get_free_pos(uint32_t free_pos)
+
+/*
+ * Returns the index of the first free slot, or -1 when the table is full.
+ * The return type must stay signed: truncating to uint8_t turns the
+ * exhaustion result into 255 and defeats every caller's bounds check.
+ */
+static int get_free_pos(uint32_t free_pos)
 {
 	return find_lsb_set(free_pos) - 1;
 }
@@ -998,7 +1004,7 @@ static int dw_i3c_i2c_attach_device(const struct device *dev, struct i3c_i2c_dev
 {
 	const struct dw_i3c_config *config = dev->config;
 	struct dw_i3c_data *data = dev->data;
-	uint8_t pos;
+	int pos;
 
 	pos = get_free_pos(data->free_pos);
 	if (pos < 0) {
@@ -1874,7 +1880,7 @@ static int dw_i3c_attach_device(const struct device *dev, struct i3c_device_desc
 {
 	const struct dw_i3c_config *config = dev->config;
 	struct dw_i3c_data *data = dev->data;
-	uint8_t pos = get_free_pos(data->free_pos);
+	int pos = get_free_pos(data->free_pos);
 	uint8_t addr = desc->dynamic_addr ? desc->dynamic_addr : desc->static_addr;
 
 	if (pos < 0) {

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1881,7 +1881,7 @@ static int dw_i3c_attach_device(const struct device *dev, struct i3c_device_desc
 	const struct dw_i3c_config *config = dev->config;
 	struct dw_i3c_data *data = dev->data;
 	int pos = get_free_pos(data->free_pos);
-	uint8_t addr = desc->dynamic_addr ? desc->dynamic_addr : desc->static_addr;
+	uint32_t dat = 0U;
 
 	if (pos < 0) {
 		LOG_ERR("%s: no space for i3c device: %s", dev->name, desc->dev->name);
@@ -1894,8 +1894,15 @@ static int dw_i3c_attach_device(const struct device *dev, struct i3c_device_desc
 
 	LOG_DBG("%s: Attaching %s", dev->name, desc->dev->name);
 
-	sys_write32(DEV_ADDR_TABLE_DYNAMIC_ADDR(addr),
-		    config->regs + DEV_ADDR_TABLE_LOC(data->datstartaddr, pos));
+	if (desc->dynamic_addr != 0U) {
+		dat |= DEV_ADDR_TABLE_DYNAMIC_ADDR(desc->dynamic_addr);
+	}
+
+	if (desc->static_addr != 0U) {
+		dat |= DEV_ADDR_TABLE_STATIC_ADDR(desc->static_addr);
+	}
+
+	sys_write32(dat, config->regs + DEV_ADDR_TABLE_LOC(data->datstartaddr, pos));
 
 	return 0;
 }


### PR DESCRIPTION
Handful of independent DAT entry related changes - put into one PR since they all touch the same code and will certainly conflict.  Can split into 3 PRs upon request

1. Bad return type on get_free_pos makes the failure case undetectable
2. Program both DA and SA into the DAT slot so a device isn't required to have both
3. Default to TIR reject bit set on new devices - it'll get re-enabled in enable_ibi once we're actually ready to handle them

**Note:** 3 breaks TIR on dual-role devices w/o https://github.com/zephyrproject-rtos/zephyr/pull/118920 It doesn't look like GitHub supports blocking a PR on another PR though which is annoying