### PR TITLE
kernel: settle the common k_yield() cases without a run queue walk

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -406,6 +406,21 @@ static inline sys_dnode_t *sys_dlist_peek_tail(const sys_dlist_t *list)
 }
 
 /**
+ * @brief get a reference to the tail item in the list
+ *
+ * The list must be known to be non-empty.
+ *
+ * @param list the doubly-linked list to operate on
+ *
+ * @return a pointer to the tail element
+ */
+
+static inline sys_dnode_t *sys_dlist_peek_tail_not_empty(const sys_dlist_t *list)
+{
+	return list->tail;
+}
+
+/**
  * @brief add node to tail of list
  *
  * This and other sys_dlist_*() functions are not thread safe.

--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -344,6 +344,21 @@ static inline sys_dnode_t *sys_dlist_peek_next_no_check(const sys_dlist_t *list,
 /**
  * @brief get a reference to the next item in the list
  *
+ * The node must be known not to be the tail of the list.
+ *
+ * @param node the node from which to get the next element in the list
+ *
+ * @return a pointer to the next element
+ */
+
+static inline sys_dnode_t *sys_dlist_peek_next_not_tail(const sys_dnode_t *node)
+{
+	return node->next;
+}
+
+/**
+ * @brief get a reference to the next item in the list
+ *
  * @param list the doubly-linked list to operate on
  * @param node the node from which to get the next element in the list
  *

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -135,31 +135,47 @@ static ALWAYS_INLINE void z_priq_simple_remove(sys_dlist_t *pq, struct k_thread 
 static ALWAYS_INLINE void z_priq_simple_yield(sys_dlist_t *pq)
 {
 #ifndef CONFIG_SMP
+	struct k_thread *cur = _current;
+	struct k_thread *t;
 	sys_dnode_t *n;
 
-	n = sys_dlist_peek_next_no_check(pq, &_current->base.qnode_dlist);
-
-	sys_dlist_dequeue(&_current->base.qnode_dlist);
-
-	struct k_thread *t;
-
-	/*
-	 * As it is possible that the current thread was not at the head of
-	 * the run queue, start searching from the present position for where
-	 * to re-insert it.
-	 */
-
-	while (n != NULL) {
-		t = CONTAINER_OF(n, struct k_thread, base.qnode_dlist);
-		if (z_sched_prio_cmp(_current, t) > 0) {
-			sys_dlist_insert(&t->base.qnode_dlist,
-					 &_current->base.qnode_dlist);
-			return;
-		}
-		n = sys_dlist_peek_next_no_check(pq, n);
+	/* Already last in the queue, so it cannot move. */
+	if (sys_dlist_is_tail(pq, &cur->base.qnode_dlist)) {
+		return;
 	}
 
-	sys_dlist_append(pq, &_current->base.qnode_dlist);
+	/*
+	 * The queue is sorted, so unless the tail ranks below the current
+	 * thread nothing does and this is a plain append.
+	 */
+	t = CONTAINER_OF(sys_dlist_peek_tail_not_empty(pq), struct k_thread,
+			 base.qnode_dlist);
+
+	if (unlikely(z_sched_prio_cmp(cur, t) > 0)) {
+		n = sys_dlist_peek_next_no_check(pq, &cur->base.qnode_dlist);
+		t = CONTAINER_OF(n, struct k_thread, base.qnode_dlist);
+
+		/* A successor that already ranks below leaves it in place. */
+		if (z_sched_prio_cmp(cur, t) > 0) {
+			return;
+		}
+
+		sys_dlist_dequeue(&cur->base.qnode_dlist);
+
+		/* The tail ranks below, so this walk always stops on it or
+		 * earlier and never runs off the end.
+		 */
+		do {
+			n = sys_dlist_peek_next_not_tail(n);
+			t = CONTAINER_OF(n, struct k_thread, base.qnode_dlist);
+		} while (z_sched_prio_cmp(cur, t) <= 0);
+
+		sys_dlist_insert(n, &cur->base.qnode_dlist);
+		return;
+	}
+
+	sys_dlist_dequeue(&cur->base.qnode_dlist);
+	sys_dlist_append(pq, &cur->base.qnode_dlist);
 #endif
 }
 

--- a/subsys/bluetooth/services/ots/ots_obj_manager.c
+++ b/subsys/bluetooth/services/ots/ots_obj_manager.c
@@ -87,7 +87,7 @@ int bt_gatt_ots_obj_manager_last_obj_get(
 		return -ENOENT;
 	}
 
-	obj_dnode = sys_dlist_peek_tail(&obj_manager->list);
+	obj_dnode = sys_dlist_peek_tail_not_empty(&obj_manager->list);
 	last_item = CONTAINER_OF(obj_dnode, struct bt_gatt_ots_pool_item,
 				 dnode);
 	*obj = &last_item->val;

--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -62,7 +62,7 @@ static bool remove_from_tail(struct shell_history *history)
 		return false;
 	}
 
-	node = sys_dlist_peek_tail(&history->list);
+	node = sys_dlist_peek_tail_not_empty(&history->list);
 	sys_dlist_remove(node);
 	k_heap_free(history->heap, CONTAINER_OF(node, struct shell_history_item, dnode));
 	return true;


### PR DESCRIPTION
`z_priq_simple_yield()` dequeues the yielding thread and walks forward to find where to re-insert it. The queue is sorted, so cheaper tests settle the common cases: a thread that is already last, or whose successor already ranks below it, does not move at all, and unless the tail ranks below it nothing does and the yield is a plain append.

`CONFIG_SCHED_SIMPLE` only, which is the default.

## Impact

Cycles per `k_yield()` on an AZ3166 (STM32F412, Cortex-M4), against E ready peers at the yielding thread's priority and L ready threads below it. *Lower is better.*

| E | L=0 | L>0 |
|---|---|---|
| 0 | −11.5% | −9.5% |
| 1 | −3.4% | −1.3% |
| 2 | −10.8% | −4.1% |
| 4 | −22.6% | −8.7% |
| 8 | −38.8% | −15.2% |

Across architectures — `latency_measure` `thread.yield.cooperative.ctx.k_to_k` (lower is better) and thread_metric cooperative scheduling (higher is better):

| arch | platform | yield latency | thread_metric |
|---|---|---|---|
| Arm Cortex-M4 | az3166_iotdevkit (hardware) | −6.4% | **+28.3%** |
| Arm Cortex-M33 | mps2/an521 | −7.1% | +37.1% |
| Arm Cortex-A53 | qemu_cortex_a53 | −2.6% | +24.5% |
| ARC EM | qemu_arc_em | −4.4% | +24.2% |
| RISC-V 64 | qemu_riscv64 | −4.5% | +17.2% |
| SPARC | qemu_leon3 | −3.2% | +14.1% |
| Xtensa | qemu_xtensa/dc233c | −1.6% | +7.5% |
| Renesas RX | qemu_rx | −5.0% | |
| x86 | qemu_x86 | −5.3% | |

Only the cooperative scenario moves. thread_metric preemptive, basic, message, synchronization and memory allocation are **±0.00% on every platform**, as is `latency_measure` outside its `thread.yield` rows: the walk this removes is on the yield path only. `SCHED_MULTIQ` and `SCHED_SCALABLE` platforms measure ±0.00% throughout, which is the control. Of 1756 recorded twister metrics, 62 improve and 3 move by ≤0.65% on paths that never yield.

For contrast on the same board, selecting `SCHED_MULTIQ` reaches the identical cooperative score (1988524) but costs **8.0% of preemptive** and 380 bytes of text; this change costs neither.

`z_sched_yield()` grows 144 → 172 bytes with no extra callee-saved register; image text grows 0–28 bytes by architecture. Under `CONFIG_SCHED_DEADLINE` (not the default) one case costs 6 cycles (+3.5%): E=1 with lower priority threads ready.

## Testing

`tests/kernel/{sched,context,threads,pending,workq,queue,semaphore,mutex}` on 19 platforms, 720 configurations: no new failures against the same sweep on `main`. `tests/unit/list` and `tests/subsys/shell/shell_history` pass. Differential fuzz of the re-insertion against the current algorithm, comparing full queue order including thread identity (500k random, exhaustive to length 8): no divergence.
