### PR TITLE
boards: nxp: frdm_mcxn236: add FXLS8974 accelerometer

### DIFF
--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -206,7 +206,7 @@
 
 /*
  * LPFLEXCOMM supports UART and I2C on the same instance, enable this for
- * LFLEXCOMM2
+ * LPFLEXCOMM2
  */
 &flexcomm2_lpuart2 {
 	status = "okay";


### PR DESCRIPTION
Add the onboard FXLS8974CFR3 accelerometer to the FRDM-MCXN236
devicetree using the existing Flexcomm2 I2C bus at address 0x18.

Also correct the LPFLEXCOMM2 name in an existing board comment.