### PR TITLE
kernel: skip the rbtree round trip when a yield cannot reorder

### DIFF
--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -204,24 +204,16 @@ static ALWAYS_INLINE void z_priq_rb_init(struct _priq_rb *pq)
 	};
 }
 
+void z_priq_rb_renumber(struct _priq_rb *pq);
+
 static ALWAYS_INLINE void z_priq_rb_add(struct _priq_rb *pq, struct k_thread *thread)
 {
-	struct k_thread *t;
-
 	thread->base.order_key = pq->next_order_key;
 	++pq->next_order_key;
 
-	/* Renumber at wraparound.  This is tiny code, and in practice
-	 * will almost never be hit on real systems.  BUT on very
-	 * long-running systems where a priq never completely empties
-	 * AND that contains very large numbers of threads, it can be
-	 * a latency glitch to loop over all the threads like this.
-	 */
-	if (!pq->next_order_key) {
-		RB_FOR_EACH_CONTAINER(&pq->tree, t, base.qnode_rb) {
-			t->base.order_key = pq->next_order_key;
-			++pq->next_order_key;
-		}
+	/* Renumber at wraparound, see z_priq_rb_renumber(). */
+	if (unlikely(pq->next_order_key == 0)) {
+		z_priq_rb_renumber(pq);
 	}
 
 	rb_insert(&pq->tree, &thread->base.qnode_rb);
@@ -239,8 +231,27 @@ static ALWAYS_INLINE void z_priq_rb_remove(struct _priq_rb *pq, struct k_thread 
 static ALWAYS_INLINE void z_priq_rb_yield(struct _priq_rb *pq)
 {
 #ifndef CONFIG_SMP
-	z_priq_rb_remove(pq, _current);
-	z_priq_rb_add(pq, _current);
+	struct k_thread *cur = _current;
+	struct rbnode *n = &cur->base.qnode_rb;
+	uint32_t key = (uint32_t)pq->next_order_key;
+
+	/*
+	 * Keys only grow while the tree is non-empty, so the thread holding
+	 * the newest key already sorts behind every equal-rank thread and a
+	 * remove/add pair would put it back in place. Only the key bookkeeping
+	 * of that pair is kept: the reset of an emptied tree here, the
+	 * wraparound renumbering on the slow path.
+	 */
+	if (unlikely((cur->base.order_key + 1U == key) && (pq->tree.root != n))) {
+		if (key + 1U != 0U) {
+			cur->base.order_key = key;
+			pq->next_order_key = (int)(key + 1U);
+			return;
+		}
+	}
+
+	z_priq_rb_remove(pq, cur);
+	z_priq_rb_add(pq, cur);
 #endif
 }
 

--- a/kernel/priority_queues.c
+++ b/kernel/priority_queues.c
@@ -28,3 +28,22 @@ bool z_priq_rb_lessthan(struct rbnode *a, struct rbnode *b)
 			? 1 : 0;
 	}
 }
+
+/* Renumber at wraparound.  This is tiny code, and in practice
+ * will almost never be hit on real systems.  BUT on very
+ * long-running systems where a priq never completely empties
+ * AND that contains very large numbers of threads, it can be
+ * a latency glitch to loop over all the threads like this.
+ *
+ * Kept out of line so that the iterator's stack allocation does not
+ * land in every caller that inlines z_priq_rb_add().
+ */
+void z_priq_rb_renumber(struct _priq_rb *pq)
+{
+	struct k_thread *t;
+
+	RB_FOR_EACH_CONTAINER(&pq->tree, t, base.qnode_rb) {
+		t->base.order_key = pq->next_order_key;
+		++pq->next_order_key;
+	}
+}


### PR DESCRIPTION
`z_priq_rb_yield()` removes the yielding thread from the rbtree and adds it straight back, so that a fresh order key sorts it behind its equals — two rebalances. But the order key is the only tie-break, so a thread that already holds the newest one is already last among its equals and the pair hands the tree back unchanged.

The fast path tests for that, plus `pq->tree.root != n`. That second test is what makes the key bookkeeping safe: if the thread is not the root then the tree holds other nodes, so removing it cannot empty the tree, so the key reset in `z_priq_rb_remove()` cannot fire and there is nothing to emulate. Only public rbtree API and members are used.

Moving the wraparound renumbering out of line drops an `alloca` (from `RB_FOR_EACH_CONTAINER`) out of `z_priq_rb_add()`, which lets `ready_thread()` inline into its four callers. Without it the rotating path regresses 1.2–1.7%, and every `latency_measure` `wake+ctx` row is 1.2–3.7% slower (mean 2.3%), so the text it costs buys the wakeup paths too.

## Impact

`CONFIG_SCHED_SCALABLE` only. Cycles per `k_yield()` on an MXChip AZ3166 (STM32F412, Cortex-M4 at 96 MHz), against E ready peers at the yielding thread's own priority and L ready threads below it. *Lower is better.*

| E | L=0 | L=1 | L=8 |
|---|---|---|---|
| 0 | +0.6% | **−66.4%** | **−69.4%** |
| 1 | −1.1% | −0.7% | −0.7% |
| 2 | −0.6% | −0.7% | −0.6% |
| 4 | −0.5% | −0.6% | −0.6% |
| 8 | −0.5% | −0.6% | −0.5% |

The one regression is a single ready thread yielding with nothing else runnable, which stays at the base cost plus two cycles; that case takes the slow path because the thread is the root.

### Size

Image text grows 216 bytes. For scale, on the same build `SCHED_SCALABLE` already costs **1700 bytes** more than `SCHED_SIMPLE` (`rb_remove` 1052, `rb_insert` 358, `z_rb_foreach_next` 238, `rotate` 160), so this is ~13% of the premium that selecting it already implies. No data or bss change.

`latency_measure` on the same board: 20 rows improve by ≥1%, topping out at −3.7% on `lifo.put.wake+ctx`; 4 regress by ≥1% (`isr.resume.interrupted.thread` +2.0%, `isr.resume.different.thread` +1.0%, and the two `events.*.immediate` rows +1.1%, none of which take a wake path).

## Testing

`tests/kernel/{sched,context,threads,pending,workq,queue,semaphore,mutex,fifo,lifo,stack,poll}` on 9 platforms with `CONFIG_SCHED_SCALABLE=y` and `CONFIG_WAITQ_SCALABLE=y`: 479 configurations, **no new failures** against the same sweep on `main` (6 pre-existing on both sides, 5 of them a known `kernel.threads.no-multithreading` timing flake).

Cycle figures above are from hardware, not estimates; the run-to-run spread on that rig is zero.
